### PR TITLE
fix: respect selections.root in Runset round-trip

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1416,6 +1416,69 @@ class TestRunsetRunSettings:
         assert runset.run_settings["run-1"].color == "#0000FF"
         assert runset.run_settings["run-1"].disabled is True
 
+    def test_additive_mode_from_model_marks_tree_as_visible(self):
+        """With root=0 (additive), tree entries are visible, not disabled."""
+        from wandb_workspaces.reports.v2 import internal
+
+        model = internal.Runset(
+            selections=internal.RunsetSelections(
+                root=0, tree=["run-1", "run-2"]
+            ),
+        )
+        runset = wr.Runset._from_model(model)
+        assert runset.run_settings["run-1"].disabled is False
+        assert runset.run_settings["run-2"].disabled is False
+        assert runset._selections_root == 0
+
+    def test_additive_mode_to_model_preserves_root(self):
+        """With root=0, _to_model should write root=0 and visible runs in tree."""
+        runset = wr.Runset(
+            entity="test",
+            project="test",
+            run_settings={
+                "run-1": wr.RunSettings(disabled=False),
+                "run-2": wr.RunSettings(disabled=True),
+            },
+        )
+        object.__setattr__(runset, "_selections_root", 0)
+        model = runset._to_model()
+        assert model.selections.root == 0
+        assert model.selections.tree == ["run-1"]
+
+    def test_additive_mode_round_trip(self):
+        """Reading and re-serializing an additive-mode runset should preserve root and tree."""
+        from wandb_workspaces.reports.v2 import internal
+
+        original = internal.Runset(
+            selections=internal.RunsetSelections(
+                root=0, tree=["visible-run"]
+            ),
+        )
+        runset = wr.Runset._from_model(original)
+        assert runset.run_settings["visible-run"].disabled is False
+        assert runset._selections_root == 0
+
+        model = runset._to_model()
+        assert model.selections.root == 0
+        assert model.selections.tree == ["visible-run"]
+
+    def test_subtractive_mode_unchanged(self):
+        """Default subtractive mode (root=1) should behave exactly as before."""
+        from wandb_workspaces.reports.v2 import internal
+
+        model = internal.Runset(
+            selections=internal.RunsetSelections(
+                root=1, tree=["hidden-run"]
+            ),
+        )
+        runset = wr.Runset._from_model(model)
+        assert runset.run_settings["hidden-run"].disabled is True
+        assert runset._selections_root == 1
+
+        result = runset._to_model()
+        assert result.selections.root == 1
+        assert result.selections.tree == ["hidden-run"]
+
 
 class TestReportSharing:
     """Tests for Report magic link sharing methods."""

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -979,6 +979,7 @@ class Runset(Base):
     run_settings: Dict[str, "RunSettings"] = Field(default_factory=dict)
 
     _id: str = Field(default_factory=internal._generate_name, init=False, repr=False)
+    _selections_root: int = Field(default=1, init=False, repr=False)
 
     @model_validator(mode="after")
     def merge_custom_run_colors_into_run_settings(self):
@@ -1027,14 +1028,21 @@ class Runset(Base):
                     "Please verify that the entity and project names are correct and that you have access to this project."
                 )
 
-        # selections.tree in the internal model stores the list of disabled (hidden)
-        # run IDs. It can contain plain strings or SelectionTreeNode objects for
-        # grouped runs. Here we only write plain run ID strings.
-        disabled_run_ids = [
-            run_id
-            for run_id, settings in self.run_settings.items()
-            if settings.disabled
-        ]
+        # selections.root determines how selections.tree is interpreted:
+        #   root=1 (subtractive/All): tree entries are HIDDEN runs
+        #   root=0 (additive/None):   tree entries are VISIBLE runs
+        if self._selections_root == 0:
+            tree_ids = [
+                run_id
+                for run_id, settings in self.run_settings.items()
+                if not settings.disabled
+            ]
+        else:
+            tree_ids = [
+                run_id
+                for run_id, settings in self.run_settings.items()
+                if settings.disabled
+            ]
 
         obj = internal.Runset(
             project=project,
@@ -1043,7 +1051,9 @@ class Runset(Base):
             filters=expr.expr_to_filters(self.filters),
             grouping=[expr.groupby_str_to_key(g) for g in self.groupby],
             sort=internal.Sort(keys=[o._to_model() for o in self.order]),
-            selections=internal.RunsetSelections(tree=disabled_run_ids),
+            selections=internal.RunsetSelections(
+                root=self._selections_root, tree=tree_ids
+            ),
         )
         obj.id = self._id
         return obj
@@ -1060,13 +1070,17 @@ class Runset(Base):
             if p.name:
                 project = p.name
 
+        # root=1 (subtractive): tree entries are disabled (hidden)
+        # root=0 (additive):    tree entries are enabled (visible)
+        is_disabled = model.selections.root != 0
+
         run_settings = {}
         for item in model.selections.tree:
             if isinstance(item, str):
-                run_settings[item] = RunSettings(disabled=True)
+                run_settings[item] = RunSettings(disabled=is_disabled)
             else:
                 for child_id in item.children:
-                    run_settings[child_id] = RunSettings(disabled=True)
+                    run_settings[child_id] = RunSettings(disabled=is_disabled)
 
         obj = cls(
             entity=entity,
@@ -1079,6 +1093,7 @@ class Runset(Base):
             run_settings=run_settings,
         )
         obj._id = model.id
+        obj._selections_root = model.selections.root
         return obj
 
 


### PR DESCRIPTION
## Summary

- `_from_model()` now checks `selections.root` to correctly interpret tree entries: `root=1` (subtractive) = tree entries are hidden, `root=0` (additive) = tree entries are visible
- `_to_model()` now preserves the original `root` value instead of always writing `root=1`
- Adds `_selections_root` private field to `Runset` for round-trip fidelity

## Problem

When a user sets up run visibility by deselecting all runs and then re-enabling specific ones, the UI stores this as additive selection mode (`selections.root=0`), where `selections.tree` contains the **visible** runs. However, `_from_model()` always interpreted tree entries as `disabled=True` regardless of root, and `_to_model()` always wrote `root=1`. This meant reading a report and saving it back **inverted the visibility**.

## Test plan

- [x] New test: additive mode `_from_model` marks tree entries as `disabled=False`
- [x] New test: additive mode `_to_model` writes `root=0` and visible runs in tree
- [x] New test: additive mode full round-trip preserves root and tree
- [x] New test: subtractive mode (default) behavior unchanged
- [x] All 15 existing + new `TestRunsetRunSettings` tests pass

Made with [Cursor](https://cursor.com)

https://coreweave.atlassian.net/browse/WB-32585