### PR TITLE
fix: preserve disabled filter state in Runset load/save roundtrip

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -187,3 +187,88 @@ def test_list_with_dashes_round_trip():
     # Verify the values survived the round-trip (nested in OR/AND structure)
     inner_filter = parsed.filters[0].filters[0]
     assert inner_filter.value == ["run-one", "two-three", "abc-123-def"]
+
+
+# ===== Disabled filter state preservation tests =====
+
+
+def test_disabled_filters_preserved_in_runset_roundtrip():
+    """Disabled (inactive) filters must survive a _from_model → _to_model roundtrip.
+
+    Regression test: filters_to_expr discarded the ``disabled`` flag and
+    expr_to_filters hardcoded ``disabled=False``, so inactive filters
+    silently became active after a load/save cycle (e.g. report migration).
+    """
+    from wandb_workspaces import expr
+    from wandb_workspaces.reports.v2 import internal
+    import wandb_workspaces.reports.v2 as wr
+
+    internal_runset = internal.Runset(
+        name="test",
+        filters=expr.Filters(
+            op="OR",
+            filters=[
+                expr.Filters(
+                    op="AND",
+                    filters=[
+                        expr.Filters(op="=", key=expr.Key(section="run", name="username"), value="alice", disabled=False),
+                        expr.Filters(op="=", key=expr.Key(section="run", name="state"), value="running", disabled=True),
+                        expr.Filters(op=">=", key=expr.Key(section="run", name="duration"), value="3600", disabled=True),
+                    ],
+                )
+            ],
+        ),
+    )
+
+    iface = wr.Runset._from_model(internal_runset)
+    model = iface._to_model()
+    leaves = model.filters.filters[0].filters
+
+    assert leaves[0].disabled is False
+    assert leaves[1].disabled is True
+    assert leaves[2].disabled is True
+
+
+def test_user_constructed_runset_parses_from_string():
+    """Runsets built by the user (not loaded) should parse filters from the string."""
+    import wandb_workspaces.reports.v2 as wr
+
+    rs = wr.Runset(filters="Metric('User') == 'alice'")
+    assert rs._filters_internal is None
+
+    model = rs._to_model()
+    leaves = model.filters.filters[0].filters
+    assert leaves[0].value == "alice"
+    assert leaves[0].disabled is False
+
+
+def test_modifying_filters_after_load_uses_new_value():
+    """Overwriting .filters on a loaded Runset must discard the stashed tree."""
+    from wandb_workspaces import expr
+    from wandb_workspaces.reports.v2 import internal
+    import wandb_workspaces.reports.v2 as wr
+
+    internal_runset = internal.Runset(
+        name="test",
+        filters=expr.Filters(
+            op="OR",
+            filters=[
+                expr.Filters(
+                    op="AND",
+                    filters=[
+                        expr.Filters(op="=", key=expr.Key(section="run", name="username"), value="alice", disabled=True),
+                    ],
+                )
+            ],
+        ),
+    )
+
+    iface = wr.Runset._from_model(internal_runset)
+    assert iface._filters_internal is not None
+
+    iface.filters = "Metric('User') == 'bob'"
+
+    model = iface._to_model()
+    leaves = model.filters.filters[0].filters
+    assert leaves[0].value == "bob", "New filter value should take effect"
+    assert leaves[0].disabled is False, "New filter should be active"

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -981,6 +981,10 @@ class Runset(Base):
     _id: str = Field(default_factory=internal._generate_name, init=False, repr=False)
     _selections_root: int = Field(default=1, init=False, repr=False)
 
+    _filters_internal: Optional["expr.Filters"] = Field(
+        default=None, init=False, repr=False
+    )
+
     @model_validator(mode="after")
     def merge_custom_run_colors_into_run_settings(self):
         """Merge plain-string-keyed custom_run_colors into run_settings for backward compat."""
@@ -1044,11 +1048,23 @@ class Runset(Base):
                 if settings.disabled
             ]
 
+        # Use the stashed Filters tree when the string hasn't been changed
+        # since loading.  This preserves per-filter metadata (e.g. disabled
+        # state) that the lossy string representation cannot express.
+        filters_unchanged = (
+            self._filters_internal is not None
+            and self.filters == expr.filters_to_expr(self._filters_internal)
+        )
+        if filters_unchanged:
+            filters = self._filters_internal
+        else:
+            filters = expr.expr_to_filters(self.filters)
+
         obj = internal.Runset(
             project=project,
             name=self.name,
             search=internal.RunsetSearch(query=self.query),
-            filters=expr.expr_to_filters(self.filters),
+            filters=filters,
             grouping=[expr.groupby_str_to_key(g) for g in self.groupby],
             sort=internal.Sort(keys=[o._to_model() for o in self.order]),
             selections=internal.RunsetSelections(
@@ -1094,6 +1110,7 @@ class Runset(Base):
         )
         obj._id = model.id
         obj._selections_root = model.selections.root
+        obj._filters_internal = model.filters
         return obj
 
 


### PR DESCRIPTION
## Summary
- Disabled (inactive) runset filters were silently re-activated when a report was loaded and re-saved via the SDK (e.g. during SaaS→dedicated migration)
- Root cause: `filters_to_expr` drops the `disabled` flag and `expr_to_filters` hardcodes `disabled=False` on all parsed filters
- Fix: stash the original `Filters` tree from the server on `_filters_internal` (same pattern as `_id` and `_selections_root`) and use it in `_to_model` when the user hasn't modified the filters string

## Test plan
- [x] `test_disabled_filters_preserved_in_runset_roundtrip` — load with disabled filters, roundtrip, verify disabled state preserved
- [x] `test_user_constructed_runset_parses_from_string` — user-created Runsets still parse from string normally
- [x] `test_modifying_filters_after_load_uses_new_value` — modifying `.filters` after load uses the new value, not the stashed tree


Made with [Cursor](https://cursor.com)

https://coreweave.atlassian.net/browse/WB-32585