### PR TITLE
add support for multiple filters in Runsets

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -330,6 +330,25 @@ def test_fix_panel_collisions():
             ],
         ],
         [
+            "b == 1 and c == 2",
+            [
+                Filters(
+                    op="==",
+                    key=Key(section="run", name="b"),
+                    filters=None,
+                    value=1,
+                    disabled=False,
+                ),
+                Filters(
+                    op="==",
+                    key=Key(section="run", name="c"),
+                    filters=None,
+                    value=2,
+                    disabled=False,
+                ),
+            ],
+        ],
+        [
             "(a >= 1)",
             [
                 Filters(

--- a/wandb_workspaces/reports/v2/expr_parsing.py
+++ b/wandb_workspaces/reports/v2/expr_parsing.py
@@ -41,7 +41,13 @@ def expr_to_filters(expr: str) -> Filters:
         filters = []
     else:
         parsed_expr = ast.parse(expr, mode="eval")
-        filters = [_parse_node(parsed_expr.body)]
+        root_filter = _parse_node(parsed_expr.body)
+
+        # If the root operation is an AND, unpack its child filters
+        if root_filter.op == "AND" and root_filter.filters:
+            filters = root_filter.filters
+        else:
+            filters = [root_filter]
 
     return Filters(op="OR", filters=[Filters(op="AND", filters=filters)])
 


### PR DESCRIPTION
Fixes: https://wandb.atlassian.net/browse/WB-25385

`expr_to_filters()` now checks whether the parsed root operation is an `AND`. If so, it extracts the child filters directly; otherwise, it keeps the single root filter. The function then returns these filters wrapped in a single `OR` clause

Code to Reproduce

```python
import wandb_workspaces.reports.v2 as wr

ENTITY="jaiswal-test"
PROJECT = "report_group_prgm"

pg = wr.PanelGrid(
    runsets=[
        wr.Runset(ENTITY, PROJECT, "Filtered Run Set", filters="group in ['experiment_1'] and tags in ['test']"),
    ],
    panels=[
        wr.LinePlot(x="Step", y=["loss"], smoothing_factor=0.8)
    ]
)

report = wr.Report(
    project=PROJECT,
    title="Filtered Group Report Example",
    description="example report",
    blocks=[wr.H1("Filtered Runset Example"), pg],
    width="fluid"
)  

report.save()
```


## Before
<img width="1376" alt="image" src="https://github.com/user-attachments/assets/6e8ed6ab-45e5-4607-8e23-f2837da4308e" />

## After
<img width="1376" alt="image" src="https://github.com/user-attachments/assets/a1b3fd29-eab3-4304-b1b5-c91676ae2d99" />

