### PR TITLE
fix: Use generic weave panel when a defined panel cannot be found

### DIFF
--- a/examples/workspaces/01_loading_and_cloning_workspaces.py
+++ b/examples/workspaces/01_loading_and_cloning_workspaces.py
@@ -2,12 +2,13 @@ import os
 
 import wandb_workspaces.workspaces as ws
 
-# !! edit to your entity and project !!
+# !! edit to your entity, project, and saved view !!
 entity = os.getenv("WANDB_ENTITY")
-project = os.getenv("WANDB_PROJECT")
+project = "workspace-api-demo2"
+saved_view = "oydw4wx21l"
 
 # 1. Load a workspace from URL
-url = "https://wandb.ai/megatruong/workspace-api-demo2?nw=vnizqj6vq3"
+url = f"https://wandb.ai/{entity}/{project}?nw={saved_view}"
 workspace = ws.Workspace.from_url(url)
 
 # 2a. Edit the workspace and save to the same view

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 license = "Apache-2.0"
 name = "wandb-workspaces"
-version = "0.1.10"
+version = "0.1.9"
 description = "A library for programatically working with the Weights & Biases UI."
 authors = ["Weights & Biases <support@wandb.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 license = "Apache-2.0"
 name = "wandb-workspaces"
-version = "0.1.9"
+version = "0.1.10"
 description = "A library for programatically working with the Weights & Biases UI."
 authors = ["Weights & Biases <support@wandb.com>"]
 readme = "README.md"

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from typing import Any, Dict, Generic, Type, TypeVar
 
@@ -15,6 +16,8 @@ from wandb_workspaces.utils.validators import (
     validate_url,
 )
 from wandb_workspaces.workspaces.errors import SpecVersionError, UnsupportedViewError
+
+ENTITY = os.getenv("WANDB_ENTITY")
 
 T = TypeVar("T")
 
@@ -141,13 +144,13 @@ def test_filter_expr(expr, spec):
 
 
 def test_load_workspace_from_url():
-    url = "https://wandb.ai/megatruong/workspace-api-demo?nw=vs71wsgdvrz"
+    url = f"https://wandb.ai/{ENTITY}/workspace-api-demo?nw=vs71wsgdvrz"
     workspace = ws.Workspace.from_url(url)  # noqa: F841
 
 
 @pytest.mark.xfail(reason="Saving to the same workspace is currently bugged")
 def test_save_workspace():
-    workspace = ws.Workspace(entity="megatruong", project="workspace-api-demo")
+    workspace = ws.Workspace(entity=ENTITY, project="workspace-api-demo")
     workspace.save()
     workspace_name = workspace._internal_name
 
@@ -160,7 +163,7 @@ def test_save_workspace():
 
 
 def test_save_workspace_as_new_view():
-    workspace = ws.Workspace(entity="megatruong", project="workspace-api-demo")
+    workspace = ws.Workspace(entity=ENTITY, project="workspace-api-demo")
     workspace.save_as_new_view()
     workspace_name = workspace._internal_name
 

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -4,10 +4,11 @@ from typing import Any, Dict, Generic, Type, TypeVar
 import pytest
 from polyfactory.factories import DataclassFactory
 from polyfactory.pytest_plugin import register_fixture
-
+import wandb_workspaces.reports.v2.internal as _wr
 import wandb_workspaces.expr
 import wandb_workspaces.reports.v2 as wr
 import wandb_workspaces.workspaces as ws
+from tests.weave_panel_factory import WeavePanelFactory
 from wandb_workspaces.utils.validators import (
     validate_no_emoji,
     validate_spec_version,
@@ -243,3 +244,24 @@ def test_validate_url(example, should_pass):
     else:
         with pytest.raises(UnsupportedViewError):
             validate_url(example)
+
+
+@pytest.mark.parametrize(
+    "panel_config, should_return_instance",
+    [
+        (
+            WeavePanelFactory.build_summary_table_panel(),
+            wr.interface.WeavePanelSummaryTable,
+        ),
+        (WeavePanelFactory.build_artifact_panel(), wr.interface.WeavePanelArtifact),
+        (
+            WeavePanelFactory.build_artifact_version_panel(),
+            wr.interface.WeavePanelArtifactVersionedFile,
+        ),
+        (WeavePanelFactory.build_run_var_panel(), wr.interface.WeavePanel),
+        (_wr.UnknownPanel(), wr.interface.UnknownPanel),
+    ],
+)
+def test_panel_lookup(panel_config, should_return_instance):
+    panel = wr.interface._lookup_panel(panel_config)
+    assert isinstance(panel, should_return_instance)

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -144,7 +144,7 @@ def test_filter_expr(expr, spec):
 
 
 def test_load_workspace_from_url():
-    url = f"https://wandb.ai/{ENTITY}/workspace-api-demo?nw=vs71wsgdvrz"
+    url = f"https://wandb.ai/{ENTITY}/workspace-api-demo?nw=tkdujz254ke"
     workspace = ws.Workspace.from_url(url)  # noqa: F841
 
 

--- a/tests/weave_panel_factory.py
+++ b/tests/weave_panel_factory.py
@@ -1,0 +1,424 @@
+from polyfactory.factories import BaseFactory
+import wandb_workspaces.reports.v2.internal as _wr
+
+
+class WeavePanelFactory(BaseFactory):
+    __model__ = _wr.WeavePanel
+
+    @classmethod
+    def is_supported_type(cls, model_type) -> bool:
+        return model_type == _wr.WeavePanel
+
+    @classmethod
+    def build(cls, **kwargs) -> _wr.WeavePanel:
+        config = kwargs.get("config", {})
+        view_type = kwargs.get("view_type", "Weave")
+        return _wr.WeavePanel(view_type=view_type, config=config)
+
+    @classmethod
+    def build_run_var_panel(cls):
+        return cls.build(
+            view_type="Weave",
+            config={
+                "panel2Config": {
+                    "exp": {
+                        "nodeType": "output",
+                        "type": {
+                            "type": "list",
+                            "objectType": {
+                                "type": "tagged",
+                                "tag": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {"run": "run"},
+                                },
+                                "value": "none",
+                            },
+                        },
+                    }
+                }
+            },
+        )
+
+    @classmethod
+    def build_summary_table_panel(cls):
+        return cls.build(
+            view_type="Weave",
+            config={
+                "panel2Config": {
+                    "autoFocus": False,
+                    "exp": {
+                        "nodeType": "output",
+                        "type": {
+                            "type": "tagged",
+                            "tag": {
+                                "type": "tagged",
+                                "tag": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "entityName": "string",
+                                        "projectName": "string",
+                                    },
+                                },
+                                "value": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "project": "project",
+                                        "filter": "string",
+                                        "order": "string",
+                                    },
+                                },
+                            },
+                            "value": {
+                                "type": "list",
+                                "objectType": {
+                                    "type": "tagged",
+                                    "tag": {
+                                        "type": "typedDict",
+                                        "propertyTypes": {"run": "run"},
+                                    },
+                                    "value": None,
+                                },
+                                "maxLength": 100,
+                            },
+                        },
+                        "fromOp": {
+                            "name": "pick",
+                            "inputs": {
+                                "obj": {
+                                    "nodeType": "output",
+                                    "type": {
+                                        "type": "tagged",
+                                        "tag": {
+                                            "type": "tagged",
+                                            "tag": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {
+                                                    "entityName": "string",
+                                                    "projectName": "string",
+                                                },
+                                            },
+                                            "value": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {
+                                                    "project": "project",
+                                                    "filter": "string",
+                                                    "order": "string",
+                                                },
+                                            },
+                                        },
+                                        "value": {
+                                            "type": "list",
+                                            "objectType": {
+                                                "type": "tagged",
+                                                "tag": {
+                                                    "type": "typedDict",
+                                                    "propertyTypes": {"run": "run"},
+                                                },
+                                                "value": {
+                                                    "type": "typedDict",
+                                                    "propertyTypes": {
+                                                        "_runtime": "float",
+                                                        "_step": "int",
+                                                        "_timestamp": "float",
+                                                        "val/img_prediction_table": {
+                                                            "type": "file",
+                                                            "_base_type": {
+                                                                "type": "FileBase"
+                                                            },
+                                                            "extension": "json",
+                                                            "wbObjectType": {
+                                                                "type": "table",
+                                                                "_base_type": {
+                                                                    "type": "Object"
+                                                                },
+                                                                "_is_object": True,
+                                                                "_rows": {
+                                                                    "type": "ArrowWeaveList",
+                                                                    "_base_type": {
+                                                                        "type": "list"
+                                                                    },
+                                                                    "objectType": {
+                                                                        "type": "typedDict",
+                                                                        "propertyTypes": {},
+                                                                    },
+                                                                },
+                                                            },
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                            "maxLength": 100,
+                                        },
+                                    },
+                                    "fromOp": {
+                                        "name": "run-summary",
+                                        "inputs": {
+                                            "run": {
+                                                "nodeType": "var",
+                                                "type": {
+                                                    "type": "tagged",
+                                                    "tag": {
+                                                        "type": "tagged",
+                                                        "tag": {
+                                                            "type": "typedDict",
+                                                            "propertyTypes": {
+                                                                "entityName": "string",
+                                                                "projectName": "string",
+                                                            },
+                                                        },
+                                                        "value": {
+                                                            "type": "typedDict",
+                                                            "propertyTypes": {
+                                                                "project": "project",
+                                                                "filter": "string",
+                                                                "order": "string",
+                                                            },
+                                                        },
+                                                    },
+                                                    "value": {
+                                                        "type": "list",
+                                                        "objectType": "run",
+                                                        "maxLength": 100,
+                                                    },
+                                                },
+                                                "varName": "runs",
+                                            }
+                                        },
+                                    },
+                                },
+                                "key": {
+                                    "nodeType": "const",
+                                    "type": "string",
+                                    "val": "table",
+                                },
+                            },
+                        },
+                    },
+                },
+                "isAuto": False,
+            },
+        )
+
+    @classmethod
+    def build_artifact_panel(cls):
+        return cls.build(
+            view_type="Weave",
+            config={
+                "panel2Config": {
+                    "autoFocus": False,
+                    "exp": {
+                        "nodeType": "output",
+                        "type": {
+                            "type": "tagged",
+                            "tag": {
+                                "type": "tagged",
+                                "tag": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "entityName": "string",
+                                        "projectName": "string",
+                                    },
+                                },
+                                "value": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "project": "project",
+                                        "artifactName": "string",
+                                    },
+                                },
+                            },
+                            "value": "artifact",
+                        },
+                        "fromOp": {
+                            "name": "project-artifact",
+                            "inputs": {
+                                "project": {
+                                    "nodeType": "var",
+                                    "type": {
+                                        "type": "tagged",
+                                        "tag": {
+                                            "type": "typedDict",
+                                            "propertyTypes": {
+                                                "entityName": "string",
+                                                "projectName": "string",
+                                            },
+                                        },
+                                        "value": "project",
+                                    },
+                                    "varName": "project",
+                                },
+                                "artifactName": {
+                                    "nodeType": "const",
+                                    "type": "string",
+                                    "val": "run-nau48rpk-valimg_prediction_table",
+                                },
+                            },
+                        },
+                    },
+                    "panelConfig": {
+                        "selectedCollectionView": "versions",
+                        "tabConfigs": {"overview": {}},
+                    },
+                    "panelInputType": {
+                        "type": "tagged",
+                        "tag": {
+                            "type": "tagged",
+                            "tag": {
+                                "type": "typedDict",
+                                "propertyTypes": {
+                                    "entityName": "string",
+                                    "projectName": "string",
+                                },
+                            },
+                            "value": {
+                                "type": "typedDict",
+                                "propertyTypes": {
+                                    "project": "project",
+                                    "artifactName": "string",
+                                },
+                            },
+                        },
+                        "value": "artifact",
+                    },
+                }
+            },
+        )
+
+    @classmethod
+    def build_artifact_version_panel(cls):
+        return cls.build(
+            view_type="Weave",
+            config={
+                "panel2Config": {
+                    "autoFocus": False,
+                    "exp": {
+                        "nodeType": "output",
+                        "type": {
+                            "type": "tagged",
+                            "tag": {
+                                "type": "tagged",
+                                "tag": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "entityName": "string",
+                                        "projectName": "string",
+                                    },
+                                },
+                                "value": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "project": "project",
+                                        "artifactName": "string",
+                                        "artifactVersionAlias": "string",
+                                    },
+                                },
+                            },
+                            "value": {
+                                "type": "file",
+                                "_base_type": {"type": "FileBase"},
+                                "extension": "json",
+                                "wbObjectType": {
+                                    "type": "table",
+                                    "_base_type": {"type": "Object"},
+                                    "_is_object": True,
+                                    "_rows": {
+                                        "type": "ArrowWeaveList",
+                                        "_base_type": {"type": "list"},
+                                        "objectType": {
+                                            "type": "typedDict",
+                                            "propertyTypes": {},
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        "fromOp": {
+                            "name": "artifactVersion-file",
+                            "inputs": {
+                                "artifactVersion": {
+                                    "nodeType": "output",
+                                    "type": {
+                                        "type": "tagged",
+                                        "tag": {
+                                            "type": "tagged",
+                                            "tag": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {
+                                                    "entityName": "string",
+                                                    "projectName": "string",
+                                                },
+                                            },
+                                            "value": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {
+                                                    "project": "project",
+                                                    "artifactName": "string",
+                                                    "artifactVersionAlias": "string",
+                                                },
+                                            },
+                                        },
+                                        "value": "artifactVersion",
+                                    },
+                                    "fromOp": {
+                                        "name": "project-artifactVersion",
+                                        "inputs": {
+                                            "project": {
+                                                "nodeType": "var",
+                                                "type": {
+                                                    "type": "tagged",
+                                                    "tag": {
+                                                        "type": "typedDict",
+                                                        "propertyTypes": {
+                                                            "entityName": "string",
+                                                            "projectName": "string",
+                                                        },
+                                                    },
+                                                    "value": "project",
+                                                },
+                                                "varName": "project",
+                                            },
+                                            "artifactName": {
+                                                "nodeType": "const",
+                                                "type": "string",
+                                                "val": "run-nau48rpk-valimg_prediction_table",
+                                            },
+                                            "artifactVersionAlias": {
+                                                "nodeType": "const",
+                                                "type": "string",
+                                                "val": "v0",
+                                            },
+                                        },
+                                    },
+                                },
+                                "path": {
+                                    "nodeType": "const",
+                                    "type": "string",
+                                    "val": "val/img_prediction_table.table.json",
+                                },
+                            },
+                        },
+                    },
+                    "panelInputType": {
+                        "type": "tagged",
+                        "tag": {
+                            "type": "tagged",
+                            "tag": {
+                                "type": "typedDict",
+                                "propertyTypes": {
+                                    "entityName": "string",
+                                    "projectName": "string",
+                                },
+                            },
+                            "value": {
+                                "type": "typedDict",
+                                "propertyTypes": {
+                                    "project": "project",
+                                    "artifactName": "string",
+                                },
+                            },
+                        },
+                        "value": "artifact",
+                    },
+                }
+            },
+        )

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3188,14 +3188,17 @@ def _lookup_panel(panel):
         wandb.termwarn(f"Unknown panel type: {panel.__class__}")
 
     if cls is WeavePanel:
-        # print('cls is weave panel')
-        for cls in defined_weave_panels:
+        # TODO the more panels that get defined, the more of a need there is to either
+        # sort the `defined_weave_panels` list by specificity or add additional logic
+        # to select the proper panel.
+        #
+        # Currently, WeaveSummaryTablePanel, WeavePanelArtifactVersionedFile, and
+        # WeavePanelArtifact have unique keys from inputs, so this logic still works.
+        for weave_cls in defined_weave_panels:
             try:
-                cls._from_model(panel)
+                return weave_cls._from_model(panel)
             except Exception:
                 continue
-            else:
-                break
 
     return cls._from_model(panel)
 


### PR DESCRIPTION
## Description

Fixes [WB-22673](https://wandb.atlassian.net/browse/WB-22673)

This fix changes the way panels are looked up. Instead of returning the last item in `defined_weave_panels` when no defined panel can be found, return `WeavePanel` or `UnknownPanel.` This way, there won't be KeyErrors resulting from preparing the inputs to `WeavePanelArtifact.`

### Testing
I added a unit test for the lookup logic, so in the future if there's a new defined panel added, it hopefully prevents a regression.

I also wanted to make sure that returning a generic `WeavePanel` wouldn't break existing functionality, so I confirmed that these scenarios work:

Duplicate the existing panel in the workspace. The existing panel's expression `runs`.
```
workspace = ws.Workspace.from_url('<url>')

panels = workspace.sections[0].panels

workspace.sections[0].panels = [panels[0], panels[0]]

workspace.save()
```

Clone the workspace with a different name. The panel on the workspace's expression is `runs`
```
workspace = ws.Workspace.from_url('<url>')

workspace.name = "updated workspace name"

workspace.save_as_new_view()
```

[WB-22673]: https://wandb.atlassian.net/browse/WB-22673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ