### PR TITLE
feat(workspaces): add 'auto_generate_panels' argument to 'Workspace' object

### DIFF
--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -525,7 +525,6 @@ class Workspace(Base):
         return obj
 
     def _to_model(self) -> internal.View:
-        # hack: create sections to hide unnecessary panels
         sections = [s._to_model() for s in self.sections]
 
         is_regex = True if self.runset_settings.regex_query else None

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -520,7 +520,7 @@ class Workspace(Base):
         # hack: create sections to hide unnecessary panels
         base_sections = [s._to_model() for s in self.sections]
 
-        possible_missing_sections = set(("Hidden Panels", "Charts", "System"))
+        possible_missing_sections = set(("Charts", "System"))
         base_section_names = set(s.name for s in self.sections)
         missing_section_names = possible_missing_sections - base_section_names
 

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -378,6 +378,9 @@ class Workspace(Base):
             the top of the workspace in the UI.
         runset_settings (RunsetSettings): Settings for the runset
             (the left bar containing runs) in a workspace.
+        auto_generate_panels (bool): Whether to automatically generate panels for all keys logged in this project. 
+            Recommended if you would like all available data to be visualized by default.
+            This can only be set during workspace creation and cannot be modified afterward.
     """
 
     entity: str
@@ -386,6 +389,7 @@ class Workspace(Base):
     sections: LList[Section] = Field(default_factory=list)
     settings: WorkspaceSettings = Field(default_factory=WorkspaceSettings)
     runset_settings: RunsetSettings = Field(default_factory=RunsetSettings)
+    _auto_generate_panels: bool = Field(default=False, repr=True, alias="auto_generate_panels")
 
     # Internal only
     _internal_name: str = Field("", init=False, repr=False)
@@ -397,6 +401,10 @@ class Workspace(Base):
     _internal_runset_id: str = Field("", init=False, repr=False)
     "The runset ID of the workspace."
 
+    @property
+    def auto_generate_panels(self) -> bool:
+        return self._auto_generate_panels
+    
     @property
     def url(self):
         "The URL to the workspace in the W&B app."
@@ -560,6 +568,7 @@ class Workspace(Base):
             color_run_names=color_run_names,
             max_runs=self.settings.max_runs,
             point_visualization_method=point_viz_method,
+            should_auto_generate_panels=self.auto_generate_panels,
         )
 
         return internal.View(

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -526,18 +526,8 @@ class Workspace(Base):
 
     def _to_model(self) -> internal.View:
         # hack: create sections to hide unnecessary panels
-        base_sections = [s._to_model() for s in self.sections]
+        sections = [s._to_model() for s in self.sections]
 
-        possible_missing_sections = set(("Charts", "System"))
-        base_section_names = set(s.name for s in self.sections)
-        missing_section_names = possible_missing_sections - base_section_names
-
-        hidden_sections = [
-            Section(name=name, is_open=False)._to_model()
-            for name in missing_section_names
-        ]
-
-        sections = base_sections + hidden_sections
         is_regex = True if self.runset_settings.regex_query else None
         auto_organize_prefix = 2 if self.settings.group_by_prefix == "last" else 1
 

--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -48,6 +48,7 @@ class ViewspecSectionSettings(WorkspaceAPIBaseModel):
     point_visualization_method: Optional[PointVizMethod] = None
     suppress_legends: Optional[bool] = None
     tooltip_number_of_runs: Optional[TooltipNumberOfRuns] = None
+    should_auto_generate_panels: bool = False
 
     @computed_field  # type: ignore[misc]
     @property


### PR DESCRIPTION
* Fixes [WB-22767](https://wandb.atlassian.net/browse/WB-22767)
* Fixes [WB-23479](https://wandb.atlassian.net/browse/WB-23479)

Add argument `auto_generate_panels` to the workspace object to allow users to decide whether automatic panels should be created or not. Defaults to False as normally users want an empty workspace, and also expect that the following code (without setting this and sections empty) produces an empty workspace

```
workspace = ws.Workspace(
        name="Example W&B Workspace",
        entity=ENTITY,
        project=PROJECT,
        sections=[],
    )
workspace.save()
```
**Before**
![image](https://github.com/user-attachments/assets/d98192a1-58f8-40c5-92be-891552753207)

**After (defaults to `False`)**
![image](https://github.com/user-attachments/assets/88e498e0-a41a-44fa-81a0-aaabb1708c26)

**If `auto_generate_panels=True`**
![image](https://github.com/user-attachments/assets/addc1146-d987-42e0-9896-7faf1e545e3d)


This can only by set when the workspace is created, after that is read-only and cannot be modified (throws an error)

Also removed this part of the code:
```
     # hack: create sections to hide unnecessary panels
      base_sections = [s._to_model() for s in self.sections]

      possible_missing_sections = set(("Hidden Panels", "Charts", "System"))
      base_section_names = set(s.name for s in self.sections)
      missing_section_names = possible_missing_sections - base_section_names

      hidden_sections = [
          Section(name=name, is_open=False)._to_model()
          for name in missing_section_names
      ]

      sections = base_sections + hidden_sections
```
As those panels are now added automatically if `auto_generate_panels=True`


[WB-22767]: https://wandb.atlassian.net/browse/WB-22767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-23479]: https://wandb.atlassian.net/browse/WB-23479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ