### PR TITLE
feat: add v2 filter format support with OR and nested groups

### DIFF
--- a/examples/workspaces/03_working_with_workspace_filters.py
+++ b/examples/workspaces/03_working_with_workspace_filters.py
@@ -66,8 +66,8 @@ workspace_with_string_filters = ws.Workspace(
         ),
     ],
     runset_settings=ws.RunsetSettings(
-        # String filters use "and" to combine conditions as there is no "or" available
-        # Supported operators: ==, =, !=, <, <=, >, >=
+        # String filters use "and" and "or" to combine conditions
+        # Supported operators: ==, =, !=, <, <=, >, >=, and, or
         # Note: < maps to <=, > maps to >=, and = maps to == internally to match existing UX behavior
         filters="SummaryMetric('accuracy') > 0.95 and Config('learning_rate') = 0.001 and Metric('State') == 'finished'"
     ),
@@ -276,3 +276,112 @@ workspace_tags_string = ws.Workspace(
 )
 
 workspace_tags_string.save()
+
+# ============================================================================
+# METHOD 5: OR filters and nested groups
+# ============================================================================
+# Combine filters with OR logic using ws.Or(), ws.And(), and ws.Group()
+# Or: combines branches with OR logic
+# And: combines items within a branch with AND logic
+# Group: creates a parenthesised group for precedence control
+
+# Using Or with FilterExpr objects
+workspace_or_filters = ws.Workspace(
+    name="Multiple Learning Rates (OR Filter)",
+    entity=entity,
+    project=project,
+    sections=[
+        ws.Section(
+            name="LR Comparison",
+            panels=[
+                wr.LinePlot(x="Step", y=["loss", "accuracy"]),
+            ],
+            is_open=True,
+        ),
+    ],
+    runset_settings=ws.RunsetSettings(
+        # Show runs with lr=0.001 OR lr=0.01
+        filters=ws.Or(
+            ws.Config("learning_rate") == 0.001,
+            ws.Config("learning_rate") == 0.01,
+        )
+    ),
+)
+
+workspace_or_filters.save()
+
+# Using Or with And groups
+workspace_or_and = ws.Workspace(
+    name="Best Runs from Two Configs (OR + AND)",
+    entity=entity,
+    project=project,
+    sections=[
+        ws.Section(
+            name="Config Comparison",
+            panels=[
+                wr.LinePlot(x="Step", y=["loss"]),
+            ],
+            is_open=True,
+        ),
+    ],
+    runset_settings=ws.RunsetSettings(
+        # (lr=0.001 AND finished) OR (lr=0.01 AND accuracy > 0.9)
+        filters=ws.Or(
+            ws.And(
+                ws.Config("learning_rate") == 0.001,
+                ws.Metric("State") == "finished",
+            ),
+            ws.And(
+                ws.Config("learning_rate") == 0.01,
+                ws.Summary("accuracy") >= 0.9,
+            ),
+        )
+    ),
+)
+
+workspace_or_and.save()
+
+# Using string expressions with OR
+workspace_or_string = ws.Workspace(
+    name="OR Filter (String Expression)",
+    entity=entity,
+    project=project,
+    sections=[
+        ws.Section(
+            name="Results",
+            panels=[
+                wr.LinePlot(x="Step", y=["loss"]),
+            ],
+            is_open=True,
+        ),
+    ],
+    runset_settings=ws.RunsetSettings(
+        # Python-style boolean expression with 'or' and 'and'
+        # Precedence: AND binds tighter than OR (standard boolean logic)
+        filters="Metric('State') == 'finished' and Config('learning_rate') == 0.001 or Config('learning_rate') == 0.01"
+    ),
+)
+
+workspace_or_string.save()
+
+# Parenthesised groups in string expressions
+workspace_group_string = ws.Workspace(
+    name="Grouped OR Filter (String Expression)",
+    entity=entity,
+    project=project,
+    sections=[
+        ws.Section(
+            name="Results",
+            panels=[
+                wr.LinePlot(x="Step", y=["loss"]),
+            ],
+            is_open=True,
+        ),
+    ],
+    runset_settings=ws.RunsetSettings(
+        # Parentheses override default precedence
+        filters="(Config('learning_rate') == 0.001 or Config('learning_rate') == 0.01) and Metric('State') == 'finished'"
+    ),
+)
+
+workspace_group_string.save()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -272,3 +272,419 @@ def test_modifying_filters_after_load_uses_new_value():
     leaves = model.filters.filters[0].filters
     assert leaves[0].value == "bob", "New filter value should take effect"
     assert leaves[0].disabled is False, "New filter should be active"
+
+
+# ===== OR filter and v2 deserialization tests =====
+
+
+class TestOrStringFilters:
+    """Test OR support via string filter expressions."""
+
+    def test_simple_or(self):
+        from wandb_workspaces import expr
+
+        tree = expr.expr_to_filters(
+            "Metric('State') == 'finished' or Config('lr') == 0.01"
+        )
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+        assert tree.filters[0].op == "AND"
+        assert tree.filters[1].op == "AND"
+        assert tree.filters[0].filters[0].value == "finished"
+        assert tree.filters[1].filters[0].value == 0.01
+
+    def test_and_or_precedence(self):
+        from wandb_workspaces import expr
+
+        tree = expr.expr_to_filters(
+            "Metric('State') == 'finished' and Config('lr') == 0.01 or Config('lr') == 0.1"
+        )
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+        # First bucket: (State AND lr==0.01)
+        assert tree.filters[0].op == "AND"
+        assert len(tree.filters[0].filters) == 2
+        # Second bucket: (lr==0.1)
+        assert tree.filters[1].op == "AND"
+
+    def test_or_round_trip(self):
+        from wandb_workspaces import expr
+
+        original = "Metric('State') == 'finished' or Config('lr') == 0.01"
+        tree = expr.expr_to_filters(original)
+        result = expr.filters_to_expr(tree)
+        re_tree = expr.expr_to_filters(result)
+        assert len(re_tree.filters) == 2
+
+    def test_parenthesised_or_in_and(self):
+        from wandb_workspaces import expr
+
+        tree = expr.expr_to_filters(
+            "(Config('lr') == 0.01 or Config('lr') == 0.1) and Metric('State') == 'finished'"
+        )
+        assert tree.op == "OR"
+
+
+class TestOrObjectAPI:
+    """Test OR support via the Or/And/Group object API."""
+
+    def test_or_filterexpr(self):
+        from wandb_workspaces import expr
+
+        f = expr.Or(
+            expr.Config("lr") == 0.01,
+            expr.Config("lr") == 0.1,
+        )
+        tree = f.to_model()
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+
+    def test_and_filterexpr(self):
+        from wandb_workspaces import expr
+
+        f = expr.And(
+            expr.Config("lr") == 0.01,
+            expr.Metric("State") == "finished",
+        )
+        tree = f.to_model()
+        assert tree.op == "AND"
+        assert len(tree.filters) == 2
+
+    def test_or_with_and_groups(self):
+        from wandb_workspaces import expr
+
+        f = expr.Or(
+            expr.And(expr.Config("lr") == 0.01, expr.Metric("State") == "finished"),
+            expr.Config("lr") == 0.1,
+        )
+        tree = f.to_model()
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+        assert tree.filters[0].op == "AND"
+        assert len(tree.filters[0].filters) == 2
+        assert tree.filters[1].op == "AND"
+        assert len(tree.filters[1].filters) == 1
+
+    def test_or_in_runset_settings(self):
+        import wandb_workspaces.workspaces as ws
+        from wandb_workspaces import expr
+
+        rs = ws.RunsetSettings(
+            filters=expr.Or(
+                expr.Config("lr") == 0.01,
+                expr.Config("lr") == 0.1,
+            )
+        )
+        assert isinstance(rs.filters, str)
+        assert "or" in rs.filters
+
+    def test_or_list_in_runset_settings(self):
+        import wandb_workspaces.workspaces as ws
+        from wandb_workspaces import expr
+
+        rs = ws.RunsetSettings(
+            filters=[
+                expr.Or(
+                    expr.Config("lr") == 0.01,
+                    expr.Config("lr") == 0.1,
+                )
+            ]
+        )
+        assert isinstance(rs.filters, str)
+        assert "or" in rs.filters
+
+
+class TestV2Deserialization:
+    """Test conversion from v2 flat filter format to legacy tree."""
+
+    def test_simple_v2_and(self):
+        from wandb_workspaces.expr import filters_v2_to_filters_tree
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "disabled": False, "connector": "AND"},
+            ],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        assert tree.op == "OR"
+        assert len(tree.filters) == 1
+        and_bucket = tree.filters[0]
+        assert and_bucket.op == "AND"
+        assert len(and_bucket.filters) == 2
+        assert and_bucket.filters[0].value == "finished"
+        assert and_bucket.filters[1].value == 0.01
+
+    def test_simple_v2_or(self):
+        from wandb_workspaces.expr import filters_v2_to_filters_tree
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "disabled": False, "connector": "OR"},
+            ],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+
+    def test_v2_and_then_or(self):
+        """Corresponds to: state=finished AND lr=0.01 OR lr=0.1"""
+        from wandb_workspaces.expr import filters_v2_to_filters_tree
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "disabled": False, "connector": "AND"},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.1, "disabled": False, "connector": "OR"},
+            ],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+        assert tree.filters[0].op == "AND"
+        assert len(tree.filters[0].filters) == 2
+        assert tree.filters[1].op == "AND"
+        assert tree.filters[1].filters[0].value == 0.1
+
+    def test_v2_with_group(self):
+        from wandb_workspaces.expr import filters_v2_to_filters_tree
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {
+                    "filters": [
+                        {"op": "=", "key": {"section": "run", "name": "host"}, "value": "abc", "disabled": False},
+                        {"op": "=", "key": {"section": "run", "name": "host"}, "value": "xyz", "disabled": False, "connector": "OR"},
+                    ],
+                    "disabled": False,
+                    "connector": "AND",
+                },
+            ],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        assert tree.op == "OR"
+        and_bucket = tree.filters[0]
+        assert and_bucket.op == "AND"
+        assert len(and_bucket.filters) == 2
+        assert and_bucket.filters[0].value == "finished"
+        # The nested group produces an OR node
+        nested = and_bucket.filters[1]
+        assert nested.op == "OR"
+
+    def test_v2_disabled_items_skipped(self):
+        from wandb_workspaces.expr import filters_v2_to_filters_tree
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "run", "name": ""}, "value": "", "disabled": True, "connector": "AND"},
+            ],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        and_bucket = tree.filters[0]
+        assert len(and_bucket.filters) == 1
+
+    def test_v2_empty_filters(self):
+        from wandb_workspaces.expr import filters_v2_to_filters_tree
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        assert tree.op == "OR"
+
+    def test_is_filter_v2(self):
+        from wandb_workspaces.expr import is_filter_v2
+
+        assert is_filter_v2({"filterFormat": "filterV2", "filters": []})
+        assert not is_filter_v2({"op": "OR", "filters": []})
+        assert not is_filter_v2({"filterFormat": "other"})
+        assert not is_filter_v2("not a dict")
+
+    def test_real_world_v2_payload(self):
+        """Test with the exact payload observed from the UI in the debugging session."""
+        from wandb_workspaces.expr import filters_v2_to_filters_tree, filters_to_expr
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "config", "name": "learning_rate.value"}, "value": 0.001, "disabled": False, "connector": "AND"},
+                {
+                    "filters": [
+                        {"key": {"section": "run", "name": "host"}, "op": "=", "value": "CW-JHWYNJMYJF-L", "disabled": False},
+                        {"key": {"section": "run", "name": ""}, "op": "=", "value": "", "disabled": True},
+                    ],
+                    "disabled": False,
+                },
+            ],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        assert tree.op == "OR"
+        and_bucket = tree.filters[0]
+        assert and_bucket.op == "AND"
+        assert len(and_bucket.filters) == 3
+        assert and_bucket.filters[0].value == "finished"
+        assert and_bucket.filters[1].value == 0.001
+        assert and_bucket.filters[2].value == "CW-JHWYNJMYJF-L"
+
+        expr_str = filters_to_expr(tree)
+        assert "and" in expr_str.lower()
+        assert "finished" in expr_str
+
+
+class TestV2RoundTrip:
+    """Test that Filters tree -> v2 dict -> Filters tree round-trips correctly."""
+
+    def test_simple_and_round_trip(self):
+        from wandb_workspaces.expr import (
+            Filters,
+            Key,
+            filters_tree_to_v2,
+            filters_v2_to_filters_tree,
+        )
+
+        tree = Filters(op="OR", filters=[
+            Filters(op="AND", filters=[
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
+                Filters(op="=", key=Key(section="run", name="state"), value="finished"),
+            ])
+        ])
+        v2 = filters_tree_to_v2(tree)
+        assert v2["filterFormat"] == "filterV2"
+        assert len(v2["filters"]) == 2
+        assert "connector" not in v2["filters"][0]
+        assert v2["filters"][1]["connector"] == "AND"
+
+        round_tripped = filters_v2_to_filters_tree(v2)
+        assert round_tripped.op == "OR"
+        assert len(round_tripped.filters) == 1
+        assert round_tripped.filters[0].op == "AND"
+        assert len(round_tripped.filters[0].filters) == 2
+
+    def test_or_round_trip(self):
+        from wandb_workspaces.expr import (
+            Filters,
+            Key,
+            filters_tree_to_v2,
+            filters_v2_to_filters_tree,
+        )
+
+        tree = Filters(op="OR", filters=[
+            Filters(op="AND", filters=[
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
+                Filters(op="=", key=Key(section="run", name="state"), value="finished"),
+            ]),
+            Filters(op="AND", filters=[
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.1),
+            ]),
+        ])
+        v2 = filters_tree_to_v2(tree)
+        assert v2["filterFormat"] == "filterV2"
+        assert len(v2["filters"]) == 3
+        assert "connector" not in v2["filters"][0]
+        assert v2["filters"][1]["connector"] == "AND"
+        assert v2["filters"][2]["connector"] == "OR"
+
+        round_tripped = filters_v2_to_filters_tree(v2)
+        assert round_tripped.op == "OR"
+        assert len(round_tripped.filters) == 2
+        assert round_tripped.filters[0].op == "AND"
+        assert len(round_tripped.filters[0].filters) == 2
+        assert round_tripped.filters[1].op == "AND"
+        assert round_tripped.filters[1].filters[0].value == 0.1
+
+    def test_empty_round_trip(self):
+        from wandb_workspaces.expr import (
+            Filters,
+            filters_tree_to_v2,
+        )
+
+        tree = Filters(op="OR", filters=[Filters(op="AND", filters=[])])
+        v2 = filters_tree_to_v2(tree)
+        assert v2["filterFormat"] == "filterV2"
+        assert v2["filters"] == []
+
+    def test_string_to_v2_round_trip(self):
+        """Full pipeline: string -> tree -> v2 -> tree -> string."""
+        from wandb_workspaces.expr import (
+            expr_to_filters,
+            filters_to_expr,
+            filters_tree_to_v2,
+            filters_v2_to_filters_tree,
+        )
+
+        original = "Metric('State') == 'finished' and Config('lr') == 0.01 or Config('lr') == 0.1"
+        tree1 = expr_to_filters(original)
+        v2 = filters_tree_to_v2(tree1)
+        tree2 = filters_v2_to_filters_tree(v2)
+        result = filters_to_expr(tree2)
+        tree3 = expr_to_filters(result)
+        assert len(tree3.filters) == 2
+        assert tree3.filters[0].op == "AND"
+        assert tree3.filters[1].op == "AND"
+
+    def test_v2_dict_to_tree_to_v2_preserves_structure(self):
+        """v2 dict -> tree -> v2 dict should preserve filter values and connectors."""
+        from wandb_workspaces.expr import (
+            filters_tree_to_v2,
+            filters_v2_to_filters_tree,
+        )
+
+        original_v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished"},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "connector": "AND"},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.1, "connector": "OR"},
+            ],
+        }
+        tree = filters_v2_to_filters_tree(original_v2)
+        result_v2 = filters_tree_to_v2(tree)
+
+        assert result_v2["filterFormat"] == "filterV2"
+        items = result_v2["filters"]
+        assert len(items) == 3
+        assert items[0]["value"] == "finished"
+        assert "connector" not in items[0]
+        assert items[1]["value"] == 0.01
+        assert items[1]["connector"] == "AND"
+        assert items[2]["value"] == 0.1
+        assert items[2]["connector"] == "OR"
+
+    def test_nested_group_round_trip(self):
+        """v2 with nested group -> tree -> v2 should preserve the group."""
+        from wandb_workspaces.expr import (
+            filters_tree_to_v2,
+            filters_v2_to_filters_tree,
+        )
+
+        original_v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished"},
+                {
+                    "connector": "AND",
+                    "filters": [
+                        {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01},
+                        {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.1, "connector": "OR"},
+                    ],
+                },
+            ],
+        }
+        tree = filters_v2_to_filters_tree(original_v2)
+        result_v2 = filters_tree_to_v2(tree)
+
+        assert result_v2["filterFormat"] == "filterV2"
+        items = result_v2["filters"]
+        assert items[0]["value"] == "finished"
+        has_group = any("filters" in item for item in items)
+        assert has_group, "Nested group should be preserved in round-trip"

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -70,6 +70,10 @@ __all__ = [
     "Ordering",
     # Filter expression type (needed for type hints)
     "FilterExpr",
+    # Combinators for OR / nested filter groups
+    "Or",
+    "And",
+    "Group",
 ]
 
 Expression = Dict[str, Any]
@@ -338,41 +342,61 @@ def _preprocess_comparison_operators(expr: str) -> str:
     return expr
 
 
+def _normalize_to_or_and_tree(root: Filters) -> Filters:
+    """Wrap a parsed Filters node into the canonical OR -> AND -> leaves tree.
+
+    The backend expects the root to be an OR node whose children are AND
+    buckets.  This function normalises any shape produced by the AST parser
+    into that form.
+    """
+    if root.op == "OR" and root.filters:
+        buckets = []
+        for child in root.filters:
+            if child.op == "AND" and child.filters is not None:
+                buckets.append(child)
+            elif child.op in ("=", "!=", "<=", ">=", "<", ">", "IN", "NIN",
+                              "==", "WITHINSECONDS"):
+                buckets.append(Filters(op="AND", filters=[child]))
+            elif child.op == "OR" and child.filters:
+                for grandchild in child.filters:
+                    if grandchild.op == "AND" and grandchild.filters is not None:
+                        buckets.append(grandchild)
+                    else:
+                        buckets.append(Filters(op="AND", filters=[grandchild]))
+            else:
+                buckets.append(Filters(op="AND", filters=[child]))
+        return Filters(op="OR", filters=buckets)
+
+    if root.op == "AND" and root.filters is not None:
+        return Filters(op="OR", filters=[root])
+
+    return Filters(op="OR", filters=[Filters(op="AND", filters=[root])])
+
+
 def expr_to_filters(expr: str) -> Filters:
     """Parse a string filter expression into an internal Filters tree.
 
+    Supports ``and``, ``or``, and parenthesised groups.
+
     Args:
         expr: A Python-like filter expression string, e.g.,
-            "Config('learning_rate') == 0.001 and State == 'finished'"
-            or "Metric('CreatedTimestamp') within_last 5 days"
+            ``"Config('learning_rate') == 0.001 and Metric('State') == 'finished'"``
+            or ``"Metric('State') == 'finished' or Config('lr') == 0.01"``
 
     Returns:
-        An internal Filters tree structure
+        An internal Filters tree in canonical OR -> AND -> leaves form.
     """
     if not expr:
-        filters = []
-    else:
-        # Preprocess: Convert within_last operator syntax to function syntax
-        # This must happen first, before other transformations
-        expr = _preprocess_within_last_syntax(expr)
+        return Filters(op="OR", filters=[Filters(op="AND", filters=[])])
 
-        # Preprocess: Replace single '=' with '==' for Python AST parsing
-        # But avoid replacing '==', '!=', '<=', '>='
-        expr = _preprocess_equality_operators(expr)
+    expr = _preprocess_within_last_syntax(expr)
+    expr = _preprocess_equality_operators(expr)
+    expr = _preprocess_comparison_operators(expr)
 
-        # Preprocess: Replace '<' with '<=' and '>' with '>=' for consistency
-        expr = _preprocess_comparison_operators(expr)
+    parsed_expr = ast.parse(expr, mode="eval")
+    root_filter = _parse_node(parsed_expr.body)
 
-        parsed_expr = ast.parse(expr, mode="eval")
-        root_filter = _parse_node(parsed_expr.body)
-
-        # If the root operation is an AND, unpack its child filters
-        if root_filter.op == "AND" and root_filter.filters:
-            filters = root_filter.filters
-        else:
-            filters = [root_filter]
-
-    return Filters(op="OR", filters=[Filters(op="AND", filters=filters)])
+    return _normalize_to_or_and_tree(root_filter)
 
 
 def _parse_node(node) -> Filters:
@@ -712,6 +736,213 @@ def filters_to_expr(filter_obj: Any, is_root=True) -> str:
             return f"{key_name} {op_map[filter.op]} {value}"
 
     return _convert_filter(filter_obj, is_root)
+
+
+# ---------------------------------------------------------------------------
+# FilterV2 (flat format) → Filters tree conversion
+# ---------------------------------------------------------------------------
+
+FILTER_FORMAT_V2 = "filterV2"
+
+
+def is_filter_v2(data: Any) -> bool:
+    """Check if a dict/object uses the v2 flat filter format."""
+    if isinstance(data, dict):
+        return data.get("filterFormat") == FILTER_FORMAT_V2
+    return False
+
+
+def _is_v2_group(item: dict) -> bool:
+    """A v2 group has a 'filters' list but no 'op' at the item level (or no key)."""
+    return "filters" in item and isinstance(item["filters"], list)
+
+
+def _is_valid_v2_leaf(item: dict) -> bool:
+    """A leaf item has a key with a non-empty name and is not disabled."""
+    if item.get("disabled", False):
+        return False
+    key = item.get("key")
+    if not key:
+        return False
+    return bool(key.get("name"))
+
+
+def _v2_leaf_to_filters(item: dict) -> Filters:
+    """Convert a single v2 leaf item to a Filters node."""
+    return Filters(
+        op=item.get("op", "="),
+        key=Key(section=item["key"]["section"], name=item["key"]["name"]),
+        value=item.get("value"),
+        disabled=item.get("disabled"),
+    )
+
+
+def _split_on_or(items: list) -> list:
+    """Split a flat v2 filter list into segments at OR boundaries.
+
+    Items with connector='OR' start a new segment. Items with connector='AND'
+    or no connector stay in the current segment. The first item never has a
+    connector.
+    """
+    if not items:
+        return []
+    segments = []
+    current = []
+    for item in items:
+        connector = item.get("connector")
+        if connector == "OR" and current:
+            segments.append(current)
+            current = []
+        current.append(item)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _segment_to_node(segment: list) -> Optional[Filters]:
+    """Convert one AND-connected segment into a Filters tree node."""
+    if not segment:
+        return None
+
+    children = []
+    for item in segment:
+        if _is_v2_group(item):
+            if item.get("disabled", False):
+                continue
+            node = _derive_tree_from_v2(item)
+            if node:
+                children.append(node)
+        elif _is_valid_v2_leaf(item):
+            children.append(_v2_leaf_to_filters(item))
+
+    if not children:
+        return None
+    if len(children) == 1:
+        return children[0]
+    return Filters(op="AND", filters=children)
+
+
+def _derive_tree_from_v2(node: dict) -> Optional[Filters]:
+    """Derive a Filters tree from a v2 node (root or group).
+
+    Mirrors the frontend's deriveTree algorithm:
+    1. Split the flat list on OR boundaries
+    2. Treat each segment as AND-connected
+    3. Recursively derive trees for nested groups
+    4. If more than one segment, combine with OR
+    """
+    items = node.get("filters", [])
+    if not items:
+        return None
+
+    segments = _split_on_or(items)
+    segment_nodes = []
+
+    for segment in segments:
+        tree_node = _segment_to_node(segment)
+        if tree_node is not None:
+            segment_nodes.append(tree_node)
+
+    if not segment_nodes:
+        return None
+    if len(segment_nodes) == 1:
+        return segment_nodes[0]
+    return Filters(op="OR", filters=segment_nodes)
+
+
+def filters_v2_to_filters_tree(data: dict) -> Filters:
+    """Convert a v2 filterFormat dict to a legacy Filters tree.
+
+    Args:
+        data: A dict with filterFormat='filterV2' and a flat filters list,
+            as stored in the view spec by the frontend v2 filter UI.
+
+    Returns:
+        A Filters tree in the canonical OR -> AND -> leaves structure.
+    """
+    tree = _derive_tree_from_v2(data)
+    if tree is None:
+        return Filters(op="OR", filters=[Filters(op="AND")])
+
+    return _normalize_to_or_and_tree(tree)
+
+
+def _leaf_to_v2_item(leaf: Filters) -> Optional[dict]:
+    """Convert a single Filters leaf node to a v2 flat item dict."""
+    if leaf.key is None or not leaf.key.name:
+        return None
+    item: dict = {
+        "key": {"section": leaf.key.section, "name": leaf.key.name},
+        "op": leaf.op,
+        "value": leaf.value,
+    }
+    if leaf.disabled is not None:
+        item["disabled"] = leaf.disabled
+    return item
+
+
+def _tree_node_to_v2_items(node: Filters, is_first_in_parent: bool) -> list:
+    """Recursively convert a Filters tree node into a flat list of v2 items.
+
+    Handles OR nodes (emit connector='OR' between segments), AND nodes
+    (emit connector='AND' between items), and nested sub-trees (emitted
+    as FilterV2Group objects).
+    """
+    if node.key is not None:
+        item = _leaf_to_v2_item(node)
+        return [item] if item else []
+
+    if node.filters is None:
+        return []
+
+    if node.op == "OR":
+        items: list = []
+        for i, child in enumerate(node.filters):
+            child_items = _tree_node_to_v2_items(child, is_first_in_parent=(i == 0 and is_first_in_parent))
+            if child_items and i > 0:
+                child_items[0]["connector"] = "OR"
+            items.extend(child_items)
+        return items
+
+    if node.op == "AND":
+        items = []
+        for j, child in enumerate(node.filters):
+            is_first = (j == 0) and is_first_in_parent
+            if child.key is not None:
+                child_item = _leaf_to_v2_item(child)
+                if child_item is None:
+                    continue
+                if not is_first:
+                    child_item["connector"] = "AND"
+                items.append(child_item)
+            else:
+                sub_items = _tree_node_to_v2_items(child, is_first_in_parent=True)
+                if not sub_items:
+                    continue
+                group: dict = {"filters": sub_items}
+                if not is_first:
+                    group["connector"] = "AND"
+                items.append(group)
+        return items
+
+    item = _leaf_to_v2_item(node)
+    return [item] if item else []
+
+
+def filters_tree_to_v2(tree: Filters) -> dict:
+    """Convert a Filters tree to the v2 flat filter format.
+
+    This is the inverse of ``filters_v2_to_filters_tree``.  The returned
+    dict is suitable for storing in the view spec as ``filterFormat: "filterV2"``.
+
+    Args:
+        tree: A Filters tree (typically in canonical OR -> AND -> leaves form).
+
+    Returns:
+        A dict with ``filterFormat`` and a flat ``filters`` list.
+    """
+    items = _tree_node_to_v2_items(tree, is_first_in_parent=True)
+    return {"filterFormat": FILTER_FORMAT_V2, "filters": items}
 
 
 def _key_to_server_path(key: Key):
@@ -1083,6 +1314,112 @@ class FilterExpr:
         )
 
 
+FilterItem = Union["FilterExpr", "And", "Or", "Group"]
+
+
+@dataclass(frozen=True)
+class And:
+    """Combine multiple filter items with AND logic.
+
+    Example:
+        >>> And(ws.Config("lr") == 0.01, ws.Metric("State") == "finished")
+    """
+
+    items: tuple
+
+    def __init__(self, *items: FilterItem):
+        object.__setattr__(self, "items", items)
+
+    def __repr__(self) -> str:
+        return f"And({', '.join(repr(i) for i in self.items)})"
+
+    def to_model(self) -> Filters:
+        """Convert to an AND Filters node."""
+        children = []
+        for item in self.items:
+            children.append(item.to_model())
+        return Filters(op="AND", filters=children)
+
+
+@dataclass(frozen=True)
+class Or:
+    """Combine multiple filter items with OR logic.
+
+    Each argument becomes a separate OR branch.  Arguments that are plain
+    ``FilterExpr`` or ``And`` groups are treated as individual AND buckets.
+
+    Example:
+        >>> Or(
+        ...     And(ws.Config("lr") == 0.01, ws.Metric("State") == "finished"),
+        ...     ws.Config("lr") == 0.1,
+        ... )
+    """
+
+    items: tuple
+
+    def __init__(self, *items: FilterItem):
+        object.__setattr__(self, "items", items)
+
+    def __repr__(self) -> str:
+        return f"Or({', '.join(repr(i) for i in self.items)})"
+
+    def to_model(self) -> Filters:
+        """Convert to the canonical OR -> AND -> leaves tree."""
+        buckets = []
+        for item in self.items:
+            node = item.to_model()
+            if node.op == "AND" and node.filters is not None:
+                buckets.append(node)
+            elif node.op == "OR" and node.filters is not None:
+                buckets.extend(node.filters)
+            else:
+                buckets.append(Filters(op="AND", filters=[node]))
+        return Filters(op="OR", filters=buckets)
+
+
+@dataclass(frozen=True)
+class Group:
+    """A parenthesised group of filters, preserving precedence.
+
+    Example:
+        >>> Or(
+        ...     Group(Or(ws.Config("lr") == 0.01, ws.Config("lr") == 0.1)),
+        ...     ws.Metric("State") == "finished",
+        ... )
+    """
+
+    inner: FilterItem
+
+    def __repr__(self) -> str:
+        return f"Group({self.inner!r})"
+
+    def to_model(self) -> Filters:
+        """Delegate to inner item's model."""
+        return self.inner.to_model()
+
+
+def _filter_items_to_filters_tree(items) -> Filters:
+    """Convert a list of FilterExpr / And / Or / Group items to a Filters tree.
+
+    Items in the list are AND'd together.  For OR logic, wrap with ``Or()``.
+    """
+    if not items:
+        return Filters(op="OR", filters=[Filters(op="AND", filters=[])])
+
+    if len(items) == 1:
+        item = items[0]
+        if isinstance(item, Or):
+            return item.to_model()
+        node = item.to_model()
+        return _normalize_to_or_and_tree(node)
+
+    and_children = []
+    for item in items:
+        and_children.append(item.to_model())
+    and_node = Filters(op="AND", filters=and_children)
+    return Filters(op="OR", filters=[and_node])
+
+
 def filters_tree_to_filter_expr(tree: Filters) -> List[FilterExpr]:
     def parse_filter(filter: Filters) -> Optional[FilterExpr]:
         if filter.key is None:
@@ -1104,7 +1441,16 @@ def filters_tree_to_filter_expr(tree: Filters) -> List[FilterExpr]:
     return parse_expression(tree)
 
 
-def filter_expr_to_filters_tree(filters: List[FilterExpr]) -> Filters:
+def filter_expr_to_filters_tree(filters) -> Filters:
+    """Convert a list of filter items to a Filters tree.
+
+    Accepts ``List[FilterExpr]`` (legacy AND-only) as well as lists containing
+    ``Or``, ``And``, and ``Group`` combinators.
+    """
+    has_combinators = any(isinstance(f, (Or, And, Group)) for f in filters)
+    if has_combinators:
+        return _filter_items_to_filters_tree(filters)
+
     def parse_key(metric: BaseMetric) -> Key:
         section = metric.section
         name = _convert_fe_to_be_metric_name(metric.name)
@@ -1183,25 +1529,22 @@ def filterexpr_list_to_string(filters: List[FilterExpr]) -> str:
 def normalize_filters_to_string(instance):
     """Shared model validator that normalizes filters to string format.
 
-    Converts List[FilterExpr] → str while preserving string inputs.
-    This creates a unified internal representation across Workspaces and Reports.
+    Converts ``List[FilterExpr]`` (and lists containing ``Or``/``And``/``Group``)
+    to a string expression.  Preserves string inputs as-is.
 
     Args:
         instance: The model instance with a 'filters' attribute
 
     Returns:
         The instance with normalized filters
-
-    Usage:
-        @model_validator(mode="after")
-        def convert_filterexpr_list_to_string(self):
-            return normalize_filters_to_string(self)
     """
     if isinstance(instance.filters, list):
-        # Convert FilterExpr list to string
-        # This unifies internal representation as string
-        filter_string = filterexpr_list_to_string(instance.filters)
-        # Update the filters field
+        filters_tree = filter_expr_to_filters_tree(instance.filters)
+        filter_string = filters_to_expr(filters_tree)
+        object.__setattr__(instance, "filters", filter_string)
+    elif isinstance(instance.filters, (Or, And, Group)):
+        filters_tree = instance.filters.to_model()
+        filter_string = filters_to_expr(filters_tree)
         object.__setattr__(instance, "filters", filter_string)
     return instance
 

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -324,10 +324,12 @@ class RunsetSettings(Base):
     Attributes:
         query (str): A query to filter the runset (can be a regex expr, see next param).
         regex_query (bool): Controls whether the query (above) is a regex expr. Default is set to `False`.
-        filters (Union[str, LList[expr.FilterExpr]]): A list of filters to apply to the runset or a string expression.
-            - As a list: Filters are AND'd together. See FilterExpr for more information on creating filters.
-            - As a string: Use Python-like expressions, e.g., "Config('lr') = 0.001 and State = 'finished'"
-              Supports operators: =, ==, !=, <, >, <=, >=, in, not in
+        filters (Union[str, LList[FilterExpr], Or, And, Group]): Filters for the runset.
+            - As a list of FilterExpr: filters are AND'd together.
+            - As a string: Python-like expressions, e.g., "Config('lr') = 0.001 and State = 'finished'"
+              Supports operators: =, ==, !=, <, >, <=, >=, in, not in, and, or
+            - As an Or/And/Group combinator: allows OR logic and nested groups.
+              e.g., Or(And(Config("lr") == 0.01, Metric("State") == "finished"), Config("lr") == 0.1)
         groupby (LList[expr.MetricType]): A list of metrics to group by in the runset. Set to
             `Metric`, `Summary`, `Config`, `Tags`, or `KeysInfo`.
         order (LList[expr.Ordering]): A list of metrics and ordering to apply to the runset.
@@ -356,7 +358,7 @@ class RunsetSettings(Base):
 
     query: str = ""
     regex_query: bool = False
-    filters: Union[str, LList[expr.FilterExpr]] = ""
+    filters: Union[str, LList[expr.FilterExpr], expr.Or, expr.And, expr.Group] = ""
     groupby: LList[expr.MetricType] = Field(default_factory=list)
     "A list of metrics to group by in the runset."
 
@@ -407,17 +409,8 @@ class RunsetSettings(Base):
 
     @model_validator(mode="after")
     def convert_filterexpr_list_to_string(self):
-        """Convert FilterExpr list to string expression (unified internal format)."""
-        # Inline the normalization logic to avoid circular import with expr module
-        if isinstance(self.filters, list):
-            # Import locally to avoid circular import at module level
-            # Convert FilterExpr list to internal Filters tree
-            filters_tree = expr.filter_expr_to_filters_tree(self.filters)
-            # Convert Filters tree to string expression
-            filter_string = expr.filters_to_expr(filters_tree)
-            # Update the filters field
-            object.__setattr__(self, "filters", filter_string)
-        return self
+        """Convert FilterExpr list / Or / And / Group to string (unified internal format)."""
+        return expr.normalize_filters_to_string(self)
 
 
 @dataclass(config=dataclass_config, repr=False)
@@ -674,7 +667,7 @@ class Workspace(Base):
                                 is_regex=is_regex,
                             ),
                             filters=expr.expr_to_filters(
-                                self.runset_settings.filters  # type: ignore[arg-type]  # validator ensures this is always str
+                                self.runset_settings.filters  # type: ignore[arg-type]
                             ),
                             grouping=[g.to_key() for g in self.runset_settings.groupby],
                             sort=internal.Sort(

--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -10,6 +10,11 @@ from wandb_gql import gql
 
 # these internal objects should be factored out into a separate module as a
 # shared dependency between Workspaces and Reports API
+from wandb_workspaces.expr import (
+    filters_tree_to_v2,
+    filters_v2_to_filters_tree,
+    is_filter_v2,
+)
 from wandb_workspaces.reports.v2.internal import *  # noqa: F403
 from wandb_workspaces.reports.v2.internal import (
     PanelBankConfig,
@@ -23,6 +28,35 @@ from wandb_workspaces.utils.validators import validate_spec_version
 
 CLIENT_SPEC_VERSION = -1
 SPEC_VERSION_KEY = "version"
+
+_v2_runset_ids: set = set()
+
+
+def _filters_dict_needs_v2(node: dict) -> bool:
+    """Check if a serialized Filters tree dict uses features that require v2.
+
+    The canonical legacy tree is OR -> AND -> leaves (depth 2).  This returns
+    True when the tree goes beyond that: multiple OR branches, or any leaf
+    position occupied by a non-leaf node (a nested group).
+    """
+    if not isinstance(node, dict):
+        return False
+    children = node.get("filters")
+    if not children:
+        return False
+    op = node.get("op", "")
+    if op == "OR" and len(children) > 1:
+        return True
+    for and_branch in children:
+        if not isinstance(and_branch, dict):
+            continue
+        leaves = and_branch.get("filters")
+        if not leaves:
+            continue
+        for leaf in leaves:
+            if isinstance(leaf, dict) and leaf.get("filters") is not None:
+                return True
+    return False
 
 
 class WorkspaceAPIBaseModel(BaseModel):
@@ -86,6 +120,29 @@ class WorkspaceViewspec(WorkspaceAPIBaseModel):
     library_expanded: bool = True
 
 
+def _migrate_v2_filters_in_spec(spec_dict: dict) -> dict:
+    """Pre-process a spec dict, converting any v2-format filters to the legacy tree.
+
+    The frontend v2 filter UI stores filters as a flat list with inline
+    connector fields.  Pydantic can't parse that into the legacy Filters
+    model correctly, so we convert before validation.
+
+    Runset IDs whose filters were originally v2 are tracked in the module-level
+    ``_v2_runset_ids`` set so that ``upsert_view2`` can write them back in v2
+    format.
+    """
+    run_sets = spec_dict.get("section", {}).get("runSets", [])
+    for rs in run_sets:
+        filters_data = rs.get("filters")
+        if filters_data and is_filter_v2(filters_data):
+            tree = filters_v2_to_filters_tree(filters_data)
+            rs["filters"] = tree.model_dump(by_alias=True, exclude_none=True)
+            rs_id = rs.get("id")
+            if rs_id:
+                _v2_runset_ids.add(rs_id)
+    return spec_dict
+
+
 class View(WorkspaceAPIBaseModel):
     entity: str
     project: str
@@ -106,7 +163,10 @@ class View(WorkspaceAPIBaseModel):
         spec = view_dict["spec"]
         display_name = view_dict["displayName"]
         id = view_dict["id"]
-        parsed_spec = WorkspaceViewspec.model_validate_json(spec)
+
+        spec_dict = json.loads(spec) if isinstance(spec, str) else spec
+        spec_dict = _migrate_v2_filters_in_spec(spec_dict)
+        parsed_spec = WorkspaceViewspec.model_validate(spec_dict)
 
         return cls(
             entity=entity,
@@ -136,7 +196,21 @@ def upsert_view2(view: View) -> Dict[str, Any]:
     )
 
     api = wandb.Api()
-    spec_str = view.spec.model_dump_json(by_alias=True, exclude_none=True)
+
+    spec_dict = view.spec.model_dump(by_alias=True, exclude_none=True)
+
+    for rs in spec_dict.get("section", {}).get("runSets", []):
+        rs_id = rs.get("id")
+        was_v2 = rs_id and rs_id in _v2_runset_ids
+        needs_v2 = _filters_dict_needs_v2(rs.get("filters", {}))
+
+        if was_v2 or needs_v2:
+            from wandb_workspaces.expr import Filters
+
+            tree = Filters.model_validate(rs["filters"])
+            rs["filters"] = filters_tree_to_v2(tree)
+
+    spec_str = json.dumps(spec_dict)
 
     # Default: assume a new view being created, so no `id` yet
     variables = {


### PR DESCRIPTION
- Add v2 filter deserialization (filters_v2_to_filters_tree) to correctly read workspaces saved with the frontend v2 filter UI
- Add v2 filter serialization (filters_tree_to_v2) to write back v2 format when the workspace was originally v2 or when OR/groups are used
- Add OR support in string filter expressions ("A and B or C")
- Add Or, And, Group classes for programmatic OR filter composition
- Update RunsetSettings to accept Or/And/Group types
- Write v2 format automatically when filters contain OR or nested groups; write legacy format for plain AND-only filters
- Add comprehensive tests for v2 round-trip, OR parsing, and object API

Made-with: Cursor

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
Please use conventional commits in your PR title. If you are unsure what conventional commits are or how to use them, please check out [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits).

JIRA/GH Issues(s)
-----------
Paste links to relevant JIRA/GH issues here, one per line e.g.
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
_What does this PR do? Write a short paragraph to contextualize and explain your change._

Testing
-------
How was this PR tested?

- [ ] _Added unit tests_
- [ ] _Manual testing (include description)_
- [ ] _N/A (include explanation)_

