### PR TITLE
fix(reports): update logic to properly parse report id and title from report URL

### DIFF
--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3175,7 +3175,15 @@ def _url_to_report_id(url):
     path = parse_result.path
 
     _, entity, project, _, name = path.split("/")
-    title, report_id = name.split("--")
+    
+    # Use rfind to find the last occurrence of '--'
+    separator_position = name.rfind("--")
+    if separator_position == -1:
+        raise ValueError("Attempted to parse invalid View ID: no separator found")
+    
+    # Split at the last '--'
+    title = name[:separator_position]
+    report_id = name[separator_position + 2:] # +2 to skip the '--'
 
     # Add correct base64 padding: calculate the number of '=' needed
     pad = (4 - (len(report_id) % 4)) % 4


### PR DESCRIPTION
Fixes [WB-25511](https://wandb.atlassian.net/browse/WB-25511)

Fixes issue where `Report.from_url()` fails when report titles contain special characters that get replaced with dashes in URLs. The previous code used `split("--")` which would incorrectly split on the first `--` occurrence and caused base64 decoding errors when report names contained multiple dashes. Updated `_url_to_report_id()` to use `rfind("--")` to find the last occurrence of `--`.

Code:
```
import wandb_workspaces.reports.v2 as wr

report = wr.Report.from_url("https://wandb.ai/luis_team_test/max_runs_per_project/reports/My-Report---VmlldzoxMzE3NzUwNg")
print(report.title, report.id)
```
Before:
````
ValueError: Attempted to parse invalid View ID
````
After:
````
My Report! VmlldzoxMzE3NzUwNg==
````


[WB-25511]: https://wandb.atlassian.net/browse/WB-25511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ