### PR TITLE
chore(reports): Look up run set project IDs on report save

### DIFF
--- a/wandb_workspaces/reports/v2/gql.py
+++ b/wandb_workspaces/reports/v2/gql.py
@@ -66,3 +66,13 @@ upsert_view = gql(
     }
 """
 )
+projectInternalId = gql(
+    """
+    query ProjectInternalId($projectName: String!, $entityName: String!) {
+        project(name: $projectName, entityName: $entityName) {
+            id
+            internalId
+        }
+    }
+    """
+)

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -182,6 +182,7 @@ class Project(ReportAPIBaseModel):
     name: Optional[str] = None
     # name: str = ""
     entity_name: str = ""
+    id: Optional[str] = None
 
 
 class PanelBankConfigSettings(ReportAPIBaseModel):


### PR DESCRIPTION
## JIRA

https://wandb.atlassian.net/browse/WB-24910

## Description

On a report panel grid, you can configure run sets to point at projects other than the one the report belongs to, e.g. a report for `wandb/project-1` can have a run set that loads runs from `wandb/project-2`.

On `upsertView` (on save report), the server will iterate through each run set, look up the project ID, and attach it to the run set config before saving the spec to the database. Instead of doing this on the server side, we can/should just do the project lookup on the client side. This allows us to validate the user's input before we send the request, and also ensures the spec is populated with the correct project IDs from the start. Of course, the server can still perform validations as needed, but mutating the user input doesn't seem appropriate.

This PR adds run set project lookup on report save. It validates that the entity/project names the user has configured, and populates the run set config with the project internal ID. Once the reports clients (i.e. UI and this sdk) are both set up to correctly populate run set project IDs, we can remove that logic from the server side.

## Testing

- See unit test
- Also manually tested by modifying `00_create_sample_report.py` to include a run set with entity/project names configured, and logging the spec object that would be upserted. The run set project is populated with the correct project internal ID.

https://github.com/user-attachments/assets/8db20f20-0216-4fb5-a885-040116f68dee
