### PR TITLE
Add better error message when user tries to load a workspace that they probably don't have permissions for

### DIFF
--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -191,7 +191,13 @@ def get_view_dict(entity: str, project: str, view_name: str) -> Dict[str, Any]:
         },
     )
 
-    edges = response.get("project", {}).get("allViews", {}).get("edges", [])
+    p = response.get("project")
+    if p is None:
+        raise ValueError(
+            f"Project `{entity}/{project}` not found.  Do you have access to this project?"
+        )
+
+    edges = p.get("allViews", {}).get("edges", [])
 
     try:
         view = edges[0]["node"]


### PR DESCRIPTION
When accessing a project you don't have access to, you'll get a more informative error message:

After:
![image](https://github.com/wandb/wandb-workspaces/assets/15385696/bc226197-65cb-4266-8036-1e5772e52bc8)

Before:
![image](https://github.com/wandb/wandb-workspaces/assets/15385696/f4b770a1-d496-4477-9476-81fb20b77891)
