### PR TITLE
feat(reports): allow hidding runsets programmatically

### DIFF
--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -954,6 +954,7 @@ class PanelGrid(Block):
     """
 
     runsets: LList["Runset"] = Field(default_factory=lambda: [Runset()])
+    hide_run_sets: bool = False
     panels: LList["PanelTypes"] = Field(default_factory=list)
     active_runset: int = 0
     custom_run_colors: Dict[Union[RunId, RunsetGroup], Union[str, dict]] = Field(
@@ -969,6 +970,7 @@ class PanelGrid(Block):
         return internal.PanelGrid(
             metadata=internal.PanelGridMetadata(
                 run_sets=[rs._to_model() for rs in self.runsets],
+                hide_run_sets=self.hide_run_sets,
                 panel_bank_section_config=internal.PanelBankSectionConfig(
                     panels=[p._to_model() for p in self.panels],
                 ),
@@ -985,6 +987,7 @@ class PanelGrid(Block):
         runsets = [Runset._from_model(rs) for rs in model.metadata.run_sets]
         obj = cls(
             runsets=runsets,
+            hide_run_sets=model.metadata.hide_run_sets,
             panels=[
                 _lookup_panel(p)
                 for p in model.metadata.panel_bank_section_config.panels

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3143,6 +3143,10 @@ def _url_to_report_id(url):
     _, entity, project, _, name = path.split("/")
     title, report_id = name.split("--")
 
+    missing_padding = len(report_id) % 4
+    if missing_padding:
+         report_id += "=" * (4 - missing_padding)
+
     return report_id
 
 

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3146,10 +3146,6 @@ def _url_to_report_id(url):
     _, entity, project, _, name = path.split("/")
     title, report_id = name.split("--")
 
-    missing_padding = len(report_id) % 4
-    if missing_padding:
-         report_id += "=" * (4 - missing_padding)
-
     return report_id
 
 

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -947,6 +947,7 @@ class PanelGrid(Block):
 
     Attributes:
         runsets (LList["Runset"]): A list of one or more `Runset` objects.
+        hide_run_sets (bool): Whether to hide the run sets of the panel grid for report viewers.
         panels (LList["PanelTypes"]): A list of one or more `Panel` objects.
         active_runset (int): The number of runs you want to display within a runset. By default, it is set to 0.
         custom_run_colors (dict): Key-value pairs where the key is the name of a

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -283,6 +283,7 @@ class PanelGridMetadata(ReportAPIBaseModel):
     open_run_set: Optional[int] = 0  # none is closed
     name: Literal["unused-name"] = "unused-name"
     run_sets: LList["Runset"] = Field(default_factory=lambda: [Runset()])
+    hide_run_sets: bool = False
     panels: PanelGridMetadataPanels = Field(default_factory=PanelGridMetadataPanels)
     panel_bank_config: PanelBankConfig = Field(default_factory=PanelBankConfig)
     panel_bank_section_config: PanelBankSectionConfig = Field(


### PR DESCRIPTION
Added `hide_run_sets` to `PanelGrid` to allow setting it programmatically:

````
import wandb_workspaces.reports.v2 as wr

report = wr.Report(
    project="reports_api_run_color",
    entity="luis_team_test",
    title="Test report",
    blocks=[
        wr.H1("Section 1"),
        wr.PanelGrid(
            runsets=[
                wr.Runset(
                    entity="luis_team_test",
                    project="reports_api_run_color"                    
                )
            ],
            hide_run_sets=True
        )
    ]
)
report.save()
````

Creates [this](https://wandb.ai/luis_team_test/reports_api_run_color/reports/Test-report--VmlldzoxMTk1MjExNw==) report:
![image](https://github.com/user-attachments/assets/f6ab5130-f646-4365-a14c-cd3e96e87b0e)

While `hide_run_sets=False` or not setting it creates [this](https://wandb.ai/luis_team_test/reports_api_run_color/reports/Test-report--VmlldzoxMTk1MjEyMg==) one:
![image](https://github.com/user-attachments/assets/47f096f9-be03-4cd5-8162-1ef8488faae8)
