### PR TITLE
fix: preserve LinePlot per-series overrides in round-trip

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -892,6 +892,36 @@ def test_lineplot_metric_regex():
     assert lp4._to_model().config.use_metric_regex is True
 
 
+def test_lineplot_series_overrides_roundtrip():
+    """Per-series overrides (colors, marks, widths, titles) must survive a round-trip."""
+    lp = wr.LinePlot(
+        y=["loss", "accuracy"],
+        line_colors={"run:loss": "#ff0000"},
+        line_marks={"run:loss": "dashed"},
+        line_widths={"run:loss": 2.0},
+        line_titles={"run:loss": "Training Loss"},
+    )
+    model = lp._to_model()
+    assert model.config.override_colors == {"run:loss": "#ff0000"}
+    assert model.config.override_marks == {"run:loss": "dashed"}
+    assert model.config.override_line_widths == {"run:loss": 2.0}
+    assert model.config.override_series_titles == {"run:loss": "Training Loss"}
+
+    reconstructed = wr.LinePlot._from_model(model)
+    assert reconstructed.line_colors == {"run:loss": "#ff0000"}
+    assert reconstructed.line_marks == {"run:loss": "dashed"}
+    assert reconstructed.line_widths == {"run:loss": 2.0}
+    assert reconstructed.line_titles == {"run:loss": "Training Loss"}
+
+    # None defaults should not be serialized
+    lp_empty = wr.LinePlot(y=["loss"])
+    spec = lp_empty._to_model().config.model_dump(by_alias=True, exclude_none=True)
+    assert "overrideColors" not in spec
+    assert "overrideMarks" not in spec
+    assert "overrideLineWidths" not in spec
+    assert "overrideSeriesTitles" not in spec
+
+
 def test_block_validation_no_unknown_blocks():
     """Test that blocks are parsed correctly without creating UnknownBlock instances."""
     from wandb_workspaces.reports.v2 import internal

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -902,16 +902,29 @@ def test_lineplot_series_overrides_roundtrip():
         line_titles={"run:loss": "Training Loss"},
     )
     model = lp._to_model()
-    assert model.config.override_colors == {"run:loss": "#ff0000"}
+    # Plain string colors are normalized to {color, transparentColor} for the frontend
+    assert model.config.override_colors == {
+        "run:loss": {"color": "#ff0000", "transparentColor": "#ff000019"}
+    }
     assert model.config.override_marks == {"run:loss": "dashed"}
     assert model.config.override_line_widths == {"run:loss": 2.0}
     assert model.config.override_series_titles == {"run:loss": "Training Loss"}
 
+    # Roundtrip preserves the expanded object format
     reconstructed = wr.LinePlot._from_model(model)
-    assert reconstructed.line_colors == {"run:loss": "#ff0000"}
+    assert reconstructed.line_colors == {
+        "run:loss": {"color": "#ff0000", "transparentColor": "#ff000019"}
+    }
     assert reconstructed.line_marks == {"run:loss": "dashed"}
     assert reconstructed.line_widths == {"run:loss": 2.0}
     assert reconstructed.line_titles == {"run:loss": "Training Loss"}
+
+    # Already-expanded color objects are passed through unchanged
+    expanded = {
+        "run:loss": {"color": "#00ff00", "transparentColor": "rgba(0,255,0,0.1)"}
+    }
+    lp2 = wr.LinePlot(y=["loss"], line_colors=expanded)
+    assert lp2._to_model().config.override_colors == expanded
 
     # None defaults should not be serialized
     lp_empty = wr.LinePlot(y=["loss"])
@@ -1451,9 +1464,7 @@ class TestRunsetRunSettings:
         from wandb_workspaces.reports.v2 import internal
 
         model = internal.Runset(
-            selections=internal.RunsetSelections(
-                root=0, tree=["run-1", "run-2"]
-            ),
+            selections=internal.RunsetSelections(root=0, tree=["run-1", "run-2"]),
         )
         runset = wr.Runset._from_model(model)
         assert runset.run_settings["run-1"].disabled is False
@@ -1480,9 +1491,7 @@ class TestRunsetRunSettings:
         from wandb_workspaces.reports.v2 import internal
 
         original = internal.Runset(
-            selections=internal.RunsetSelections(
-                root=0, tree=["visible-run"]
-            ),
+            selections=internal.RunsetSelections(root=0, tree=["visible-run"]),
         )
         runset = wr.Runset._from_model(original)
         assert runset.run_settings["visible-run"].disabled is False
@@ -1497,9 +1506,7 @@ class TestRunsetRunSettings:
         from wandb_workspaces.reports.v2 import internal
 
         model = internal.Runset(
-            selections=internal.RunsetSelections(
-                root=1, tree=["hidden-run"]
-            ),
+            selections=internal.RunsetSelections(root=1, tree=["hidden-run"]),
         )
         runset = wr.Runset._from_model(model)
         assert runset.run_settings["hidden-run"].disabled is True

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -1932,6 +1932,10 @@ class LinePlot(Panel):
            points when there are too many to display. Options include "bucketing-gorilla" (buckets
            data points and shows min, max, avg per bucket to preserve outliers and spikes) or
            "sampling" (randomly samples points for faster rendering but may miss outliers).
+        line_titles (Optional[dict]): The titles of the lines. The keys are the line names and the values are the titles.
+        line_colors (Optional[dict]): The colors of the lines. The keys are the line names and the values are the colors.
+        line_widths (Optional[dict]): The widths of the lines. The keys are the line names and the values are the widths.
+        line_marks (Optional[dict]): The dash styles of the lines. The keys are the line names and the values are the styles.
     """
 
     title: Optional[str] = None
@@ -1962,6 +1966,10 @@ class LinePlot(Panel):
     legend_fields: Optional[LList[str]] = None
     metric_regex: Optional[str] = None
     point_visualization_method: Optional[PointVizMethod] = None
+    line_titles: Optional[dict] = None
+    line_colors: Optional[dict] = None
+    line_widths: Optional[dict] = None
+    line_marks: Optional[dict] = None
 
     def _to_model(self):
         return internal.LinePlot(
@@ -1997,6 +2005,10 @@ class LinePlot(Panel):
                 metric_regex=self.metric_regex,
                 use_metric_regex=True if self.metric_regex else None,
                 point_visualization_method=self.point_visualization_method,
+                override_series_titles=self.line_titles,
+                override_colors=self.line_colors,
+                override_line_widths=self.line_widths,
+                override_marks=self.line_marks,
             ),
             id=self._id,
             layout=self.layout._to_model(),
@@ -2049,6 +2061,10 @@ class LinePlot(Panel):
         object.__setattr__(
             obj, "point_visualization_method", model.config.point_visualization_method
         )
+        object.__setattr__(obj, "line_titles", model.config.override_series_titles)
+        object.__setattr__(obj, "line_colors", model.config.override_colors)
+        object.__setattr__(obj, "line_widths", model.config.override_line_widths)
+        object.__setattr__(obj, "line_marks", model.config.override_marks)
         return obj
 
 

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -2008,7 +2008,7 @@ class LinePlot(Panel):
                 use_metric_regex=True if self.metric_regex else None,
                 point_visualization_method=self.point_visualization_method,
                 override_series_titles=self.line_titles,
-                override_colors=self.line_colors,
+                override_colors=_normalize_color_overrides(self.line_colors),
                 override_line_widths=self.line_widths,
                 override_marks=self.line_marks,
             ),
@@ -2244,7 +2244,7 @@ class BarPlot(Panel):
                 legend_template=self.legend_template,
                 font_size=self.font_size,
                 override_series_titles=self.line_titles,
-                override_colors=self.line_colors,
+                override_colors=_normalize_color_overrides(self.line_colors),
                 aggregate=self.groupby not in (None, "None") or self.aggregate,
             ),
             layout=self.layout._to_model(),
@@ -4032,6 +4032,26 @@ def _collides(p1: Panel, p2: Panel) -> bool:
         return False
 
     return True
+
+
+def _normalize_color_overrides(
+    colors: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Normalize color overrides to the frontend's expected format.
+
+    The frontend expects ``{color: str, transparentColor: str}`` objects.
+    For convenience the SDK accepts plain color strings (e.g. ``"#ff0000"``)
+    and expands them here.  Already-expanded dicts are passed through.
+    """
+    if colors is None:
+        return None
+    result = {}
+    for key, val in colors.items():
+        if isinstance(val, str):
+            result[key] = {"color": val, "transparentColor": val + "19"}
+        else:
+            result[key] = val
+    return result
 
 
 def _metric_to_backend(x: Optional[MetricType]):

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -29,7 +29,7 @@ report.save()
 import base64
 import os
 from datetime import datetime
-from typing import TYPE_CHECKING, Dict, Iterable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Tuple, Union
 from typing import List as LList
 
 from annotated_types import Annotated, Ge, Le
@@ -55,6 +55,7 @@ from .internal import (
     Language,
     LegendPosition,
     LinePlotStyle,
+    Mark,
     Range,
     ReportWidth,
     SmoothingType,
@@ -1932,10 +1933,11 @@ class LinePlot(Panel):
            points when there are too many to display. Options include "bucketing-gorilla" (buckets
            data points and shows min, max, avg per bucket to preserve outliers and spikes) or
            "sampling" (randomly samples points for faster rendering but may miss outliers).
-        line_titles (Optional[dict]): The titles of the lines. The keys are the line names and the values are the titles.
-        line_colors (Optional[dict]): The colors of the lines. The keys are the line names and the values are the colors.
-        line_widths (Optional[dict]): The widths of the lines. The keys are the line names and the values are the widths.
-        line_marks (Optional[dict]): The dash styles of the lines. The keys are the line names and the values are the styles.
+        line_titles (Optional[Dict[str, str]]): Per-series display titles. Keys use the format "{runId}:{metricName}".
+        line_colors (Optional[Dict[str, Any]]): Per-series colors. Keys use the format "{runId}:{metricName}".
+        line_widths (Optional[Dict[str, float]]): Per-series line widths. Keys use the format "{runId}:{metricName}".
+        line_marks (Optional[Dict[str, Mark]]): Per-series dash styles. Keys use the format "{runId}:{metricName}".
+            Valid values: "solid", "dashed", "dotted", "dotdash", "dotdotdash", "points".
     """
 
     title: Optional[str] = None
@@ -1966,10 +1968,10 @@ class LinePlot(Panel):
     legend_fields: Optional[LList[str]] = None
     metric_regex: Optional[str] = None
     point_visualization_method: Optional[PointVizMethod] = None
-    line_titles: Optional[dict] = None
-    line_colors: Optional[dict] = None
-    line_widths: Optional[dict] = None
-    line_marks: Optional[dict] = None
+    line_titles: Optional[Dict[str, str]] = None
+    line_colors: Optional[Dict[str, Any]] = None
+    line_widths: Optional[Dict[str, float]] = None
+    line_marks: Optional[Dict[str, Mark]] = None
 
     def _to_model(self):
         return internal.LinePlot(

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -74,7 +74,7 @@ LegendPosition = Literal["north", "south", "east", "west"]
 LegendOrientation = Literal["horizontal", "vertical"]
 GroupAgg = Literal["mean", "min", "max", "median", "sum", "samples"]
 GroupArea = Literal["minmax", "stddev", "stderr", "none", "samples"]
-Mark = Literal["solid", "dashed", "dotted", "dotdash", "dotdotdash"]
+Mark = Literal["solid", "dashed", "dotted", "dotdash", "dotdotdash", "points"]
 Timestep = Literal["seconds", "minutes", "hours", "days"]
 SmoothingType = Literal[
     "exponentialTimeWeighted", "exponential", "gaussian", "average", "none"

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -674,6 +674,7 @@ class LinePlotConfig(ReportAPIBaseModel):
     override_line_widths: Optional[dict] = None
     override_colors: Optional[dict] = None
     override_series_titles: Optional[dict] = None
+    override_marks: Optional[dict] = None
     legend_fields: Optional[LList[str]] = None
 
     metric_regex: Optional[str] = None


### PR DESCRIPTION
## Summary

- LinePlot per-series overrides (`overrideColors`, `overrideMarks`, `overrideLineWidths`, `overrideSeriesTitles`) were silently dropped during report load/save, causing lines to reset to solid style and default colors after migration.
- Adds `line_colors`, `line_marks`, `line_widths`, `line_titles` to the public `LinePlot` class and wires them through `_to_model()` / `_from_model()`, following the existing `BarPlot` pattern.
- Adds `override_marks` to the internal `LinePlotConfig` (the other three fields already existed).


Made with [Cursor](https://cursor.com)

https://coreweave.atlassian.net/browse/WB-32586