### PR TITLE
Fix: Pass Runset query parameter to internal model

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -528,6 +528,37 @@ def test_runset_project_lookup(monkeypatch):
     assert "project 'bad-entity/bad-project' not found" in str(exc_info.value)
 
 
+def test_runset_query_parameter():
+    """Test that Runset query parameter is properly passed through to internal model"""
+    from wandb_workspaces.reports.v2 import internal
+    
+    # Test _to_model() - query parameter should be passed to internal model
+    runset = wr.Runset(query="test-run-name")
+    model = runset._to_model()
+    assert model.search is not None
+    assert model.search.query == "test-run-name"
+    
+    # Test empty query string
+    runset_empty = wr.Runset(query="")
+    model_empty = runset_empty._to_model()
+    assert model_empty.search is not None
+    assert model_empty.search.query == ""
+    
+    # Test _from_model() - query parameter should be reconstructed from internal model
+    # Create a mock internal runset with search
+    mock_search = internal.RunsetSearch(query="reconstructed-query")
+    mock_runset = internal.Runset(name="test", search=mock_search)
+    
+    reconstructed = wr.Runset._from_model(mock_runset)
+    assert reconstructed.query == "reconstructed-query"
+    
+    # Test _from_model() with empty search object
+    mock_empty_search = internal.RunsetSearch(query="")
+    mock_runset_empty_search = internal.Runset(name="test", search=mock_empty_search)
+    reconstructed_empty_search = wr.Runset._from_model(mock_runset_empty_search)
+    assert reconstructed_empty_search.query == ""
+
+
 def test_metric_to_backend_groupby():
     """Test the _metric_to_backend_groupby function with various input formats"""
 

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -959,6 +959,7 @@ class Runset(Base):
         obj = internal.Runset(
             project=project,
             name=self.name,
+            search=internal.RunsetSearch(query=self.query),
             filters=expr_parsing.expr_to_filters(self.filters),
             grouping=[expr_parsing.groupby_str_to_key(g) for g in self.groupby],
             sort=internal.Sort(keys=[o._to_model() for o in self.order]),
@@ -982,6 +983,7 @@ class Runset(Base):
             entity=entity,
             project=project,
             name=model.name,
+            query=model.search.query if model.search else "",
             filters=expr_parsing.filters_to_expr(model.filters),
             groupby=[expr_parsing.to_frontend_name(k.name) for k in model.grouping],
             order=[OrderBy._from_model(s) for s in model.sort.keys],


### PR DESCRIPTION
## Summary

This PR fixes the issue where the `query` parameter in `Runset` was accepted but never used when converting to the internal model.

## Problem

The `Runset` class has a `query` field that is documented as "A query string to filter runs", but this parameter was completely ignored in the `_to_model()` method. Users could set a query parameter but it would have no effect on the actual filtering.

## Solution

### Changes to `wandb_workspaces/reports/v2/interface.py`:

1. **Fixed `_to_model()` method**: Added `search=internal.RunsetSearch(query=self.query)` to pass the query parameter to the internal model
2. **Fixed `_from_model()` method**: Added `query=model.search.query if model.search else ""` to reconstruct the query parameter when loading from internal model

### Added comprehensive tests:

- Test that query parameter is correctly passed to internal model
- Test that empty query strings are handled properly  
- Test that query parameter is correctly reconstructed from internal model
- Test edge cases with empty search objects

## Impact

This enables programmatic creation of filtered reports using the query parameter:

```python
# This now works as expected:
runset = wr.Runset(
    entity="my-entity",
    project="my-project", 
    query="run-name-pattern"  # ✅ Now actually filters runs
)
```

## Testing

- Added `test_runset_query_parameter()` with comprehensive coverage
- All existing tests continue to pass
- Verified both directions: `_to_model()` and `_from_model()`

This is the first of 4 separate PRs split from the original PR #70 to make the changes easier to review and test independently.