### PR TITLE
fix(reports): fix Report.from_url() to handle shortened report URLs from UI

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -412,3 +412,22 @@ def test_layout_config():
 
     for panel in [p1, p2, p3, p4]:
         assert panel._to_model().layout.model_dump() == CUSTOM_USER_DEFINED_LAYOUT
+
+
+def test_url_to_report_id_padding():
+    import base64
+    import wandb_workspaces.reports.v2 as wr
+
+    # "test" -> base64 encoded becomes "dGVzdA=="
+    original = b"test"
+    encoded = base64.b64encode(original).decode("utf-8")  # "dGVzdA=="
+    # Remove the '=' padding to simulate a URL-embedded report id.
+    stripped = encoded.replace("=", "")
+    
+    # Construct a fake URL in the expected format:
+    #   http://wandb.ai/{entity}/{project}/reports/{title}--{report_id}
+    url = f"http://wandb.ai/my_entity/my_project/reports/my-report--{stripped}"
+    
+    # Call the function and verify that the returned id matches the properly padded version.
+    result = wr.interface._url_to_report_id(url)
+    assert result == encoded, f"Expected {encoded} but got {result}"

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -26,6 +26,7 @@ report.save()
 
 """
 
+import base64
 import os
 from datetime import datetime
 from typing import Dict, Iterable, Optional, Tuple, Union
@@ -3143,9 +3144,9 @@ def _url_to_report_id(url):
     _, entity, project, _, name = path.split("/")
     title, report_id = name.split("--")
 
-    missing_padding = len(report_id) % 4
-    if missing_padding:
-         report_id += "=" * (4 - missing_padding)
+    report_id = base64.b64encode(base64.b64decode(report_id + "==")).decode(
+        "utf-8"
+    )
 
     return report_id
 

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3144,11 +3144,18 @@ def _url_to_report_id(url):
     _, entity, project, _, name = path.split("/")
     title, report_id = name.split("--")
 
-    report_id = base64.b64encode(base64.b64decode(report_id + "==")).decode(
-        "utf-8"
-    )
+    # Add correct base64 padding: calculate the number of '=' needed
+    pad = (4 - (len(report_id) % 4)) % 4
+    padded_report_id = report_id + ("=" * pad)
+    try:
+        # Validate the padded report ID by attempting to decode it
+        decoded = base64.b64decode(padded_report_id)
+    except Exception as e:
+        raise ValueError("Attempted to parse invalid View ID") from e
 
-    return report_id
+    # Re-encode to standard base64 string (which will include proper padding)
+    final_report_id = base64.b64encode(decoded).decode("utf-8")
+    return final_report_id
 
 
 def _lookup(block):

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3154,8 +3154,8 @@ def _url_to_report_id(url):
         raise ValueError("Attempted to parse invalid View ID") from e
 
     # Re-encode to standard base64 string (which will include proper padding)
-    final_report_id = base64.b64encode(decoded).decode("utf-8")
-    return final_report_id
+    report_id = base64.b64encode(decoded).decode("utf-8")
+    return report_id
 
 
 def _lookup(block):


### PR DESCRIPTION
* Fixes [WB-23860](https://wandb.atlassian.net/browse/WB-23860)

Currently, when users copy report URLs from the W&B UI, Report.from_url() fails because the UI sometimes displays shortened URLs that omit base64 padding ('=') characters from the report ID. For example:

UI shows:    `.../reports/Title--VmlldzoxMDg3MzI0Mw`
Actual ID:   `.../reports/Title--VmlldzoxMDg3MzI0Mw==`

This PR adds logic to automatically append the correct base64 padding when parsing report IDs, making Report.from_url() work seamlessly with URLs copied from the UI.

Changes:
- Added base64 padding calculation in _url_to_report_id()
- Ensures report IDs are properly padded before querying

```
import wandb_workspaces.reports.v2 as wr

broken_report = wr.Report.from_url(
    "https://wandb.ai/luis_team_test/reports_api_run_color/reports/Test-report--VmlldzoxMTg5NDY4NQ"
    )

working_report = wr.Report.from_url(
    "https://wandb.ai/luis_team_test/reports_api_run_color/reports/Test-report--VmlldzoxMTg5NDY4NQ=="
    )

print(broken_report.id)
print(working_report.id)
```
**Before**
````
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://api.wandb.ai/graphql
````
**After**
````
VmlldzoxMTg5NDY4NQ==
VmlldzoxMTg5NDY4NQ==
````


[WB-23860]: https://wandb.atlassian.net/browse/WB-23860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ