### PR TITLE
Add OrderBy to reports.v2 module exports

### DIFF
--- a/wandb_workspaces/reports/v2/__init__.py
+++ b/wandb_workspaces/reports/v2/__init__.py
@@ -13,6 +13,7 @@ from .interface import (
     InlineLatex,
     Layout,
     Link,
+    OrderBy,
     ParallelCoordinatesPlotColumn,
     Report,
     Runset,


### PR DESCRIPTION
# Summary
Add OrderBy class to direct exports in the wandb_workspaces.reports.v2 module to avoid additional import.

# Problem

You must explicitly import the OrderBy class from wandb_workspaces.reports.v2.interface even though you should only import the main module as wr. This creates unnecessary import statements 

# Impact

### Before PR:

```
import wandb_workspaces.reports.v2 as wr
from wandb_workspaces.reports.v2.interface import OrderBy

runset = wr.Runset(
    entity=ENTITY,
    project=PROJECT,
    order=[OrderBy("CreatedTimestamp", ascending=True)]
)
```

### After PR:

```
import wandb_workspaces.reports.v2 as wr

runset = wr.Runset(
    entity=ENTITY,
    project=PROJECT,
    order=[wr.OrderBy("CreatedTimestamp", ascending=True)]
)
```