### PR TITLE
fix: Pass through layout config to weave panels

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -393,20 +393,20 @@ def test_layout_config():
     }
     CUSTOM_USER_DEFINED_LAYOUT = {"x": 0, "y": 0, "w": 24, "h": 24}
 
-    p0 = wr.interface.WeavePanelSummaryTable(table_name="test")
-    p1 = wr.interface.WeavePanelSummaryTable(
+    p0 = wr.WeavePanelSummaryTable(table_name="test")
+    p1 = wr.WeavePanelSummaryTable(
         table_name="test", layout=CUSTOM_USER_DEFINED_LAYOUT
     )
-    p2 = wr.interface.WeavePanelArtifact(
+    p2 = wr.WeavePanelArtifact(
         artifact="test", layout=CUSTOM_USER_DEFINED_LAYOUT
     )
-    p3 = wr.interface.WeavePanelArtifactVersionedFile(
+    p3 = wr.WeavePanelArtifactVersionedFile(
         artifact="test",
         version="vtest",
         file="test.txt",
         layout=CUSTOM_USER_DEFINED_LAYOUT,
     )
-    p4 = wr.interface.WeavePanel(layout=CUSTOM_USER_DEFINED_LAYOUT)
+    p4 = wr.WeavePanel(layout=CUSTOM_USER_DEFINED_LAYOUT)
 
     assert p0._to_model().layout.model_dump() == DEFAULT_LAYOUT
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -382,3 +382,33 @@ def test_expression_parsing(expr, expected_filters):
     assert expr_to_filters(expr) == Filters(
         op="OR", filters=[Filters(op="AND", filters=expected_filters)]
     )
+
+
+def test_layout_config():
+    DEFAULT_LAYOUT = {
+        "x": wr.Layout.x,
+        "y": wr.Layout.y,
+        "w": wr.Layout.w,
+        "h": wr.Layout.h,
+    }
+    CUSTOM_USER_DEFINED_LAYOUT = {"x": 0, "y": 0, "w": 24, "h": 24}
+
+    p0 = wr.interface.WeavePanelSummaryTable(table_name="test")
+    p1 = wr.interface.WeavePanelSummaryTable(
+        table_name="test", layout=CUSTOM_USER_DEFINED_LAYOUT
+    )
+    p2 = wr.interface.WeavePanelArtifact(
+        artifact="test", layout=CUSTOM_USER_DEFINED_LAYOUT
+    )
+    p3 = wr.interface.WeavePanelArtifactVersionedFile(
+        artifact="test",
+        version="vtest",
+        file="test.txt",
+        layout=CUSTOM_USER_DEFINED_LAYOUT,
+    )
+    p4 = wr.interface.WeavePanel(layout=CUSTOM_USER_DEFINED_LAYOUT)
+
+    assert p0._to_model().layout.model_dump() == DEFAULT_LAYOUT
+
+    for panel in [p1, p2, p3, p4]:
+        assert panel._to_model().layout.model_dump() == CUSTOM_USER_DEFINED_LAYOUT

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -2468,7 +2468,7 @@ class WeavePanel(Panel):
     config: dict = Field(default_factory=dict)
 
     def _to_model(self):
-        return internal.WeavePanel(config=self.config)
+        return internal.WeavePanel(config=self.config, layout=self.layout._to_model())
 
     @classmethod
     def _from_model(cls, model: internal.WeavePanel):
@@ -2668,7 +2668,8 @@ class WeavePanelSummaryTable(Panel):
                         "__userInput": True,
                     }
                 }
-            }
+            },
+            layout=self.layout._to_model()
         )
 
     @classmethod
@@ -2800,7 +2801,8 @@ class WeavePanelArtifactVersionedFile(Panel):
                         "__userInput": True,
                     }
                 }
-            }
+            },
+            layout=self.layout._to_model()
         )
 
     @classmethod
@@ -2910,7 +2912,8 @@ class WeavePanelArtifact(WeavePanel):
                         "tabConfigs": {"overview": {"selectedTab": self.tab}}
                     },
                 }
-            }
+            },
+            layout=self.layout._to_model()
         )
 
     @classmethod


### PR DESCRIPTION
Fixes [WB-22945](https://wandb.atlassian.net/jira/software/c/projects/WB/issues/WB-22945)

### Description

Layout configs weren't being respected in reports.v2 WeavePanels. This fix passes the layout model in the WeavePanel's `_to_model()` method.

### Testing

I used this script to repro and to test the fix:

```
report = wr.Report(
    entity=ENTITY,
    project=PROJECT,
    title="Test add tables",
    blocks=[
        wr.PanelGrid(
            runsets=[wr.Runset(project=PROJECT, entity=ENTITY, name="Test", filters=f"name in ['pzp5npth']" )],
            panels=[wr.WeavePanelSummaryTable(table_name=TABLE_KEY, layout={"x": 0, "y": 0, "w": 24, "h": 12})],
        ),
    ]
)

report.save()
```

Report Generated Before Fix: https://wandb.ai/dominic-phan-weights-and-biases/default-table-duplication/reports/Test-add-tables--VmlldzoxMTE2NjIyMA

Report Generated After Fix: https://wandb.ai/dominic-phan-weights-and-biases/default-table-duplication/reports/Test-add-tables--VmlldzoxMTE2NjI4NQ

[WB-22945]: https://wandb.atlassian.net/browse/WB-22945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ