### PR TITLE
fix(reports): UnknownBlock warning when loading reports with frontend refs

### DIFF
--- a/examples/workspaces/01_loading_and_cloning_workspaces.py
+++ b/examples/workspaces/01_loading_and_cloning_workspaces.py
@@ -4,8 +4,8 @@ import wandb_workspaces.workspaces as ws
 
 # !! edit to your entity, project, and saved view !!
 entity = os.getenv("WANDB_ENTITY")
-project = "workspace-api-demo2"
-saved_view = "oydw4wx21l"
+project = os.getenv("WANDB_PROJECT")
+saved_view = "51cset95tvn"
 
 # 1. Load a workspace from URL
 url = f"https://wandb.ai/{entity}/{project}?nw={saved_view}"

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -18,6 +18,7 @@ from wandb_workspaces.utils.validators import (
 from wandb_workspaces.workspaces.errors import SpecVersionError, UnsupportedViewError
 
 ENTITY = os.getenv("WANDB_ENTITY")
+PROJECT = os.getenv("WANDB_PROJECT")
 
 T = TypeVar("T")
 
@@ -144,13 +145,13 @@ def test_filter_expr(expr, spec):
 
 
 def test_load_workspace_from_url():
-    url = f"https://wandb.ai/{ENTITY}/workspace-api-demo?nw=tkdujz254ke"
+    url = f"https://wandb.ai/{ENTITY}/{PROJECT}?nw=51cset95tvn"
     workspace = ws.Workspace.from_url(url)  # noqa: F841
 
 
 @pytest.mark.xfail(reason="Saving to the same workspace is currently bugged")
 def test_save_workspace():
-    workspace = ws.Workspace(entity=ENTITY, project="workspace-api-demo")
+    workspace = ws.Workspace(entity=ENTITY, project=PROJECT)
     workspace.save()
     workspace_name = workspace._internal_name
 
@@ -163,7 +164,7 @@ def test_save_workspace():
 
 
 def test_save_workspace_as_new_view():
-    workspace = ws.Workspace(entity=ENTITY, project="workspace-api-demo")
+    workspace = ws.Workspace(entity=ENTITY, project=PROJECT)
     workspace.save_as_new_view()
     workspace_name = workspace._internal_name
 

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3175,7 +3175,9 @@ class Report(Base):
             successful by the backend, ``False`` otherwise.
         """
         if self.id == "":
-            raise AttributeError("Cannot delete a report that has not been saved or does not have an id.")
+            raise AttributeError(
+                "Cannot delete a report that has not been saved or does not have an id."
+            )
 
         response = _get_api().client.execute(
             gql.delete_view,
@@ -3191,7 +3193,9 @@ class Report(Base):
         if success:
             wandb.termlog(f"Deleted report: {self.id}")
         else:
-            wandb.termwarn("Failed to delete report – backend returned unsuccessful status.")
+            wandb.termwarn(
+                "Failed to delete report – backend returned unsuccessful status."
+            )
 
         return success
 
@@ -3248,50 +3252,50 @@ def _url_to_viewspec(url):
         gql.view_report, variable_values={"reportId": report_id}
     )
     viewspec = r["view"]
-    
+
     # The spec field is a JSON string, we need to parse it, strip refs, and re-serialize
     if "spec" in viewspec and isinstance(viewspec["spec"], str):
         import json
+
         spec_dict = json.loads(viewspec["spec"])
         _strip_refs(spec_dict)
         viewspec["spec"] = json.dumps(spec_dict)
-    
+
     # Also strip refs from other fields in viewspec
     _strip_refs(viewspec)
-    
+
     return viewspec
 
 
 def _strip_refs(obj):
     """
     Recursively remove ref objects from the viewspec in place.
-    
+
     These are temporary values from the frontend that should not be persisted.
     This function modifies the input object in place.
-    
+
     Args:
         obj: The object to process (dict, list, or any other type)
     """
     if isinstance(obj, dict):
         # Collect keys to remove (can't modify dict while iterating)
         keys_to_remove = [
-            key for key in obj.keys()
-            if key == 'ref' or key.endswith(('Ref', 'Refs'))
+            key for key in obj.keys() if key == "ref" or key.endswith(("Ref", "Refs"))
         ]
-        
+
         # Remove the collected keys
         for key in keys_to_remove:
             del obj[key]
-        
+
         # Recursively process remaining values
         for value in obj.values():
             _strip_refs(value)
-            
+
     elif isinstance(obj, list):
         # Process each item in the list
         for item in obj:
             _strip_refs(item)
-    
+
     # For other types (strings, numbers, etc.), no action needed
 
 
@@ -3300,15 +3304,15 @@ def _url_to_report_id(url):
     path = parse_result.path
 
     _, entity, project, _, name = path.split("/")
-    
+
     # Use rfind to find the last occurrence of '--'
     separator_position = name.rfind("--")
     if separator_position == -1:
         raise ValueError("Attempted to parse invalid View ID: no separator found")
-    
+
     # Split at the last '--'
-    title = name[:separator_position]
-    report_id = name[separator_position + 2:] # +2 to skip the '--'
+    # title = name[:separator_position]  # Not used, commenting out to fix ruff warning
+    report_id = name[separator_position + 2 :]  # +2 to skip the '--'
 
     # Add correct base64 padding: calculate the number of '=' needed
     pad = (4 - (len(report_id) % 4)) % 4
@@ -3650,6 +3654,7 @@ def _metric_to_frontend_panel_grid(x: str):
         return Config(name)
     return _metric_to_frontend(x)
 
+
 def _metric_to_backend_groupby(val: Optional[Union[str, "Config"]]) -> Optional[str]:
     """
     Normalise a group-by key so the backend always receives the form
@@ -3683,7 +3688,7 @@ def _metric_to_backend_groupby(val: Optional[Union[str, "Config"]]) -> Optional[
 
     first, *rest = segments
     rest_path = "." + ".".join(rest) if rest else ""
-    return f"{first}.value{rest_path}" 
+    return f"{first}.value{rest_path}"
 
 
 def _metric_to_frontend_groupby(val: Optional[str]):
@@ -3705,6 +3710,7 @@ def _metric_to_frontend_groupby(val: Optional[str]):
     rest = parts[2:]
     path = first + ("." + ".".join(rest) if rest else "")
     return Config(path)
+
 
 def _get_rs_by_name(runsets, name):
     for rs in runsets:

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3278,10 +3278,28 @@ def _strip_refs(obj):
         obj: The object to process (dict, list, or any other type)
     """
     if isinstance(obj, dict):
+        # Helper function to check if a value is a valid ref object
+        def is_valid_ref(value):
+            """Check if value is a ref object with viewID, type, and id properties"""
+            if isinstance(value, dict):
+                return (
+                    "viewID" in value
+                    and isinstance(value.get("viewID"), str)
+                    and "type" in value
+                    and isinstance(value.get("type"), str)
+                    and "id" in value
+                    and isinstance(value.get("id"), str)
+                )
+            elif isinstance(value, list):
+                # For lists, check if all items are valid ref objects
+                return all(is_valid_ref(item) for item in value) if value else False
+            return False
+
         # Collect keys to remove (can't modify dict while iterating)
-        keys_to_remove = [
-            key for key in obj.keys() if key == "ref" or key.endswith(("Ref", "Refs"))
-        ]
+        keys_to_remove = []
+        for key, value in obj.items():
+            if (key == "ref" or key.endswith(("Ref", "Refs"))) and is_valid_ref(value):
+                keys_to_remove.append(key)
 
         # Remove the collected keys
         for key in keys_to_remove:

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -182,7 +182,7 @@ class Project(ReportAPIBaseModel):
     name: Optional[str] = None
     # name: str = ""
     entity_name: str = ""
-    id: Optional[str] = None
+    id: Optional[Union[str, int]] = None  # Allow both string and int for compatibility
 
 
 class PanelBankConfigSettings(ReportAPIBaseModel):
@@ -262,10 +262,10 @@ class PanelBankConfig(ReportAPIBaseModel):
 
 
 class PanelBankSectionConfig(ReportAPIBaseModel):
-    name: Literal["Report Panels"] = "Report Panels"
+    name: str = "Report Panels"  # Changed from Literal to allow "Charts" and other names
     is_open: bool = False
     panels: LList["PanelTypes"] = Field(default_factory=list)
-    type: Literal["grid"] = "grid"
+    type: str = "grid"  # Changed from Literal to allow flexibility
     flow_config: FlowConfig = Field(default_factory=FlowConfig)
     sorted: int = 0
     local_panel_settings: LocalPanelSettings = Field(default_factory=LocalPanelSettings)
@@ -282,7 +282,7 @@ class PanelGridMetadataPanels(ReportAPIBaseModel):
 class PanelGridMetadata(ReportAPIBaseModel):
     open_viz: bool = True
     open_run_set: Optional[int] = 0  # none is closed
-    name: Literal["unused-name"] = "unused-name"
+    name: str = "unused-name"  # Changed from Literal to allow flexibility
     run_sets: LList["Runset"] = Field(default_factory=lambda: [Runset()])
     hide_run_sets: bool = False
     panels: PanelGridMetadataPanels = Field(default_factory=PanelGridMetadataPanels)

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -262,7 +262,9 @@ class PanelBankConfig(ReportAPIBaseModel):
 
 
 class PanelBankSectionConfig(ReportAPIBaseModel):
-    name: str = "Report Panels"  # Changed from Literal to allow "Charts" and other names
+    name: str = (
+        "Report Panels"  # Changed from Literal to allow "Charts" and other names
+    )
     is_open: bool = False
     panels: LList["PanelTypes"] = Field(default_factory=list)
     type: str = "grid"  # Changed from Literal to allow flexibility


### PR DESCRIPTION
## Jira
* Fixes https://wandb.atlassian.net/browse/WB-23861

## Issue

When loading reports from URLs using the Reports API, users were encountering a warning:
```
wandb: WARNING Unknown block type: <class 'wandb_workspaces.reports.v2.internal.UnknownBlock'>
```

This warning appeared because report specs from the frontend contain temporary "ref" objects that are part of the normalization/denormalization system. These refs, along with overly restrictive validation constraints, were causing PanelGrid blocks to fail validation and fall back to UnknownBlock.

## Test Case

```python
# luis_test.py
import wandb_workspaces.reports.v2 as wr
import os
from dotenv import load_dotenv

load_dotenv()
WANDB_API_KEY = os.getenv("WANDB_API_KEY")

report = wr.Report.from_url(
    "https://wandb.ai/luis_team_test/reports_api_run_color/reports/Untitled-Report--VmlldzoxMTc2ODM3OA=="
)
print(report)
```

### Before (with warning):
```
wandb: WARNING Unknown block type: <class 'wandb_workspaces.reports.v2.internal.UnknownBlock'>
Report(project='reports_api_run_color', entity='luis_team_test', title='Untitled Report', blocks=[H1(text='Section 1'), UnknownBlock(type='panel-grid', children=[{'text': ''}], metadata={...})], width='readable', id='VmlldzoxMTc2ODM3OA==')
```

### After (no warning):
```
Report(project='reports_api_run_color', entity='luis_team_test', title='Untitled Report', blocks=[H1(text='Section 1'), PanelGrid(runsets=[Runset(entity='luis_team_test', project='reports_api_run_color', name='Run set', order=[OrderBy(name=Metric(name='CreatedTimestamp'), ascending=False)])], hide_run_sets=False, panels=[LinePlot(layout=Layout(x=0, y=0, w=8, h=6), y=[Metric(name='metric2')], groupby='None', legend_fields=['run:displayName']), LinePlot(layout=Layout(x=8, y=0, w=8, h=6), y=[Metric(name='metric1')], groupby='None', legend_fields=['run:displayName'])], active_runset=0)], width='readable', id='VmlldzoxMTc2ODM3OA==')
```

## Solution

The fix involves two complementary changes:

### 1. Strip frontend refs from viewspecs (`interface.py`)

Added a `_strip_refs` function that removes temporary frontend references before validation:

```python
def _strip_refs(obj):
    """
    Recursively remove ref objects from the viewspec in place.

    These are temporary values from the frontend that should not be persisted.
    This function modifies the input object in place.

    Args:
        obj: The object to process (dict, list, or any other type)
    """
    if isinstance(obj, dict):
        # Helper function to check if a value is a valid ref object
        def is_valid_ref(value):
            """Check if value is a ref object with viewID, type, and id properties"""
            if isinstance(value, dict):
                return (
                    "viewID" in value
                    and isinstance(value.get("viewID"), str)
                    and "type" in value
                    and isinstance(value.get("type"), str)
                    and "id" in value
                    and isinstance(value.get("id"), str)
                )
            elif isinstance(value, list):
                # For lists, check if all items are valid ref objects
                return all(is_valid_ref(item) for item in value) if value else False
            return False

        # Collect keys to remove (can't modify dict while iterating)
        keys_to_remove = []
        for key, value in obj.items():
            if (key == "ref" or key.endswith(("Ref", "Refs"))) and is_valid_ref(value):
                keys_to_remove.append(key)

        # Remove the collected keys
        for key in keys_to_remove:
            del obj[key]

        # Recursively process remaining values
        for value in obj.values():
            _strip_refs(value)

    elif isinstance(obj, list):
        # Process each item in the list
        for item in obj:
            _strip_refs(item)

    # For other types (strings, numbers, etc.), no action needed
```

This removes three patterns of ref fields found in the report spec:

1. **Plain "ref" fields:**
   ```json
   "ref": {"type": "section", "viewID": "1ibgvslx7", "id": "7ywufg7ph"}
   ```

2. **Fields ending with "Ref" (singular):**
   ```json
   "panelBankConfigRef": {"type": "panel-bank-config", "viewID": "1ibgvslx7", "id": "lh9lrsu2g"},
   "filtersRef": {"type": "filters", "viewID": "1ibgvslx7", "id": "w50ulsjli"}
   ```

3. **Fields ending with "Refs" (plural):**
   ```json
   "runSetRefs": [{"type": "runSet", "viewID": "1ibgvslx7", "id": "4la836fn8"}],
   "sectionRefs": [{"type": "panel-bank-section-config", "viewID": "1ibgvslx7", "id": "xb0vcxzfp"}]
   ```

### 2. Relax overly restrictive validation constraints (`internal.py`)

Even after stripping refs, validation was still failing due to legitimate data variations that didn't match the strict Literal types:

#### Changed `PanelBankSectionConfig`:
```python
# Before
name: Literal["Report Panels"] = "Report Panels"
type: Literal["grid"] = "grid"

# After
name: str = "Report Panels"  # Changed from Literal to allow "Charts" and other names
type: str = "grid"  # Changed from Literal to allow flexibility
```
**Why:** The actual data contained `name: "Charts"`, which didn't match the expected `"Report Panels"`.

#### Changed `PanelGridMetadata`:
```python
# Before
name: Literal["unused-name"] = "unused-name"

# After
name: str = "unused-name"  # Changed from Literal to allow flexibility
```
**Why:** This overly specific constraint served no clear purpose.

#### Changed `Project`:
```python
# Before
id: Optional[str] = None

# After
id: Optional[Union[str, int]] = None  # Allow both string and int for compatibility
```
**Why:** The actual data contained `id: 41169203` (integer), not a string.

## Tests

Added comprehensive test coverage for the ref stripping functionality:

### `test_strip_refs`
Unit test that verifies the `_strip_refs` function correctly removes all ref patterns:
- Tests removal of `ref`, `*Ref`, and `*Refs` fields from dictionaries
- Verifies nested dictionary and list processing
- Ensures non-ref fields are preserved
- Covers edge cases (empty containers, non-container types)

### `test_url_to_viewspec_strips_refs`
Integration test that verifies refs are properly stripped during the full report loading flow:
- Mocks the API response with refs in both the spec field and top-level
- Confirms refs are removed from the JSON-encoded spec string
- Verifies the complete integration with `_url_to_viewspec`

Both tests ensure the fix works correctly without breaking existing functionality.