### PR TITLE
feat: Add active_runset parameter to PanelGrid for runset visibility control

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -738,3 +738,23 @@ def test_url_to_viewspec_strips_refs(monkeypatch):
     assert (
         spec_dict["blocks"][0]["metadata"]["panelBankSectionConfig"]["name"] == "Charts"
     )
+
+
+def test_panelgrid_active_runset():
+    """Test PanelGrid active_runset parameter to control runset visibility."""
+    # Test with default value
+    pg1 = wr.PanelGrid()
+    assert pg1._to_model().metadata.open_run_set == 0
+    
+    # Test with integer value
+    pg2 = wr.PanelGrid(active_runset=1)
+    assert pg2._to_model().metadata.open_run_set == 1
+    
+    # Test with None (hide runset selector)
+    pg3 = wr.PanelGrid(active_runset=None)
+    assert pg3._to_model().metadata.open_run_set is None
+    
+    # Test round-trip serialization
+    model = pg3._to_model()
+    reconstructed = wr.PanelGrid._from_model(model)
+    assert reconstructed.active_runset is None

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -1029,7 +1029,7 @@ class PanelGrid(Block):
     runsets: LList["Runset"] = Field(default_factory=lambda: [Runset()])
     hide_run_sets: bool = False
     panels: LList["PanelTypes"] = Field(default_factory=list)
-    active_runset: int = 0
+    active_runset: Optional[int] = 0
     custom_run_colors: Dict[Union[RunId, RunsetGroup], Union[str, dict]] = Field(
         default_factory=dict
     )
@@ -1051,6 +1051,7 @@ class PanelGrid(Block):
                     panel_bank_config=internal.PanelBankConfig(),
                     open_viz=self._open_viz,
                 ),
+                open_run_set=self.active_runset,
                 custom_run_colors=_to_color_dict(self.custom_run_colors, self.runsets),
             )
         )


### PR DESCRIPTION
## Summary

This PR adds the `active_runset` parameter to `PanelGrid`, allowing users to programmatically control which runset is displayed or hide the runset selector entirely.

## Changes

- Change `active_runset` type from `int` to `Optional[int]` in `PanelGrid` class
- Pass `active_runset` value to `open_run_set` in metadata during serialization
- Add tests for the new functionality in `tests/test_reports.py`

## Usage

```python
# Show specific runset (0-indexed)
panel_grid = wr.PanelGrid(
    active_runset=1,  # Show the second runset
    runsets=[...],
    panels=[...]
)

# Hide runset selector entirely
panel_grid = wr.PanelGrid(
    active_runset=None,  # Hide the runset dropdown
    runsets=[...],
    panels=[...]
)

# Default behavior (show first runset)
panel_grid = wr.PanelGrid(
    active_runset=0,  # Default value
    runsets=[...],
    panels=[...]
)
```

## Notes

- Setting `active_runset=None` hides the runset selector UI completely
- The parameter accepts 0-indexed integers to display specific runsets
- Preserves backward compatibility with default value of 0

## Testing

- Added unit test `test_panelgrid_active_runset` that verifies:
  - Default value behavior (0)
  - Integer values are correctly passed
  - None value is handled properly
  - Round-trip serialization works correctly

## Related Issues

This is the second of three PRs split from PR #67. The other PRs handle:
1. ✅ LinePlot x-axis format parameter (PR #68)
3. 🔜 Optional filters for `WeavePanelSummaryTable`