### PR TITLE
Fix config metric conversion in ScatterPlot and ParallelCoordinatesPlot panels

### DIFF
--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3636,8 +3636,9 @@ def _metric_to_backend_pc(x: Optional[SummaryOrConfigOnlyMetric]):
         backend_name = expr_parsing.to_backend_name(name)
         return f"run:{backend_name}"
     if isinstance(x, Config):
-        name = x.name
-        return f"c::{name}"
+        name, *rest = x.name.split(".")
+        rest = "." + ".".join(rest) if rest else ""
+        return f"config:{name}.value{rest}"
     if isinstance(x, SummaryMetric):
         name = x.name
         return f"summary:{name}"
@@ -3647,6 +3648,14 @@ def _metric_to_backend_pc(x: Optional[SummaryOrConfigOnlyMetric]):
 def _metric_to_frontend_pc(x: str):
     if x is None:
         return x
+    if x.startswith("config:") and ".value" in x:
+        name = x.replace("config:", "")
+        value_idx = name.find(".value")
+        if value_idx != -1:
+            prefix = name[:value_idx]
+            suffix = name[value_idx + 6 :]  # Skip ".value"
+            full_name = prefix + suffix
+            return Config(full_name)
     if x.startswith("c::"):
         name = x.replace("c::", "")
         return Config(name)


### PR DESCRIPTION
## Description

This PR fixes a bug where config metrics weren't displayed correctly in ScatterPlot and ParallelCoordinatesPlot panels. The issue was that these panels were using a legacy format () instead of the current format ().

## Changes

- Fixed  to use  format instead of legacy 
- Fixed  to handle the correct  format with  suffix  
- Maintained backward compatibility with legacy  format for existing reports

## Testing

Tested with the following code:
```python
import wandb_workspaces.reports.v2 as wr

report = wr.Report(
    entity="luis_team_test",
    project="test_compare_configs",
    blocks=[
        wr.PanelGrid(
            panels=[
                wr.ScatterPlot(
                    x=wr.Config("epochs"),
                    y=wr.Config("params.max_tokens"),
                ),
                wr.ParallelCoordinatesPlot(
                    columns=[
                        wr.ParallelCoordinatesPlotColumn(wr.Config("epochs")),
                        wr.ParallelCoordinatesPlotColumn(wr.Config("params.max_tokens"))
                    ]
                )
            ]
        )
    ]
).save()
```

The report now correctly displays config metrics in both ScatterPlot and ParallelCoordinatesPlot panels.

## Jira

Fixes: [WB-21723](https://wandb.atlassian.net/browse/WB-21723)