### PR TITLE
fix(reports): adding logic to parse multiline code when querying a report from its url

### DIFF
--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -586,7 +586,17 @@ class CodeBlock(Block):
 
     @classmethod
     def _from_model(cls, model: internal.CodeBlock):
-        code = _internal_children_to_text(model.children[0].children)
+        # Aggregate all lines of code into a single multiline string
+        lines = []
+        for code_line in model.children:
+            # code_line.children contains internal.Text nodes for each line
+            line_text = _internal_children_to_text(code_line.children)
+            if not isinstance(line_text, str):
+                # If the line_text is a list of segments, join them into a string
+                line_text = ''.join(str(x) for x in line_text)
+            lines.append(line_text)
+        # Join lines preserving line breaks
+        code = "\n".join(lines)
         return cls(code=code, language=model.language)
 
 


### PR DESCRIPTION
* Fixes [WB-24535](https://wandb.atlassian.net/browse/WB-24535)

Report example:
![image](https://github.com/user-attachments/assets/865d1072-ff8c-4576-b191-a35b42e0af01)

Code:
````

import wandb_workspaces.reports.v2 as wr

report = wr.Report.from_url("https://wandb.ai/luis_team_test/test_custom_hist_reports_api/reports/Test-Report--VmlldzoxMjM5NDU0MA")
print(report.blocks)

new_report = wr.Report(
    project="test_custom_hist_reports_api",
    entity="luis_team_test",
    title="Test-Report",
)
new_report.blocks = report.blocks
new_report.save()
````
Before this returns only the first line of the code block:
````
[P(text='Code:'), CodeBlock(code='import wandb', language='python')]
````
Now it returns all lines:
````
[P(text='Code:'), CodeBlock(code='import wandb\n\nwandb.init()', language='python')]
````


