### PR TITLE
Add plotting and table customization options

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -414,7 +414,11 @@ def test_layout_config():
     CUSTOM_USER_DEFINED_LAYOUT = {"x": 0, "y": 0, "w": 24, "h": 24}
 
     p0 = wr.WeavePanelSummaryTable(table_name="test")
-    p1 = wr.WeavePanelSummaryTable(table_name="test", layout=CUSTOM_USER_DEFINED_LAYOUT)
+    p1 = wr.WeavePanelSummaryTable(
+        table_name="test",
+        layout=CUSTOM_USER_DEFINED_LAYOUT,
+        table_filter="metric>5",
+    )
     p2 = wr.WeavePanelArtifact(artifact="test", layout=CUSTOM_USER_DEFINED_LAYOUT)
     p3 = wr.WeavePanelArtifactVersionedFile(
         artifact="test",
@@ -428,6 +432,24 @@ def test_layout_config():
 
     for panel in [p1, p2, p3, p4]:
         assert panel._to_model().layout.model_dump() == CUSTOM_USER_DEFINED_LAYOUT
+
+
+def test_lineplot_xaxis_format():
+    lp = wr.LinePlot(y=["loss"], xaxis_format="dateTime")
+    assert lp._to_model().config.x_axis_format == "dateTime"
+
+
+def test_panelgrid_active_runset_none():
+    pg = wr.PanelGrid(active_runset=None)
+    assert pg._to_model().metadata.open_run_set is None
+
+
+def test_weave_table_filter_in_config():
+    p = wr.WeavePanelSummaryTable(table_name="test", table_filter="foo")
+    cfg = p._to_model().config
+    assert (
+        cfg["panel2Config"]["exp"]["fromOp"]["inputs"]["filter"] == "foo"
+    )
 
 
 def test_url_to_report_id_padding():

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -1029,7 +1029,7 @@ class PanelGrid(Block):
     runsets: LList["Runset"] = Field(default_factory=lambda: [Runset()])
     hide_run_sets: bool = False
     panels: LList["PanelTypes"] = Field(default_factory=list)
-    active_runset: int = 0
+    active_runset: Optional[int] = 0
     custom_run_colors: Dict[Union[RunId, RunsetGroup], Union[str, dict]] = Field(
         default_factory=dict
     )
@@ -1051,6 +1051,7 @@ class PanelGrid(Block):
                     panel_bank_config=internal.PanelBankConfig(),
                     open_viz=self._open_viz,
                 ),
+                open_run_set=self.active_runset,
                 custom_run_colors=_to_color_dict(self.custom_run_colors, self.runsets),
             )
         )
@@ -1815,6 +1816,7 @@ class LinePlot(Panel):
     legend_template: Optional[str] = None
     aggregate: Optional[bool] = None
     xaxis_expression: Optional[str] = None
+    xaxis_format: Optional[str] = None
     legend_fields: Optional[LList[str]] = None
 
     def _to_model(self):
@@ -1846,6 +1848,7 @@ class LinePlot(Panel):
                 legend_template=self.legend_template,
                 aggregate=True if self.groupby else self.aggregate,
                 x_expression=self.xaxis_expression,
+                x_axis_format=self.xaxis_format,
                 legend_fields=self.legend_fields,
             ),
             id=self._id,
@@ -1879,6 +1882,7 @@ class LinePlot(Panel):
             legend_template=model.config.legend_template,
             aggregate=model.config.aggregate,
             xaxis_expression=model.config.x_expression,
+            xaxis_format=model.config.x_axis_format,
             layout=Layout._from_model(model.layout),
             legend_fields=model.config.legend_fields,
         )
@@ -2579,6 +2583,7 @@ class WeavePanelSummaryTable(Panel):
 
     # TODO: Replace with actual weave panels when ready
     table_name: str = Field(..., kw_only=True)
+    table_filter: Optional[str] = None
 
     def _to_model(self):
         return internal.WeavePanel(
@@ -2748,6 +2753,7 @@ class WeavePanelSummaryTable(Panel):
                                     "type": "string",
                                     "val": self.table_name,
                                 },
+                                "filter": self.table_filter,
                             },
                         },
                         "__userInput": True,
@@ -2761,7 +2767,7 @@ class WeavePanelSummaryTable(Panel):
     def _from_model(cls, model: internal.WeavePanel):
         inputs = internal._get_weave_panel_inputs(model.config)
         table_name = inputs["key"]["val"]
-        return cls(table_name=table_name)
+        return cls(table_name=table_name, table_filter=inputs.get("filter"))
 
 
 @dataclass(config=dataclass_config)

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -630,6 +630,7 @@ class LinePlotConfig(ReportAPIBaseModel):
     legend_template: Optional[str] = None
     aggregate: Optional[bool] = None
     x_expression: Optional[str] = None
+    x_axis_format: Optional[str] = None
 
     override_line_widths: Optional[dict] = None
     override_colors: Optional[dict] = None


### PR DESCRIPTION
## Summary
- allow specifying x-axis format for LinePlot panels
- expose run set visibility via `active_runset` in PanelGrid
- support optional filters for WeavePanelSummaryTable

## Testing
- `pytest -p no:cov --override-ini addopts=""` *(fails: ModuleNotFoundError: No module named 'polyfactory')*
- `bash ./code_checks.sh check` *(fails: pre-commit: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a09dea7eb48323974f1bf3afefe854