### PR TITLE
fix(reports): automatically aggregate when groupby is set in LinePlot and BarPlot

### DIFF
--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -1801,7 +1801,7 @@ class LinePlot(Panel):
     title_x: Optional[str] = None
     title_y: Optional[str] = None
     ignore_outliers: Optional[bool] = None
-    groupby: Optional[str] = None
+    groupby: Optional[Union[str, Config]] = None
     groupby_aggfunc: Optional[GroupAgg] = None
     groupby_rangefunc: Optional[GroupArea] = None
     smoothing_factor: Optional[float] = None
@@ -1832,7 +1832,7 @@ class LinePlot(Panel):
                 x_axis_title=self.title_x,
                 y_axis_title=self.title_y,
                 ignore_outliers=self.ignore_outliers,
-                group_by=self.groupby,
+                group_by=_metric_to_backend_groupby(self.groupby),
                 group_agg=self.groupby_aggfunc,
                 group_area=self.groupby_rangefunc,
                 smoothing_weight=self.smoothing_factor,
@@ -1865,7 +1865,7 @@ class LinePlot(Panel):
             title_x=model.config.x_axis_title,
             title_y=model.config.y_axis_title,
             ignore_outliers=model.config.ignore_outliers,
-            groupby=model.config.group_by,
+            groupby=_metric_to_frontend_groupby(model.config.group_by),
             groupby_aggfunc=model.config.group_agg,
             groupby_rangefunc=model.config.group_area,
             smoothing_factor=model.config.smoothing_weight,
@@ -2029,7 +2029,7 @@ class BarPlot(Panel):
     range_x: Range = Field(default_factory=lambda: (None, None))
     title_x: Optional[str] = None
     title_y: Optional[str] = None
-    groupby: Optional[str] = None
+    groupby: Optional[Union[str, Config]] = None
     groupby_aggfunc: Optional[GroupAgg] = None
     groupby_rangefunc: Optional[GroupArea] = None
     max_runs_to_show: Optional[int] = None
@@ -2051,7 +2051,7 @@ class BarPlot(Panel):
                 x_axis_max=self.range_x[1],
                 x_axis_title=self.title_x,
                 y_axis_title=self.title_y,
-                group_by=self.groupby,
+                group_by=_metric_to_backend_groupby(self.groupby),
                 group_agg=self.groupby_aggfunc,
                 group_area=self.groupby_rangefunc,
                 limit=self.max_runs_to_show,
@@ -2076,7 +2076,7 @@ class BarPlot(Panel):
             range_x=(model.config.x_axis_min, model.config.x_axis_max),
             title_x=model.config.x_axis_title,
             title_y=model.config.y_axis_title,
-            groupby=model.config.group_by,
+            groupby=_metric_to_frontend_groupby(model.config.group_by),
             groupby_aggfunc=model.config.group_agg,
             groupby_rangefunc=model.config.group_area,
             max_runs_to_show=model.config.limit,
@@ -3606,6 +3606,63 @@ def _metric_to_frontend_panel_grid(x: str):
         return Config(name)
     return _metric_to_frontend(x)
 
+def _metric_to_backend_groupby(val: Optional[Union[str, "Config"]]) -> Optional[str]:
+    """
+    Normalise a group-by key so the backend always receives the form
+        <first_segment>.value[.<rest>]
+
+    Accepts
+    --------
+    1. wr.Config("epochs")              ➔ "epochs.value"
+    2. "config.epochs" / "config.a.b"   ➔ "epochs.value" / "a.value.b"
+    3. "epochs" / "a.b"                 ➔ "epochs.value" / "a.value.b"
+
+    Anything that is already in the correct format
+    ("epochs.value", "a.value.b", …) is returned unchanged.
+    Non-string inputs (run-level metrics, SummaryMetric, etc.) are passed
+    through untouched so existing behaviour stays the same.
+    """
+    if val is None:
+        return None
+
+    # 1) unwrap wr.Config
+    if isinstance(val, Config):
+        val = val.name
+
+    # 2) drop an explicit "config." prefix for uniform handling
+    if val.startswith("config."):
+        val = val.split("config.", 1)[1]
+
+    segments = val.split(".")
+
+    # 3) if we already have ".value" immediately after the first segment, keep it
+    if len(segments) >= 2 and segments[1] == "value":
+        return val
+
+    first, *rest = segments
+    rest_path = "." + ".".join(rest) if rest else ""
+    return f"{first}.value{rest_path}" 
+
+
+def _metric_to_frontend_groupby(val: Optional[str]):
+    """
+    Convert the backend form back into a user-friendly object.
+        "epochs.value"   ➔ Config("epochs")
+        "a.value.b"      ➔ Config("a.b")
+    Anything that isn’t a config path (doesn’t have '.value' as the second
+    token) is returned unchanged.
+    """
+    if val is None or not isinstance(val, str):
+        return val
+
+    parts = val.split(".")
+    if len(parts) < 2 or parts[1] != "value":
+        return val  # not a config key, just return as-is
+
+    first = parts[0]
+    rest = parts[2:]
+    path = first + ("." + ".".join(rest) if rest else "")
+    return Config(path)
 
 def _get_rs_by_name(runsets, name):
     for rs in runsets:

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -1786,7 +1786,6 @@ class LinePlot(Panel):
         legend_position Optional[LegendPosition]: Where to place the legend.
             Options include "north", "south", "east", "west", or `None`.
         legend_template (Optional[str]): The template for the legend.
-        aggregate (Optional[bool]): If set to `True`, aggregate the data.
         xaxis_expression (Optional[str]): The expression for the x-axis.
         legend_fields (Optional[LList[str]]): The fields to include in the legend.
     """
@@ -1813,7 +1812,6 @@ class LinePlot(Panel):
     font_size: Optional[FontSize] = None
     legend_position: Optional[LegendPosition] = None
     legend_template: Optional[str] = None
-    aggregate: Optional[bool] = None
     xaxis_expression: Optional[str] = None
     legend_fields: Optional[LList[str]] = None
 
@@ -1844,7 +1842,7 @@ class LinePlot(Panel):
                 font_size=self.font_size,
                 legend_position=self.legend_position,
                 legend_template=self.legend_template,
-                aggregate=self.aggregate,
+                aggregate=True if self.groupby else False,
                 x_expression=self.xaxis_expression,
                 legend_fields=self.legend_fields,
             ),

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -2057,6 +2057,7 @@ class BarPlot(Panel):
                 font_size=self.font_size,
                 override_series_titles=self.line_titles,
                 override_colors=self.line_colors,
+                aggregate=True if self.groupby else False,
             ),
             layout=self.layout._to_model(),
             id=self._id,
@@ -2081,6 +2082,7 @@ class BarPlot(Panel):
             font_size=model.config.font_size,
             line_titles=model.config.override_series_titles,
             line_colors=model.config.override_colors,
+            aggregate=model.config.aggregate,
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3619,8 +3619,6 @@ def _metric_to_backend_groupby(val: Optional[Union[str, "Config"]]) -> Optional[
 
     Anything that is already in the correct format
     ("epochs.value", "a.value.b", …) is returned unchanged.
-    Non-string inputs (run-level metrics, SummaryMetric, etc.) are passed
-    through untouched so existing behaviour stays the same.
     """
     if val is None:
         return None

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -1786,6 +1786,7 @@ class LinePlot(Panel):
         legend_position Optional[LegendPosition]: Where to place the legend.
             Options include "north", "south", "east", "west", or `None`.
         legend_template (Optional[str]): The template for the legend.
+        aggregate (Optional[bool]): If set to `True`, aggregate the data.
         xaxis_expression (Optional[str]): The expression for the x-axis.
         legend_fields (Optional[LList[str]]): The fields to include in the legend.
     """
@@ -1812,6 +1813,7 @@ class LinePlot(Panel):
     font_size: Optional[FontSize] = None
     legend_position: Optional[LegendPosition] = None
     legend_template: Optional[str] = None
+    aggregate: Optional[bool] = None
     xaxis_expression: Optional[str] = None
     legend_fields: Optional[LList[str]] = None
 
@@ -1842,7 +1844,7 @@ class LinePlot(Panel):
                 font_size=self.font_size,
                 legend_position=self.legend_position,
                 legend_template=self.legend_template,
-                aggregate=True if self.groupby else False,
+                aggregate=True if self.groupby else self.aggregate,
                 x_expression=self.xaxis_expression,
                 legend_fields=self.legend_fields,
             ),
@@ -2018,6 +2020,7 @@ class BarPlot(Panel):
             Options include "small", "medium", "large", "auto", or `None`.
         line_titles (Optional[dict]): The titles of the lines. The keys are the line names and the values are the titles.
         line_colors (Optional[dict]): The colors of the lines. The keys are the line names and the values are the colors.
+        aggregate (Optional[bool]): If set to `True`, aggregate the data.
     """
 
     title: Optional[str] = None
@@ -2036,6 +2039,7 @@ class BarPlot(Panel):
     font_size: Optional[FontSize] = None
     line_titles: Optional[dict] = None
     line_colors: Optional[dict] = None
+    aggregate: Optional[bool] = None
 
     def _to_model(self):
         return internal.BarPlot(
@@ -2057,7 +2061,7 @@ class BarPlot(Panel):
                 font_size=self.font_size,
                 override_series_titles=self.line_titles,
                 override_colors=self.line_colors,
-                aggregate=True if self.groupby else False,
+                aggregate=True if self.groupby else self.aggregate,
             ),
             layout=self.layout._to_model(),
             id=self._id,

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -693,6 +693,7 @@ class BarPlotConfig(ReportAPIBaseModel):
     font_size: Optional[FontSize] = None
     override_series_titles: Optional[dict] = None
     override_colors: Optional[dict] = None
+    aggregate: Optional[bool] = None
 
 
 class BarPlot(Panel):


### PR DESCRIPTION
### Fixes:
* https://wandb.atlassian.net/browse/WB-12407
* https://wandb.atlassian.net/browse/WB-16436
### Description:
* Updated both `LinePlot` and `BarPlot` to:
   * Automatically set `aggregate=True` if `groupby` is set. It was confusing for users that setting `groupby` didn't make any difference on the UI and they had to also set `aggregate`
   * If `groupby` isn't set, allow users to set `aggregate` (If True runs are grouped by None as in the UI)
   * Added `_metric_to_backend_groupby` and `_metric_to_frontend_groupby` to handle groupby values and have more flexibility:
       * Before users could only use `epochs.value` or `keys.value.key1` for nested config keys, making it hard for them to figure that out
       * Now they can simply use `epochs`, `keys.key1` or `wr.Config('epochs')` or `wr.Config('keys.key1')` which is more intuitive and aligns with the rest of the code
### Testing:
Added comprehensive tests for the new groupby functionality:

* **`test_metric_to_backend_groupby()`** - Tests the `_metric_to_backend_groupby` function with various input formats:
  - `Config("epochs")` → `"epochs.value"`
  - `Config("keys.key1")` → `"keys.value.key1"`
  - `"config.epochs"` → `"epochs.value"`
  - `"epochs"` → `"epochs.value"` (legacy support)
  - Edge cases (None, empty string)

* **`test_metric_to_frontend_groupby()`** - Tests the `_metric_to_frontend_groupby` function for proper reverse conversion:
  - `"epochs.value"` → `Config("epochs")`
  - `"keys.value.key1"` → `Config("keys.key1")`
  - Non-config paths pass through unchanged

* **`test_groupby_aggregate_behavior()`** - Validates the auto-aggregate feature:
  - Panels with `groupby` automatically set `aggregate=True`
  - Panels without `groupby` allow manual `aggregate` control
  - Tests both LinePlot and BarPlot with Config objects and strings

Before:
![image](https://github.com/user-attachments/assets/fe309dd5-85d7-4d8b-9dfb-8c1594610ff9)

````
import wandb_workspaces.reports.v2 as wr

entity = "luis_team_test"
project = "group_line_bar_plot_2"

report = wr.Report(
    entity=entity,
    project=project,
    width="fluid",
    blocks=[
        wr.PanelGrid(
            panels=[
                wr.LinePlot(
                    x="_step",
                    y=["metric"],
                    groupby="epochs.value",
                    layout=wr.Layout(w=10, h=6),
                    aggregate=True,
                ),
                wr.BarPlot(
                    metrics=["bar_metric"],
                    groupby="epochs",
                    layout=wr.Layout(w=10, h=6),
                ),
                wr.LinePlot(
                    x="_step",
                    y=["metric"],
                    groupby="keys.value.key1",
                    layout=wr.Layout(w=10, h=6),
                    aggregate=True,
                ),
                wr.BarPlot(
                    metrics=["bar_metric"],
                    groupby="keys.key1",
                    layout=wr.Layout(w=10, h=6),
                ),
            ]
        )
    ]
)
report.save()

url = report.url


new_report = wr.Report.from_url(url)
new_report.save()
````
After:
![image](https://github.com/user-attachments/assets/3f51756f-ddaa-42c4-be7f-2aae60ba8886)

````
import wandb_workspaces.reports.v2 as wr

entity = "luis_team_test"
project = "group_line_bar_plot_2"

report = wr.Report(
    entity=entity,
    project=project,
    width="fluid",
    blocks=[
        wr.PanelGrid(
            panels=[
                wr.LinePlot(
                    x="_step",
                    y=["metric"],
                    groupby=wr.Config("epochs"),
                    layout=wr.Layout(w=10, h=6),
                ),
                wr.BarPlot(
                    metrics=["bar_metric"],
                    groupby="epochs",
                    layout=wr.Layout(w=10, h=6),
                ),
                wr.LinePlot(
                    x="_step",
                    y=["metric"],
                    groupby=wr.Config("keys.key1"),
                    layout=wr.Layout(w=10, h=6),
                ),
                wr.BarPlot(
                    metrics=["bar_metric"],
                    groupby="keys.key1",
                    layout=wr.Layout(w=10, h=6),
                ),
            ]
        )
    ]
)
report.save()

url = report.url


new_report = wr.Report.from_url(url)
new_report.save()
````

