### PR TITLE
feat(reports): add title argument to MediaBrowser panel

### DIFF
--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -2346,16 +2346,19 @@ class MediaBrowser(Panel):
     A panel that displays media files in a grid layout.
 
     Attributes:
+        title (Optional[str]): The title of the panel.
         num_columns (Optional[int]): The number of columns in the grid.
         media_keys (LList[str]): A list of media keys that correspond to the media files.
     """
 
+    title: Optional[str] = None
     num_columns: Optional[int] = None
     media_keys: LList[str] = Field(default_factory=list)
 
     def _to_model(self):
         return internal.MediaBrowser(
             config=internal.MediaBrowserConfig(
+                chart_title=self.title,
                 column_count=self.num_columns,
                 media_keys=self.media_keys,
             ),
@@ -2366,6 +2369,7 @@ class MediaBrowser(Panel):
     @classmethod
     def _from_model(cls, model: internal.MediaBrowser):
         obj = cls(
+            title=model.config.chart_title,
             num_columns=model.config.column_count,
             media_keys=model.config.media_keys,
             layout=Layout._from_model(model.layout),

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -585,6 +585,7 @@ class Panel(ReportAPIBaseModel):
 
 
 class MediaBrowserConfig(ReportAPIBaseModel):
+    chart_title: Optional[str] = None
     column_count: Optional[int] = None
     media_keys: LList[str] = Field(default_factory=list)
 


### PR DESCRIPTION
## Jira
* https://wandb.atlassian.net/browse/WB-26846
* https://wandb.atlassian.net/browse/WB-25482

## Summary
Adds first-class support for setting and editing a MediaBrowser panel title. Users can pass a `title` when creating a `MediaBrowser`, and titles are hydrated when loading a report from a URL so they can be edited and saved.

## What changed
- `wandb_workspaces/reports/v2/internal.py`
  - Add `chart_title: Optional[str]` to `MediaBrowserConfig` to match report spec.
- `wandb_workspaces/reports/v2/interface.py`
  - Add `title: Optional[str]` to `MediaBrowser` API.
  - Map `title` ⇄ `config.chart_title` in `_to_model`/`_from_model`.
  - Update docstring to include `title`.

## Behavior
- New reports: `wr.MediaBrowser(title=..., media_keys=[...])` shows the title in the UI.
- Existing reports: `wr.Report.from_url(...)` populates `MediaBrowser.title` from `config.chartTitle`. Editing `title` + `save()` persists it.

## Backwards compatibility
- Non-breaking: `title`/`chartTitle` is optional. Existing reports and code continue to work.

## Tests
Following snippet:
```python
import wandb_workspaces.reports.v2 as wr

report = wr.Report(
    project="log_different_media_types_plotly",
    entity="luis_team_test",
    blocks=[
        wr.PanelGrid(
            panels=[
                wr.MediaBrowser(title="My Image", media_keys=["image"]),
                wr.MediaBrowser(title="My Plotly", media_keys=["plotly"]),
            ]
        )
    ]
).save()

# Load by URL, edit the first MediaBrowser title, and save
report1 = wr.Report.from_url(report.url)
report1.blocks[0].panels[0].title = "My Image 2"
report1.save()
```
Produces:
<img width="593" height="568" alt="image" src="https://github.com/user-attachments/assets/70fecd5c-3780-47b5-99ec-750b8512cff9" />
