### PR TITLE
fix(reports): hierarchical selections causing UnknownBlock errors

### DIFF
--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -350,10 +350,16 @@ class Sort(ReportAPIBaseModel):
     keys: LList[SortKey] = Field(default_factory=lambda: [SortKey()])
 
 
+class SelectionTreeNode(ReportAPIBaseModel):
+    value: str
+    children: LList[str] = Field(default_factory=list)
+    skip: Optional[bool] = None
+
+
 class RunsetSelections(ReportAPIBaseModel):
     root: int = 1
     bounds: LList = Field(default_factory=list)
-    tree: LList[str] = Field(default_factory=list)
+    tree: Union[LList[str], LList[SelectionTreeNode]] = Field(default_factory=list)
 
 
 class Runset(ReportAPIBaseModel):

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -432,8 +432,12 @@ class Workspace(Base):
         run_settings = {}
 
         disabled_runs = model.spec.section.run_sets[0].selections.tree
-        for id in disabled_runs:
-            run_settings[id] = RunSettings(disabled=True)
+        for item in disabled_runs:
+            if isinstance(item, str):
+                run_settings[item] = RunSettings(disabled=True)
+            else:
+                for child_id in item.children:
+                    run_settings[child_id] = RunSettings(disabled=True)
 
         custom_run_colors = model.spec.section.custom_run_colors
         for k, v in custom_run_colors.items():


### PR DESCRIPTION
### Jira
* [WB-27349](https://wandb.atlassian.net/browse/WB-27349)

### Problem
Reports and workspaces were failing to parse when users selected runs within grouped runsets, causing `panel-grid` blocks to become `UnknownBlock` and workspaces to crash with validation errors.
<img width="1044" height="743" alt="image" src="https://github.com/user-attachments/assets/53ad5133-7d74-4791-97fe-e0c1a1a6b512" />


The issue occurred because the frontend sends hierarchical selection data when runs are grouped:
```json
{
  "selections": {
    "tree": [
      {"value": "group2", "children": ["qcafzbn0"]},
      {"value": "group1", "skip": true, "children": ["hauu95tf"]}
    ]
  }
}
```

But the backend `RunsetSelections.tree` field only expected a flat list of strings: `List[str]`

### Solution
1. Added `SelectionTreeNode` model to handle hierarchical selection structure
2. Updated `RunsetSelections.tree` to accept both formats: `Union[List[str], List[SelectionTreeNode]]`
3. Updated workspace interface to properly extract run IDs from hierarchical selections

### Changes
- `wandb_workspaces/reports/v2/internal.py`: Added `SelectionTreeNode` model and updated `RunsetSelections`
- `wandb_workspaces/workspaces/interface.py`: Handle both string and hierarchical formats when processing selections

### Testing
```
import wandb_workspaces.reports.v2 as wr
import wandb_workspaces.workspaces as ws

report = wr.Report.from_url(
    "https://wandb.ai/luis_team_test/reports_api_run_color/reports/Copy-of-luis_bergua-s-Untitled-Report--VmlldzoxNDE4NDEyMg"
)
print("Report loaded")
workspace = ws.Workspace.from_url(
    "https://wandb.ai/luis_team_test/reports_api_run_color?nw=2jlfc05k92"
)
print("Workspace loaded")
```
*Before:*
```
wandb: WARNING Unknown block type: <class 'wandb_workspaces.reports.v2.internal.UnknownBlock'>
Report loaded
Traceback (most recent call last):
  File "/Users/luisbergua/Desktop/reports_api_repo/second_clone/wandb-workspaces/luis_test.py", line 9, in <module>
    workspace = ws.Workspace.from_url(
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/luisbergua/Desktop/reports_api_repo/second_clone/wandb-workspaces/wandb_workspaces/workspaces/interface.py", line 629, in from_url
    view = internal.View.from_name(entity, project, internal_view_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/luisbergua/Desktop/reports_api_repo/second_clone/wandb-workspaces/wandb_workspaces/workspaces/internal.py", line 109, in from_name
    parsed_spec = WorkspaceViewspec.model_validate_json(spec)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/luisbergua/anaconda3/lib/python3.12/site-packages/pydantic/main.py", line 734, in model_validate_json
    return cls.__pydantic_validator__.validate_json(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 2 validation errors for WorkspaceViewspec
section.runSets.0.selections.tree.0
  Input should be a valid string [type=string_type, input_value={'value': 'group2', 'skip...children': ['jz4is7mk']}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
section.runSets.0.selections.tree.1
  Input should be a valid string [type=string_type, input_value={'value': 'group1', 'skip...children': ['uvtfafb5']}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
```
*After:*
```
Report loaded
Workspace loaded
```

[WB-27349]: https://wandb.atlassian.net/browse/WB-27349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ