### PR TITLE
fix: support reading and round-tripping v2 filter format

### DIFF
--- a/tests/filter_test_helpers.py
+++ b/tests/filter_test_helpers.py
@@ -65,20 +65,19 @@ def verify_operator_mapping_string_filters(container_factory: Callable):
     container1 = container_factory(filters='Metric("loss") < 1.0')
     with pytest.warns(UserWarning, match="'<' operator.*mapped to '<='"):
         parsed1 = expr_to_filters(container1.filters)
-    assert parsed1.filters[0].filters[0].op == "<="
+    assert parsed1.op == "<="
 
     # Test > operator (should map to >= with warning during parsing)
     container2 = container_factory(filters='Metric("accuracy") > 0.9')
     with pytest.warns(UserWarning, match="'>' operator.*mapped to '>='"):
         parsed2 = expr_to_filters(container2.filters)
-    assert parsed2.filters[0].filters[0].op == ">="
+    assert parsed2.op == ">="
 
     # Test <= and >= operators (should NOT trigger warnings)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         container3 = container_factory(filters='Metric("loss") <= 1.0')
         parsed3 = expr_to_filters(container3.filters)
-        # Filter for warnings that contain both "operator" and "mapped to"
         relevant_warnings = [
             warning
             for warning in w
@@ -86,7 +85,7 @@ def verify_operator_mapping_string_filters(container_factory: Callable):
             and "mapped to" in str(warning.message).lower()
         ]
         assert len(relevant_warnings) == 0
-        assert parsed3.filters[0].filters[0].op == "<="
+        assert parsed3.op == "<="
 
 
 def verify_operator_mapping_filterexpr(container_factory: Callable):
@@ -340,9 +339,12 @@ def test_expression_parsing():
 
     for expr_str, expected_filters in test_cases:
         result = expr_to_filters(expr_str)
-        expected = Filters(
-            op="OR", filters=[Filters(op="AND", filters=expected_filters)]
-        )
+        if not expected_filters:
+            expected = Filters(op="AND", filters=[])
+        elif len(expected_filters) == 1:
+            expected = expected_filters[0]
+        else:
+            expected = Filters(op="AND", filters=expected_filters)
         assert result == expected, f"Failed for expression: {expr_str}"
 
 
@@ -423,24 +425,24 @@ def verify_within_last_string_filters(container_factory: Callable):
         filters="WithinLast(Metric('CreatedTimestamp'), 5, 'days')"
     )
     parsed1 = expr_to_filters(container1.filters)
-    assert parsed1.filters[0].filters[0].op == "WITHINSECONDS"
-    assert parsed1.filters[0].filters[0].value == 432000  # 5 days in seconds
+    assert parsed1.op == "WITHINSECONDS"
+    assert parsed1.value == 432000  # 5 days in seconds
 
     # Test WithinLast with hours
     container2 = container_factory(
         filters="WithinLast(Metric('CreatedTimestamp'), 2, 'hours')"
     )
     parsed2 = expr_to_filters(container2.filters)
-    assert parsed2.filters[0].filters[0].op == "WITHINSECONDS"
-    assert parsed2.filters[0].filters[0].value == 7200  # 2 hours in seconds
+    assert parsed2.op == "WITHINSECONDS"
+    assert parsed2.value == 7200  # 2 hours in seconds
 
     # Test WithinLast with minutes
     container3 = container_factory(
         filters="WithinLast(Metric('CreatedTimestamp'), 30, 'minutes')"
     )
     parsed3 = expr_to_filters(container3.filters)
-    assert parsed3.filters[0].filters[0].op == "WITHINSECONDS"
-    assert parsed3.filters[0].filters[0].value == 1800  # 30 minutes in seconds
+    assert parsed3.op == "WITHINSECONDS"
+    assert parsed3.value == 1800  # 30 minutes in seconds
 
 
 def verify_within_last_operator_syntax(container_factory: Callable):
@@ -452,41 +454,42 @@ def verify_within_last_operator_syntax(container_factory: Callable):
         filters="Metric('CreatedTimestamp') within_last 5 days"
     )
     parsed1 = expr_to_filters(container1.filters)
-    assert parsed1.filters[0].filters[0].op == "WITHINSECONDS"
-    assert parsed1.filters[0].filters[0].value == 432000  # 5 days in seconds
+    assert parsed1.op == "WITHINSECONDS"
+    assert parsed1.value == 432000  # 5 days in seconds
 
     # Test with hours
     container2 = container_factory(
         filters="Metric('CreatedTimestamp') within_last 2 hours"
     )
     parsed2 = expr_to_filters(container2.filters)
-    assert parsed2.filters[0].filters[0].op == "WITHINSECONDS"
-    assert parsed2.filters[0].filters[0].value == 7200  # 2 hours in seconds
+    assert parsed2.op == "WITHINSECONDS"
+    assert parsed2.value == 7200  # 2 hours in seconds
 
     # Test with minutes
     container3 = container_factory(
         filters="Metric('CreatedTimestamp') within_last 30 minutes"
     )
     parsed3 = expr_to_filters(container3.filters)
-    assert parsed3.filters[0].filters[0].op == "WITHINSECONDS"
-    assert parsed3.filters[0].filters[0].value == 1800  # 30 minutes in seconds
+    assert parsed3.op == "WITHINSECONDS"
+    assert parsed3.value == 1800  # 30 minutes in seconds
 
     # Test combined with other filters
     container4 = container_factory(
         filters="Metric('CreatedTimestamp') within_last 7 days and State == 'finished'"
     )
     parsed4 = expr_to_filters(container4.filters)
-    assert len(parsed4.filters[0].filters) == 2
-    assert parsed4.filters[0].filters[0].op == "WITHINSECONDS"
-    assert parsed4.filters[0].filters[1].op == "="
+    assert parsed4.op == "AND"
+    assert len(parsed4.filters) == 2
+    assert parsed4.filters[0].op == "WITHINSECONDS"
+    assert parsed4.filters[1].op == "="
 
     # Test with singular unit names
     container5 = container_factory(
         filters="Metric('CreatedTimestamp') within_last 1 day"
     )
     parsed5 = expr_to_filters(container5.filters)
-    assert parsed5.filters[0].filters[0].op == "WITHINSECONDS"
-    assert parsed5.filters[0].filters[0].value == 86400  # 1 day in seconds
+    assert parsed5.op == "WITHINSECONDS"
+    assert parsed5.value == 86400  # 1 day in seconds
 
 
 def test_within_last_time_conversion():
@@ -580,7 +583,7 @@ def test_within_last_validation():
 
     # Should work
     valid = expr_to_filters("Metric('CreatedTimestamp') within_last 5 days")
-    assert valid.filters[0].filters[0].op == "WITHINSECONDS"
+    assert valid.op == "WITHINSECONDS"
 
     # Should fail
     with pytest.raises(ValueError, match="only available for CreatedTimestamp"):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -235,8 +235,11 @@ def test_user_constructed_runset_parses_from_string():
     assert rs._filters_internal is None
 
     model = rs._to_model()
-    assert model.filters.value == "alice"
-    assert model.filters.disabled is False
+    # _to_model wraps in canonical OR → AND → leaves for legacy backend
+    assert model.filters.op == "OR"
+    leaf = model.filters.filters[0].filters[0]
+    assert leaf.value == "alice"
+    assert leaf.disabled is False
 
 
 def test_modifying_filters_after_load_uses_new_value():
@@ -266,8 +269,10 @@ def test_modifying_filters_after_load_uses_new_value():
     iface.filters = "Metric('User') == 'bob'"
 
     model = iface._to_model()
-    assert model.filters.value == "bob", "New filter value should take effect"
-    assert model.filters.disabled is False, "New filter should be active"
+    # _to_model wraps in canonical OR → AND → leaves for legacy backend
+    leaf = model.filters.filters[0].filters[0]
+    assert leaf.value == "bob", "New filter value should take effect"
+    assert leaf.disabled is False, "New filter should be active"
 
 
 # ===== OR filter and v2 deserialization tests =====
@@ -871,7 +876,7 @@ class TestWorkspaceWriteBack:
         assert any(f.get("value") == 0.01 for f in filters_out["filters"])
 
     def test_legacy_workspace_writes_legacy_tree(self):
-        """A workspace without v2 filters writes a legacy Filters tree."""
+        """A workspace without v2 filters writes a canonical OR → AND → leaves tree."""
         from wandb_workspaces.workspaces.interface import RunsetSettings, Workspace
         from wandb_workspaces import expr
 
@@ -886,4 +891,8 @@ class TestWorkspaceWriteBack:
         model = ws._to_model()
         filters_out = model.spec.section.run_sets[0].filters
         assert isinstance(filters_out, expr.Filters)
+        assert filters_out.op == "OR"
+        assert len(filters_out.filters) == 1
+        assert filters_out.filters[0].op == "AND"
+        assert len(filters_out.filters[0].filters) == 2
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -319,48 +319,6 @@ class TestOrStringFilters:
         assert len(tree.filters) == 2
 
 
-class TestOrObjectAPI:
-    """Test OR support via the Or/And/Group object API."""
-
-    def test_or_filterexpr(self):
-        from wandb_workspaces import expr
-
-        f = expr.Or(
-            expr.Config("lr") == 0.01,
-            expr.Config("lr") == 0.1,
-        )
-        tree = f.to_model()
-        assert tree.op == "OR"
-        assert len(tree.filters) == 2
-
-    def test_and_filterexpr(self):
-        from wandb_workspaces import expr
-
-        f = expr.And(
-            expr.Config("lr") == 0.01,
-            expr.Metric("State") == "finished",
-        )
-        tree = f.to_model()
-        assert tree.op == "AND"
-        assert len(tree.filters) == 2
-
-    def test_or_with_and_groups(self):
-        from wandb_workspaces import expr
-
-        f = expr.Or(
-            expr.And(expr.Config("lr") == 0.01, expr.Metric("State") == "finished"),
-            expr.Config("lr") == 0.1,
-        )
-        tree = f.to_model()
-        assert tree.op == "OR"
-        assert len(tree.filters) == 2
-        assert tree.filters[0].op == "AND"
-        assert len(tree.filters[0].filters) == 2
-        assert tree.filters[1].op == "AND"
-        assert len(tree.filters[1].filters) == 1
-
-
-
 class TestV2ToString:
     """Test conversion from v2 flat filter format to display string."""
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -662,8 +662,8 @@ class TestV2DirectFilterRoundTrip:
         assert filters.op == "OR"
 
 
-class TestAlwaysWriteV2:
-    """Test tree-to-v2 conversion and Or/And/Group in RunsetSettings."""
+class TestTreeToV2Conversion:
+    """Test Filters tree to v2 flat format conversion."""
 
     def test_and_only_tree_converts_to_v2(self):
         from wandb_workspaces.expr import Filters, Key, filters_tree_to_v2
@@ -694,4 +694,38 @@ class TestAlwaysWriteV2:
         assert len(v2["filters"]) == 2
         assert "connector" not in v2["filters"][0]
         assert v2["filters"][1]["connector"] == "OR"
+
+    def test_group_tree_converts_to_v2(self):
+        """a or (b and c) — the AND subtree becomes a v2 group.
+
+        Expected v2:
+        {"filterFormat": "filterV2", "filters": [
+            {"key": ..., "op": "=", "value": "a"},
+            {"connector": "OR", "filters": [
+                {"key": ..., "op": "=", "value": "b"},
+                {"key": ..., "op": "=", "value": "finished", "connector": "AND"},
+            ]},
+        ]}
+        """
+        from wandb_workspaces.expr import Filters, Key, filters_tree_to_v2
+
+        tree = Filters(op="OR", filters=[
+            Filters(op="=", key=Key(section="run", name="displayName"), value="a"),
+            Filters(op="AND", filters=[
+                Filters(op="=", key=Key(section="run", name="displayName"), value="b"),
+                Filters(op="=", key=Key(section="run", name="state"), value="finished"),
+            ]),
+        ])
+        v2 = filters_tree_to_v2(tree)
+        assert v2["filterFormat"] == "filterV2"
+        assert len(v2["filters"]) == 2
+        assert v2["filters"][0]["value"] == "a"
+        assert "connector" not in v2["filters"][0]
+        group = v2["filters"][1]
+        assert group["connector"] == "OR"
+        assert "filters" in group
+        assert len(group["filters"]) == 2
+        assert group["filters"][0]["value"] == "b"
+        assert group["filters"][1]["value"] == "finished"
+        assert group["filters"][1]["connector"] == "AND"
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -277,6 +277,12 @@ class TestOrStringFilters:
     """Test OR support via string filter expressions."""
 
     def test_simple_or(self):
+        """Expected tree:
+        Filters(op="OR", filters=[
+            Filters(op="=", key=Key(section="run", name="state"), value="finished"),
+            Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
+        ])
+        """
         from wandb_workspaces import expr
 
         tree = expr.expr_to_filters(
@@ -287,7 +293,18 @@ class TestOrStringFilters:
         assert tree.filters[0].value == "finished"
         assert tree.filters[1].value == 0.01
 
-    def test_and_or_precedence(self):
+    def test_mixed_and_or(self):
+        """AND binds tighter than OR via Python's ast.parse.
+
+        Expected tree:
+        Filters(op="OR", filters=[
+            Filters(op="AND", filters=[
+                Filters(op="=", key=Key(section="run", name="state"), value="finished"),
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
+            ]),
+            Filters(op="=", key=Key(section="config", name="lr"), value=0.1),
+        ])
+        """
         from wandb_workspaces import expr
 
         tree = expr.expr_to_filters(
@@ -310,6 +327,17 @@ class TestOrStringFilters:
         assert len(re_tree.filters) == 2
 
     def test_parenthesised_or_in_and(self):
+        """Explicit parens override default precedence.
+
+        Expected tree:
+        Filters(op="AND", filters=[
+            Filters(op="OR", filters=[
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.1),
+            ]),
+            Filters(op="=", key=Key(section="run", name="state"), value="finished"),
+        ])
+        """
         from wandb_workspaces import expr
 
         tree = expr.expr_to_filters(
@@ -317,6 +345,134 @@ class TestOrStringFilters:
         )
         assert tree.op == "AND"
         assert len(tree.filters) == 2
+
+    def test_explicit_group_single_element(self):
+        """Parens around a single expression don't create nesting.
+
+        Expected tree:
+        Filters(op="=", key=Key(section="run", name="state"), value="finished")
+        """
+        from wandb_workspaces import expr
+
+        tree = expr.expr_to_filters(
+            "(Metric('State') == 'finished')"
+        )
+        assert tree.op == "="
+        assert tree.value == "finished"
+
+    def test_explicit_group_with_and(self):
+        """Parenthesised AND group inside an OR.
+
+        Expected tree:
+        Filters(op="OR", filters=[
+            Filters(op="=", key=Key(section="config", name="lr"), value=0.1),
+            Filters(op="AND", filters=[
+                Filters(op="=", key=Key(section="run", name="state"), value="finished"),
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
+            ]),
+        ])
+        """
+        from wandb_workspaces import expr
+
+        tree = expr.expr_to_filters(
+            "Config('lr') == 0.1 or (Metric('State') == 'finished' and Config('lr') == 0.01)"
+        )
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+        assert tree.filters[0].op == "="
+        assert tree.filters[0].value == 0.1
+        assert tree.filters[1].op == "AND"
+        assert len(tree.filters[1].filters) == 2
+
+    def test_explicit_group_with_or(self):
+        """Parenthesised OR group inside an AND.
+
+        Expected tree:
+        Filters(op="AND", filters=[
+            Filters(op="OR", filters=[
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.1),
+            ]),
+            Filters(op="=", key=Key(section="run", name="state"), value="finished"),
+        ])
+        """
+        from wandb_workspaces import expr
+
+        tree = expr.expr_to_filters(
+            "(Config('lr') == 0.01 or Config('lr') == 0.1) and Metric('State') == 'finished'"
+        )
+        assert tree.op == "AND"
+        assert len(tree.filters) == 2
+        assert tree.filters[0].op == "OR"
+        assert len(tree.filters[0].filters) == 2
+        assert tree.filters[1].op == "="
+        assert tree.filters[1].value == "finished"
+
+    def test_nested_groups(self):
+        """Groups containing groups — inner parens inside outer parens.
+
+        Expected tree:
+        Filters(op="OR", filters=[
+            Filters(op="=", key=Key(section="run", name="displayName"), value="a"),
+            Filters(op="OR", filters=[                          # outer parens
+                Filters(op="AND", filters=[                     # AND binds b, finished
+                    Filters(op="=", key=Key(section="run", name="displayName"), value="b"),
+                    Filters(op="=", key=Key(section="run", name="state"), value="finished"),
+                ]),
+                Filters(op="OR", filters=[                      # inner parens
+                    Filters(op="=", key=Key(section="run", name="displayName"), value="c"),
+                    Filters(op="=", key=Key(section="run", name="displayName"), value="d"),
+                ]),
+            ]),
+        ])
+        """
+        from wandb_workspaces import expr
+
+        tree = expr.expr_to_filters(
+            "Metric('Name') == 'a' or (Metric('Name') == 'b' and Metric('State') == 'finished'"
+            " or (Metric('Name') == 'c' or Metric('Name') == 'd'))"
+        )
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+        assert tree.filters[0].op == "="
+        assert tree.filters[0].value == "a"
+        inner = tree.filters[1]
+        assert inner.op == "OR"
+        assert len(inner.filters) == 2
+        assert inner.filters[0].op == "AND"
+        assert len(inner.filters[0].filters) == 2
+        assert inner.filters[1].op == "OR"
+        assert len(inner.filters[1].filters) == 2
+
+    def test_nested_groups_v2_output(self):
+        """Groups containing groups flatten to one level of nesting in v2.
+
+        Expected v2:
+        {"filterFormat": "filterV2", "filters": [
+            {"key": {"section": "run", "name": "displayName"}, "op": "=", "value": "a"},
+            {"connector": "OR", "filters": [
+                {"key": {"section": "run", "name": "displayName"}, "op": "=", "value": "b"},
+                {"key": {"section": "run", "name": "state"}, "op": "=", "value": "finished", "connector": "AND"},
+                {"key": {"section": "run", "name": "displayName"}, "op": "=", "value": "c", "connector": "OR"},
+                {"key": {"section": "run", "name": "displayName"}, "op": "=", "value": "d", "connector": "OR"},
+            ]},
+        ]}
+        """
+        from wandb_workspaces import expr
+
+        tree = expr.expr_to_filters(
+            "Metric('Name') == 'a' or (Metric('Name') == 'b' and Metric('State') == 'finished'"
+            " or (Metric('Name') == 'c' or Metric('Name') == 'd'))"
+        )
+        v2 = expr.filters_tree_to_v2(tree)
+        items = v2["filters"]
+        assert len(items) == 2
+        assert items[0]["value"] == "a"
+        assert "filters" in items[1]
+        group_items = items[1]["filters"]
+        assert len(group_items) == 4
+        for gi in group_items:
+            assert "filters" not in gi
 
 
 class TestV2ToString:
@@ -333,9 +489,7 @@ class TestV2ToString:
             ],
         }
         result = filters_v2_to_string(v2)
-        assert "and" in result
-        assert "finished" in result
-        assert "0.01" in result
+        assert result == 'Metric("State") == \'finished\' and Config("lr") == 0.01'
 
     def test_simple_v2_or(self):
         from wandb_workspaces.expr import filters_v2_to_string
@@ -348,8 +502,7 @@ class TestV2ToString:
             ],
         }
         result = filters_v2_to_string(v2)
-        assert "or" in result
-        assert "finished" in result
+        assert result == 'Metric("State") == \'finished\' or Config("lr") == 0.01'
 
     def test_v2_and_then_or(self):
         """Corresponds to: state=finished AND lr=0.01 OR lr=0.1"""
@@ -364,9 +517,9 @@ class TestV2ToString:
             ],
         }
         result = filters_v2_to_string(v2)
-        assert "and" in result
-        assert "or" in result
-        assert "0.1" in result
+        assert result == (
+            'Metric("State") == \'finished\' and Config("lr") == 0.01 or Config("lr") == 0.1'
+        )
 
     def test_v2_with_group(self):
         from wandb_workspaces.expr import filters_v2_to_string
@@ -386,11 +539,10 @@ class TestV2ToString:
             ],
         }
         result = filters_v2_to_string(v2)
-        assert "(" in result
-        assert ")" in result
-        assert "finished" in result
-        assert "abc" in result
-        assert "or" in result
+        assert result == (
+            'Metric("State") == \'finished\' and '
+            '(Metric("Hostname") == \'abc\' or Metric("Hostname") == \'xyz\')'
+        )
 
     def test_v2_disabled_items_skipped(self):
         from wandb_workspaces.expr import filters_v2_to_string
@@ -403,8 +555,7 @@ class TestV2ToString:
             ],
         }
         result = filters_v2_to_string(v2)
-        assert "finished" in result
-        assert "and" not in result
+        assert result == 'Metric("State") == \'finished\''
 
     def test_v2_empty_filters(self):
         from wandb_workspaces.expr import filters_v2_to_string
@@ -424,30 +575,6 @@ class TestV2ToString:
         assert not is_filter_v2({"filterFormat": "other"})
         assert not is_filter_v2("not a dict")
 
-    def test_real_world_v2_payload(self):
-        """Test with the exact payload observed from the UI in the debugging session."""
-        from wandb_workspaces.expr import filters_v2_to_string
-
-        v2 = {
-            "filterFormat": "filterV2",
-            "filters": [
-                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
-                {"op": "=", "key": {"section": "config", "name": "learning_rate.value"}, "value": 0.001, "disabled": False, "connector": "AND"},
-                {
-                    "filters": [
-                        {"key": {"section": "run", "name": "host"}, "op": "=", "value": "CW-JHWYNJMYJF-L", "disabled": False},
-                        {"key": {"section": "run", "name": ""}, "op": "=", "value": "", "disabled": True},
-                    ],
-                    "disabled": False,
-                },
-            ],
-        }
-        result = filters_v2_to_string(v2)
-        assert "and" in result.lower()
-        assert "finished" in result
-        assert "0.001" in result
-        assert "CW-JHWYNJMYJF-L" in result
-
     def test_v2_within_last(self):
         from wandb_workspaces.expr import filters_v2_to_string
 
@@ -458,9 +585,7 @@ class TestV2ToString:
             ],
         }
         result = filters_v2_to_string(v2)
-        assert "within_last" in result
-        assert "5" in result
-        assert "days" in result
+        assert result == 'Metric("CreatedTimestamp") within_last 5 days'
 
     def test_v2_in_operator(self):
         from wandb_workspaces.expr import filters_v2_to_string
@@ -472,9 +597,7 @@ class TestV2ToString:
             ],
         }
         result = filters_v2_to_string(v2)
-        assert "in" in result
-        assert "prod" in result
-        assert "staging" in result
+        assert result == 'Metric("Tags") in [\'prod\', \'staging\']'
 
 
 class TestV2DirectFilterRoundTrip:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -896,3 +896,158 @@ class TestWorkspaceWriteBack:
         assert filters_out.filters[0].op == "AND"
         assert len(filters_out.filters[0].filters) == 2
 
+
+class TestReportWriteBack:
+    """Test report Runset write-back behavior for v2 and legacy filters.
+
+    Report _to_model() requires an API call for project lookup, so these tests
+    exercise the filter decision logic directly by simulating the three branches
+    in _to_model.
+    """
+
+    def _compute_filters(self, runset):
+        """Extract the filter value that _to_model would write, without the API call."""
+        from wandb_workspaces import expr
+
+        if runset._raw_filters_v2 is not None:
+            if runset.filters == runset._original_v2_filter_string:
+                return runset._raw_filters_v2
+            else:
+                tree = expr.expr_to_filters(runset.filters)
+                return expr.filters_tree_to_v2(tree)
+        elif (
+            runset._filters_internal is not None
+            and runset.filters == expr.filters_to_expr(runset._filters_internal)
+        ):
+            return runset._filters_internal
+        else:
+            return expr.wrap_as_legacy_tree(expr.expr_to_filters(runset.filters))
+
+    def _make_report_runset_from_v2(self, v2_filters):
+        """Simulate loading a report runset that has v2 filters."""
+        from copy import deepcopy
+        from wandb_workspaces.reports.v2.interface import Runset
+        from wandb_workspaces import expr
+
+        filter_string = expr.filters_v2_to_string(v2_filters)
+        rs = Runset(filters=filter_string)
+        rs._raw_filters_v2 = deepcopy(v2_filters)
+        rs._original_v2_filter_string = filter_string
+        return rs
+
+    def _make_report_runset_from_legacy(self, legacy_filters):
+        """Simulate loading a report runset that has legacy filters."""
+        from wandb_workspaces.reports.v2.interface import Runset
+        from wandb_workspaces import expr
+
+        filter_string = expr.filters_to_expr(legacy_filters)
+        rs = Runset(filters=filter_string)
+        rs._filters_internal = legacy_filters
+        return rs
+
+    def test_unchanged_v2_uses_raw_dict(self):
+        """If v2 filters haven't been modified, write-back uses the raw v2 dict."""
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "disabled": False, "connector": "AND"},
+            ],
+        }
+        rs = self._make_report_runset_from_v2(v2)
+        filters_out = self._compute_filters(rs)
+        assert isinstance(filters_out, dict)
+        assert filters_out["filterFormat"] == "filterV2"
+        assert filters_out == v2
+
+    def test_modified_v2_reconverts_to_v2(self):
+        """If v2 filters are modified, write-back converts through tree -> v2."""
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+            ],
+        }
+        rs = self._make_report_runset_from_v2(v2)
+        rs.filters = "Config('lr') == 0.01"
+        filters_out = self._compute_filters(rs)
+        assert isinstance(filters_out, dict)
+        assert filters_out["filterFormat"] == "filterV2"
+        assert any(f.get("value") == 0.01 for f in filters_out["filters"])
+
+    def test_modified_v2_with_group(self):
+        """Modified v2 filters with a group produce a nested v2 group."""
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+            ],
+        }
+        rs = self._make_report_runset_from_v2(v2)
+        rs.filters = (
+            'Metric("Name") == "willow"'
+            ' or (Metric("Name") == "folklore" and Metric("State") == "finished")'
+        )
+        filters_out = self._compute_filters(rs)
+        assert isinstance(filters_out, dict)
+        assert filters_out["filterFormat"] == "filterV2"
+        has_group = any("filters" in f for f in filters_out["filters"])
+        assert has_group
+
+    def test_unchanged_legacy_preserves_tree(self):
+        """If legacy filters haven't been modified, write-back uses the stashed Filters tree."""
+        from wandb_workspaces import expr
+
+        legacy = expr.Filters(
+            op="OR",
+            filters=[
+                expr.Filters(
+                    op="AND",
+                    filters=[
+                        expr.Filters(op="=", key=expr.Key(section="run", name="state"), value="finished"),
+                    ],
+                )
+            ],
+        )
+        rs = self._make_report_runset_from_legacy(legacy)
+        filters_out = self._compute_filters(rs)
+        assert isinstance(filters_out, expr.Filters)
+        assert filters_out is legacy
+
+    def test_legacy_report_writes_legacy_tree(self):
+        """A report runset without v2 filters writes a canonical OR -> AND -> leaves tree."""
+        from wandb_workspaces.reports.v2.interface import Runset
+        from wandb_workspaces import expr
+
+        rs = Runset(filters="Config('lr') == 0.01 and Metric('State') == 'finished'")
+        filters_out = self._compute_filters(rs)
+        assert isinstance(filters_out, expr.Filters)
+        assert filters_out.op == "OR"
+        assert len(filters_out.filters) == 1
+        assert filters_out.filters[0].op == "AND"
+        assert len(filters_out.filters[0].filters) == 2
+
+    def test_v2_fields_are_separate(self):
+        """_raw_filters_v2 and _filters_internal are separate fields."""
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+            ],
+        }
+        rs = self._make_report_runset_from_v2(v2)
+        assert rs._raw_filters_v2 is not None
+        assert rs._filters_internal is None
+
+        from wandb_workspaces import expr
+
+        legacy = expr.Filters(
+            op="OR",
+            filters=[expr.Filters(op="AND", filters=[
+                expr.Filters(op="=", key=expr.Key(section="run", name="state"), value="finished"),
+            ])],
+        )
+        rs2 = self._make_report_runset_from_legacy(legacy)
+        assert rs2._raw_filters_v2 is None
+        assert rs2._filters_internal is not None
+

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -365,7 +365,7 @@ class TestOrObjectAPI:
         assert tree.filters[1].op == "AND"
         assert len(tree.filters[1].filters) == 1
 
-    @pytest.mark.skip(reason="PR2: Or/Group not exposed in RunsetSettings until v2 flag rollout")
+    @pytest.mark.skip(reason="Or in RunsetSettings is PR2 functionality")
     def test_or_in_runset_settings(self):
         import wandb_workspaces.workspaces as ws
         from wandb_workspaces import expr
@@ -379,28 +379,27 @@ class TestOrObjectAPI:
         assert isinstance(rs.filters, str)
         assert "or" in rs.filters
 
-    @pytest.mark.skip(reason="PR2: Or/Group not exposed in RunsetSettings until v2 flag rollout")
-    def test_or_list_in_runset_settings(self):
+    @pytest.mark.skip(reason="Or in RunsetSettings is PR2 functionality")
+    def test_or_direct_in_runset_settings(self):
+        """Or should be passed directly, not wrapped in a list."""
         import wandb_workspaces.workspaces as ws
         from wandb_workspaces import expr
 
         rs = ws.RunsetSettings(
-            filters=[
-                expr.Or(
-                    expr.Config("lr") == 0.01,
-                    expr.Config("lr") == 0.1,
-                )
-            ]
+            filters=expr.Or(
+                expr.Config("lr") == 0.01,
+                expr.Config("lr") == 0.1,
+            )
         )
         assert isinstance(rs.filters, str)
         assert "or" in rs.filters
 
 
-class TestV2Deserialization:
-    """Test conversion from v2 flat filter format to legacy tree."""
+class TestV2ToString:
+    """Test conversion from v2 flat filter format to display string."""
 
     def test_simple_v2_and(self):
-        from wandb_workspaces.expr import filters_v2_to_filters_tree
+        from wandb_workspaces.expr import filters_v2_to_string
 
         v2 = {
             "filterFormat": "filterV2",
@@ -409,17 +408,13 @@ class TestV2Deserialization:
                 {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "disabled": False, "connector": "AND"},
             ],
         }
-        tree = filters_v2_to_filters_tree(v2)
-        assert tree.op == "OR"
-        assert len(tree.filters) == 1
-        and_bucket = tree.filters[0]
-        assert and_bucket.op == "AND"
-        assert len(and_bucket.filters) == 2
-        assert and_bucket.filters[0].value == "finished"
-        assert and_bucket.filters[1].value == 0.01
+        result = filters_v2_to_string(v2)
+        assert "and" in result
+        assert "finished" in result
+        assert "0.01" in result
 
     def test_simple_v2_or(self):
-        from wandb_workspaces.expr import filters_v2_to_filters_tree
+        from wandb_workspaces.expr import filters_v2_to_string
 
         v2 = {
             "filterFormat": "filterV2",
@@ -428,13 +423,13 @@ class TestV2Deserialization:
                 {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "disabled": False, "connector": "OR"},
             ],
         }
-        tree = filters_v2_to_filters_tree(v2)
-        assert tree.op == "OR"
-        assert len(tree.filters) == 2
+        result = filters_v2_to_string(v2)
+        assert "or" in result
+        assert "finished" in result
 
     def test_v2_and_then_or(self):
         """Corresponds to: state=finished AND lr=0.01 OR lr=0.1"""
-        from wandb_workspaces.expr import filters_v2_to_filters_tree
+        from wandb_workspaces.expr import filters_v2_to_string
 
         v2 = {
             "filterFormat": "filterV2",
@@ -444,16 +439,13 @@ class TestV2Deserialization:
                 {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.1, "disabled": False, "connector": "OR"},
             ],
         }
-        tree = filters_v2_to_filters_tree(v2)
-        assert tree.op == "OR"
-        assert len(tree.filters) == 2
-        assert tree.filters[0].op == "AND"
-        assert len(tree.filters[0].filters) == 2
-        assert tree.filters[1].op == "AND"
-        assert tree.filters[1].filters[0].value == 0.1
+        result = filters_v2_to_string(v2)
+        assert "and" in result
+        assert "or" in result
+        assert "0.1" in result
 
     def test_v2_with_group(self):
-        from wandb_workspaces.expr import filters_v2_to_filters_tree
+        from wandb_workspaces.expr import filters_v2_to_string
 
         v2 = {
             "filterFormat": "filterV2",
@@ -469,18 +461,15 @@ class TestV2Deserialization:
                 },
             ],
         }
-        tree = filters_v2_to_filters_tree(v2)
-        assert tree.op == "OR"
-        and_bucket = tree.filters[0]
-        assert and_bucket.op == "AND"
-        assert len(and_bucket.filters) == 2
-        assert and_bucket.filters[0].value == "finished"
-        # The nested group produces an OR node
-        nested = and_bucket.filters[1]
-        assert nested.op == "OR"
+        result = filters_v2_to_string(v2)
+        assert "(" in result
+        assert ")" in result
+        assert "finished" in result
+        assert "abc" in result
+        assert "or" in result
 
     def test_v2_disabled_items_skipped(self):
-        from wandb_workspaces.expr import filters_v2_to_filters_tree
+        from wandb_workspaces.expr import filters_v2_to_string
 
         v2 = {
             "filterFormat": "filterV2",
@@ -489,19 +478,19 @@ class TestV2Deserialization:
                 {"op": "=", "key": {"section": "run", "name": ""}, "value": "", "disabled": True, "connector": "AND"},
             ],
         }
-        tree = filters_v2_to_filters_tree(v2)
-        and_bucket = tree.filters[0]
-        assert len(and_bucket.filters) == 1
+        result = filters_v2_to_string(v2)
+        assert "finished" in result
+        assert "and" not in result
 
     def test_v2_empty_filters(self):
-        from wandb_workspaces.expr import filters_v2_to_filters_tree
+        from wandb_workspaces.expr import filters_v2_to_string
 
         v2 = {
             "filterFormat": "filterV2",
             "filters": [],
         }
-        tree = filters_v2_to_filters_tree(v2)
-        assert tree.op == "OR"
+        result = filters_v2_to_string(v2)
+        assert result == ""
 
     def test_is_filter_v2(self):
         from wandb_workspaces.expr import is_filter_v2
@@ -513,7 +502,7 @@ class TestV2Deserialization:
 
     def test_real_world_v2_payload(self):
         """Test with the exact payload observed from the UI in the debugging session."""
-        from wandb_workspaces.expr import filters_v2_to_filters_tree, filters_to_expr
+        from wandb_workspaces.expr import filters_v2_to_string
 
         v2 = {
             "filterFormat": "filterV2",
@@ -529,116 +518,51 @@ class TestV2Deserialization:
                 },
             ],
         }
-        tree = filters_v2_to_filters_tree(v2)
-        assert tree.op == "OR"
-        and_bucket = tree.filters[0]
-        assert and_bucket.op == "AND"
-        assert len(and_bucket.filters) == 3
-        assert and_bucket.filters[0].value == "finished"
-        assert and_bucket.filters[1].value == 0.001
-        assert and_bucket.filters[2].value == "CW-JHWYNJMYJF-L"
+        result = filters_v2_to_string(v2)
+        assert "and" in result.lower()
+        assert "finished" in result
+        assert "0.001" in result
+        assert "CW-JHWYNJMYJF-L" in result
 
-        expr_str = filters_to_expr(tree)
-        assert "and" in expr_str.lower()
-        assert "finished" in expr_str
+    def test_v2_within_last(self):
+        from wandb_workspaces.expr import filters_v2_to_string
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"key": {"section": "run", "name": "createdAt"}, "op": "WITHINSECONDS", "value": 432000},
+            ],
+        }
+        result = filters_v2_to_string(v2)
+        assert "within_last" in result
+        assert "5" in result
+        assert "days" in result
+
+    def test_v2_in_operator(self):
+        from wandb_workspaces.expr import filters_v2_to_string
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"key": {"section": "run", "name": "tags"}, "op": "IN", "value": ["prod", "staging"]},
+            ],
+        }
+        result = filters_v2_to_string(v2)
+        assert "in" in result
+        assert "prod" in result
+        assert "staging" in result
 
 
-class TestV2RoundTrip:
-    """Test that Filters tree -> v2 dict -> Filters tree round-trips correctly."""
+class TestV2RawStashRoundTrip:
+    """Test that v2 filters are stashed as raw dicts and replayed on write."""
 
-    def test_simple_and_round_trip(self):
-        from wandb_workspaces.expr import (
-            Filters,
-            Key,
-            filters_tree_to_v2,
-            filters_v2_to_filters_tree,
-        )
+    def test_v2_stash_and_replay(self):
+        """v2 filter dict should be stashed on read and replayed on write."""
+        from copy import deepcopy
 
-        tree = Filters(op="OR", filters=[
-            Filters(op="AND", filters=[
-                Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
-                Filters(op="=", key=Key(section="run", name="state"), value="finished"),
-            ])
-        ])
-        v2 = filters_tree_to_v2(tree)
-        assert v2["filterFormat"] == "filterV2"
-        assert len(v2["filters"]) == 2
-        assert "connector" not in v2["filters"][0]
-        assert v2["filters"][1]["connector"] == "AND"
-
-        round_tripped = filters_v2_to_filters_tree(v2)
-        assert round_tripped.op == "OR"
-        assert len(round_tripped.filters) == 1
-        assert round_tripped.filters[0].op == "AND"
-        assert len(round_tripped.filters[0].filters) == 2
-
-    def test_or_round_trip(self):
-        from wandb_workspaces.expr import (
-            Filters,
-            Key,
-            filters_tree_to_v2,
-            filters_v2_to_filters_tree,
-        )
-
-        tree = Filters(op="OR", filters=[
-            Filters(op="AND", filters=[
-                Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
-                Filters(op="=", key=Key(section="run", name="state"), value="finished"),
-            ]),
-            Filters(op="AND", filters=[
-                Filters(op="=", key=Key(section="config", name="lr"), value=0.1),
-            ]),
-        ])
-        v2 = filters_tree_to_v2(tree)
-        assert v2["filterFormat"] == "filterV2"
-        assert len(v2["filters"]) == 3
-        assert "connector" not in v2["filters"][0]
-        assert v2["filters"][1]["connector"] == "AND"
-        assert v2["filters"][2]["connector"] == "OR"
-
-        round_tripped = filters_v2_to_filters_tree(v2)
-        assert round_tripped.op == "OR"
-        assert len(round_tripped.filters) == 2
-        assert round_tripped.filters[0].op == "AND"
-        assert len(round_tripped.filters[0].filters) == 2
-        assert round_tripped.filters[1].op == "AND"
-        assert round_tripped.filters[1].filters[0].value == 0.1
-
-    def test_empty_round_trip(self):
-        from wandb_workspaces.expr import (
-            Filters,
-            filters_tree_to_v2,
-        )
-
-        tree = Filters(op="OR", filters=[Filters(op="AND", filters=[])])
-        v2 = filters_tree_to_v2(tree)
-        assert v2["filterFormat"] == "filterV2"
-        assert v2["filters"] == []
-
-    def test_string_to_v2_round_trip(self):
-        """Full pipeline: string -> tree -> v2 -> tree -> string."""
-        from wandb_workspaces.expr import (
-            expr_to_filters,
-            filters_to_expr,
-            filters_tree_to_v2,
-            filters_v2_to_filters_tree,
-        )
-
-        original = "Metric('State') == 'finished' and Config('lr') == 0.01 or Config('lr') == 0.1"
-        tree1 = expr_to_filters(original)
-        v2 = filters_tree_to_v2(tree1)
-        tree2 = filters_v2_to_filters_tree(v2)
-        result = filters_to_expr(tree2)
-        tree3 = expr_to_filters(result)
-        assert len(tree3.filters) == 2
-        assert tree3.filters[0].op == "AND"
-        assert tree3.filters[1].op == "AND"
-
-    def test_v2_dict_to_tree_to_v2_preserves_structure(self):
-        """v2 dict -> tree -> v2 dict should preserve filter values and connectors."""
-        from wandb_workspaces.expr import (
-            filters_tree_to_v2,
-            filters_v2_to_filters_tree,
+        from wandb_workspaces.workspaces.internal import (
+            WorkspaceViewspec,
+            _migrate_v2_filters_in_spec,
         )
 
         original_v2 = {
@@ -649,44 +573,56 @@ class TestV2RoundTrip:
                 {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.1, "connector": "OR"},
             ],
         }
-        tree = filters_v2_to_filters_tree(original_v2)
-        result_v2 = filters_tree_to_v2(tree)
+        spec_dict = {
+            "section": {
+                "panelBankConfig": {"state": 0, "settings": {}, "sections": []},
+                "panelBankSectionConfig": {"pinned": False},
+                "customRunColors": {},
+                "runSets": [{"id": "rs1", "filters": deepcopy(original_v2)}],
+            }
+        }
 
-        assert result_v2["filterFormat"] == "filterV2"
-        items = result_v2["filters"]
-        assert len(items) == 3
-        assert items[0]["value"] == "finished"
-        assert "connector" not in items[0]
-        assert items[1]["value"] == 0.01
-        assert items[1]["connector"] == "AND"
-        assert items[2]["value"] == 0.1
-        assert items[2]["connector"] == "OR"
+        v2_stash = _migrate_v2_filters_in_spec(spec_dict)
+        assert 0 in v2_stash
+        assert v2_stash[0]["filterFormat"] == "filterV2"
+        assert len(v2_stash[0]["filters"]) == 3
 
-    def test_nested_group_round_trip(self):
-        """v2 with nested group -> tree -> v2 should preserve the group."""
-        from wandb_workspaces.expr import (
-            filters_tree_to_v2,
-            filters_v2_to_filters_tree,
+        parsed_spec = WorkspaceViewspec.model_validate(spec_dict)
+        parsed_spec.section.run_sets[0]._raw_filters_v2 = v2_stash[0]
+
+        spec_out = parsed_spec.model_dump(by_alias=True, exclude_none=True)
+        for i, rs_model in enumerate(parsed_spec.section.run_sets):
+            if rs_model._raw_filters_v2 is not None:
+                spec_out["section"]["runSets"][i]["filters"] = rs_model._raw_filters_v2
+
+        assert spec_out["section"]["runSets"][0]["filters"] == original_v2
+
+    def test_legacy_filters_unchanged(self):
+        """Legacy (non-v2) filters should pass through without stashing."""
+        from wandb_workspaces.workspaces.internal import (
+            WorkspaceViewspec,
+            _migrate_v2_filters_in_spec,
         )
 
-        original_v2 = {
-            "filterFormat": "filterV2",
-            "filters": [
-                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished"},
-                {
-                    "connector": "AND",
-                    "filters": [
-                        {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01},
-                        {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.1, "connector": "OR"},
-                    ],
-                },
-            ],
+        spec_dict = {
+            "section": {
+                "panelBankConfig": {"state": 0, "settings": {}, "sections": []},
+                "panelBankSectionConfig": {"pinned": False},
+                "customRunColors": {},
+                "runSets": [{
+                    "id": "rs1",
+                    "filters": {
+                        "op": "OR",
+                        "filters": [{"op": "AND", "filters": [
+                            {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "disabled": False}
+                        ]}]
+                    },
+                }],
+            }
         }
-        tree = filters_v2_to_filters_tree(original_v2)
-        result_v2 = filters_tree_to_v2(tree)
 
-        assert result_v2["filterFormat"] == "filterV2"
-        items = result_v2["filters"]
-        assert items[0]["value"] == "finished"
-        has_group = any("filters" in item for item in items)
-        assert has_group, "Nested group should be preserved in round-trip"
+        v2_stash = _migrate_v2_filters_in_spec(spec_dict)
+        assert v2_stash == {}
+
+        parsed_spec = WorkspaceViewspec.model_validate(spec_dict)
+        assert parsed_spec.section.run_sets[0]._raw_filters_v2 is None

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -272,3 +272,421 @@ def test_modifying_filters_after_load_uses_new_value():
     leaves = model.filters.filters[0].filters
     assert leaves[0].value == "bob", "New filter value should take effect"
     assert leaves[0].disabled is False, "New filter should be active"
+
+
+# ===== OR filter and v2 deserialization tests =====
+
+
+class TestOrStringFilters:
+    """Test OR support via string filter expressions."""
+
+    def test_simple_or(self):
+        from wandb_workspaces import expr
+
+        tree = expr.expr_to_filters(
+            "Metric('State') == 'finished' or Config('lr') == 0.01"
+        )
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+        assert tree.filters[0].op == "AND"
+        assert tree.filters[1].op == "AND"
+        assert tree.filters[0].filters[0].value == "finished"
+        assert tree.filters[1].filters[0].value == 0.01
+
+    def test_and_or_precedence(self):
+        from wandb_workspaces import expr
+
+        tree = expr.expr_to_filters(
+            "Metric('State') == 'finished' and Config('lr') == 0.01 or Config('lr') == 0.1"
+        )
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+        # First bucket: (State AND lr==0.01)
+        assert tree.filters[0].op == "AND"
+        assert len(tree.filters[0].filters) == 2
+        # Second bucket: (lr==0.1)
+        assert tree.filters[1].op == "AND"
+
+    def test_or_round_trip(self):
+        from wandb_workspaces import expr
+
+        original = "Metric('State') == 'finished' or Config('lr') == 0.01"
+        tree = expr.expr_to_filters(original)
+        result = expr.filters_to_expr(tree)
+        re_tree = expr.expr_to_filters(result)
+        assert len(re_tree.filters) == 2
+
+    def test_parenthesised_or_in_and(self):
+        from wandb_workspaces import expr
+
+        tree = expr.expr_to_filters(
+            "(Config('lr') == 0.01 or Config('lr') == 0.1) and Metric('State') == 'finished'"
+        )
+        assert tree.op == "OR"
+
+
+class TestOrObjectAPI:
+    """Test OR support via the Or/And/Group object API."""
+
+    def test_or_filterexpr(self):
+        from wandb_workspaces import expr
+
+        f = expr.Or(
+            expr.Config("lr") == 0.01,
+            expr.Config("lr") == 0.1,
+        )
+        tree = f.to_model()
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+
+    def test_and_filterexpr(self):
+        from wandb_workspaces import expr
+
+        f = expr.And(
+            expr.Config("lr") == 0.01,
+            expr.Metric("State") == "finished",
+        )
+        tree = f.to_model()
+        assert tree.op == "AND"
+        assert len(tree.filters) == 2
+
+    def test_or_with_and_groups(self):
+        from wandb_workspaces import expr
+
+        f = expr.Or(
+            expr.And(expr.Config("lr") == 0.01, expr.Metric("State") == "finished"),
+            expr.Config("lr") == 0.1,
+        )
+        tree = f.to_model()
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+        assert tree.filters[0].op == "AND"
+        assert len(tree.filters[0].filters) == 2
+        assert tree.filters[1].op == "AND"
+        assert len(tree.filters[1].filters) == 1
+
+    @pytest.mark.skip(reason="PR2: Or/Group not exposed in RunsetSettings until v2 flag rollout")
+    def test_or_in_runset_settings(self):
+        import wandb_workspaces.workspaces as ws
+        from wandb_workspaces import expr
+
+        rs = ws.RunsetSettings(
+            filters=expr.Or(
+                expr.Config("lr") == 0.01,
+                expr.Config("lr") == 0.1,
+            )
+        )
+        assert isinstance(rs.filters, str)
+        assert "or" in rs.filters
+
+    @pytest.mark.skip(reason="PR2: Or/Group not exposed in RunsetSettings until v2 flag rollout")
+    def test_or_list_in_runset_settings(self):
+        import wandb_workspaces.workspaces as ws
+        from wandb_workspaces import expr
+
+        rs = ws.RunsetSettings(
+            filters=[
+                expr.Or(
+                    expr.Config("lr") == 0.01,
+                    expr.Config("lr") == 0.1,
+                )
+            ]
+        )
+        assert isinstance(rs.filters, str)
+        assert "or" in rs.filters
+
+
+class TestV2Deserialization:
+    """Test conversion from v2 flat filter format to legacy tree."""
+
+    def test_simple_v2_and(self):
+        from wandb_workspaces.expr import filters_v2_to_filters_tree
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "disabled": False, "connector": "AND"},
+            ],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        assert tree.op == "OR"
+        assert len(tree.filters) == 1
+        and_bucket = tree.filters[0]
+        assert and_bucket.op == "AND"
+        assert len(and_bucket.filters) == 2
+        assert and_bucket.filters[0].value == "finished"
+        assert and_bucket.filters[1].value == 0.01
+
+    def test_simple_v2_or(self):
+        from wandb_workspaces.expr import filters_v2_to_filters_tree
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "disabled": False, "connector": "OR"},
+            ],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+
+    def test_v2_and_then_or(self):
+        """Corresponds to: state=finished AND lr=0.01 OR lr=0.1"""
+        from wandb_workspaces.expr import filters_v2_to_filters_tree
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "disabled": False, "connector": "AND"},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.1, "disabled": False, "connector": "OR"},
+            ],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        assert tree.op == "OR"
+        assert len(tree.filters) == 2
+        assert tree.filters[0].op == "AND"
+        assert len(tree.filters[0].filters) == 2
+        assert tree.filters[1].op == "AND"
+        assert tree.filters[1].filters[0].value == 0.1
+
+    def test_v2_with_group(self):
+        from wandb_workspaces.expr import filters_v2_to_filters_tree
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {
+                    "filters": [
+                        {"op": "=", "key": {"section": "run", "name": "host"}, "value": "abc", "disabled": False},
+                        {"op": "=", "key": {"section": "run", "name": "host"}, "value": "xyz", "disabled": False, "connector": "OR"},
+                    ],
+                    "disabled": False,
+                    "connector": "AND",
+                },
+            ],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        assert tree.op == "OR"
+        and_bucket = tree.filters[0]
+        assert and_bucket.op == "AND"
+        assert len(and_bucket.filters) == 2
+        assert and_bucket.filters[0].value == "finished"
+        # The nested group produces an OR node
+        nested = and_bucket.filters[1]
+        assert nested.op == "OR"
+
+    def test_v2_disabled_items_skipped(self):
+        from wandb_workspaces.expr import filters_v2_to_filters_tree
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "run", "name": ""}, "value": "", "disabled": True, "connector": "AND"},
+            ],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        and_bucket = tree.filters[0]
+        assert len(and_bucket.filters) == 1
+
+    def test_v2_empty_filters(self):
+        from wandb_workspaces.expr import filters_v2_to_filters_tree
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        assert tree.op == "OR"
+
+    def test_is_filter_v2(self):
+        from wandb_workspaces.expr import is_filter_v2
+
+        assert is_filter_v2({"filterFormat": "filterV2", "filters": []})
+        assert not is_filter_v2({"op": "OR", "filters": []})
+        assert not is_filter_v2({"filterFormat": "other"})
+        assert not is_filter_v2("not a dict")
+
+    def test_real_world_v2_payload(self):
+        """Test with the exact payload observed from the UI in the debugging session."""
+        from wandb_workspaces.expr import filters_v2_to_filters_tree, filters_to_expr
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "config", "name": "learning_rate.value"}, "value": 0.001, "disabled": False, "connector": "AND"},
+                {
+                    "filters": [
+                        {"key": {"section": "run", "name": "host"}, "op": "=", "value": "CW-JHWYNJMYJF-L", "disabled": False},
+                        {"key": {"section": "run", "name": ""}, "op": "=", "value": "", "disabled": True},
+                    ],
+                    "disabled": False,
+                },
+            ],
+        }
+        tree = filters_v2_to_filters_tree(v2)
+        assert tree.op == "OR"
+        and_bucket = tree.filters[0]
+        assert and_bucket.op == "AND"
+        assert len(and_bucket.filters) == 3
+        assert and_bucket.filters[0].value == "finished"
+        assert and_bucket.filters[1].value == 0.001
+        assert and_bucket.filters[2].value == "CW-JHWYNJMYJF-L"
+
+        expr_str = filters_to_expr(tree)
+        assert "and" in expr_str.lower()
+        assert "finished" in expr_str
+
+
+class TestV2RoundTrip:
+    """Test that Filters tree -> v2 dict -> Filters tree round-trips correctly."""
+
+    def test_simple_and_round_trip(self):
+        from wandb_workspaces.expr import (
+            Filters,
+            Key,
+            filters_tree_to_v2,
+            filters_v2_to_filters_tree,
+        )
+
+        tree = Filters(op="OR", filters=[
+            Filters(op="AND", filters=[
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
+                Filters(op="=", key=Key(section="run", name="state"), value="finished"),
+            ])
+        ])
+        v2 = filters_tree_to_v2(tree)
+        assert v2["filterFormat"] == "filterV2"
+        assert len(v2["filters"]) == 2
+        assert "connector" not in v2["filters"][0]
+        assert v2["filters"][1]["connector"] == "AND"
+
+        round_tripped = filters_v2_to_filters_tree(v2)
+        assert round_tripped.op == "OR"
+        assert len(round_tripped.filters) == 1
+        assert round_tripped.filters[0].op == "AND"
+        assert len(round_tripped.filters[0].filters) == 2
+
+    def test_or_round_trip(self):
+        from wandb_workspaces.expr import (
+            Filters,
+            Key,
+            filters_tree_to_v2,
+            filters_v2_to_filters_tree,
+        )
+
+        tree = Filters(op="OR", filters=[
+            Filters(op="AND", filters=[
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
+                Filters(op="=", key=Key(section="run", name="state"), value="finished"),
+            ]),
+            Filters(op="AND", filters=[
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.1),
+            ]),
+        ])
+        v2 = filters_tree_to_v2(tree)
+        assert v2["filterFormat"] == "filterV2"
+        assert len(v2["filters"]) == 3
+        assert "connector" not in v2["filters"][0]
+        assert v2["filters"][1]["connector"] == "AND"
+        assert v2["filters"][2]["connector"] == "OR"
+
+        round_tripped = filters_v2_to_filters_tree(v2)
+        assert round_tripped.op == "OR"
+        assert len(round_tripped.filters) == 2
+        assert round_tripped.filters[0].op == "AND"
+        assert len(round_tripped.filters[0].filters) == 2
+        assert round_tripped.filters[1].op == "AND"
+        assert round_tripped.filters[1].filters[0].value == 0.1
+
+    def test_empty_round_trip(self):
+        from wandb_workspaces.expr import (
+            Filters,
+            filters_tree_to_v2,
+        )
+
+        tree = Filters(op="OR", filters=[Filters(op="AND", filters=[])])
+        v2 = filters_tree_to_v2(tree)
+        assert v2["filterFormat"] == "filterV2"
+        assert v2["filters"] == []
+
+    def test_string_to_v2_round_trip(self):
+        """Full pipeline: string -> tree -> v2 -> tree -> string."""
+        from wandb_workspaces.expr import (
+            expr_to_filters,
+            filters_to_expr,
+            filters_tree_to_v2,
+            filters_v2_to_filters_tree,
+        )
+
+        original = "Metric('State') == 'finished' and Config('lr') == 0.01 or Config('lr') == 0.1"
+        tree1 = expr_to_filters(original)
+        v2 = filters_tree_to_v2(tree1)
+        tree2 = filters_v2_to_filters_tree(v2)
+        result = filters_to_expr(tree2)
+        tree3 = expr_to_filters(result)
+        assert len(tree3.filters) == 2
+        assert tree3.filters[0].op == "AND"
+        assert tree3.filters[1].op == "AND"
+
+    def test_v2_dict_to_tree_to_v2_preserves_structure(self):
+        """v2 dict -> tree -> v2 dict should preserve filter values and connectors."""
+        from wandb_workspaces.expr import (
+            filters_tree_to_v2,
+            filters_v2_to_filters_tree,
+        )
+
+        original_v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished"},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "connector": "AND"},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.1, "connector": "OR"},
+            ],
+        }
+        tree = filters_v2_to_filters_tree(original_v2)
+        result_v2 = filters_tree_to_v2(tree)
+
+        assert result_v2["filterFormat"] == "filterV2"
+        items = result_v2["filters"]
+        assert len(items) == 3
+        assert items[0]["value"] == "finished"
+        assert "connector" not in items[0]
+        assert items[1]["value"] == 0.01
+        assert items[1]["connector"] == "AND"
+        assert items[2]["value"] == 0.1
+        assert items[2]["connector"] == "OR"
+
+    def test_nested_group_round_trip(self):
+        """v2 with nested group -> tree -> v2 should preserve the group."""
+        from wandb_workspaces.expr import (
+            filters_tree_to_v2,
+            filters_v2_to_filters_tree,
+        )
+
+        original_v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished"},
+                {
+                    "connector": "AND",
+                    "filters": [
+                        {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01},
+                        {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.1, "connector": "OR"},
+                    ],
+                },
+            ],
+        }
+        tree = filters_v2_to_filters_tree(original_v2)
+        result_v2 = filters_tree_to_v2(tree)
+
+        assert result_v2["filterFormat"] == "filterV2"
+        items = result_v2["filters"]
+        assert items[0]["value"] == "finished"
+        has_group = any("filters" in item for item in items)
+        assert has_group, "Nested group should be preserved in round-trip"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -599,6 +599,18 @@ class TestV2ToString:
         result = filters_v2_to_string(v2)
         assert result == 'Metric("Tags") in [\'prod\', \'staging\']'
 
+    def test_v2_nin_operator(self):
+        from wandb_workspaces.expr import filters_v2_to_string
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"key": {"section": "run", "name": "tags"}, "op": "NIN", "value": ["debug", "test"]},
+            ],
+        }
+        result = filters_v2_to_string(v2)
+        assert result == 'Metric("Tags") not in [\'debug\', \'test\']'
+
 
 class TestV2DirectFilterRoundTrip:
     """Test that v2 filters are stored directly in Runset.filters and round-trip correctly."""
@@ -728,4 +740,150 @@ class TestTreeToV2Conversion:
         assert group["filters"][0]["value"] == "b"
         assert group["filters"][1]["value"] == "finished"
         assert group["filters"][1]["connector"] == "AND"
+
+
+class TestV2FullRoundTrip:
+    """Test v2 dict → string → tree → v2 round-trip preserves semantics."""
+
+    def test_v2_group_round_trip(self):
+        """A v2 payload with a group should survive the full round-trip."""
+        from wandb_workspaces.expr import (
+            expr_to_filters,
+            filters_tree_to_v2,
+            filters_v2_to_string,
+        )
+
+        v2_original = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {
+                    "filters": [
+                        {"op": "=", "key": {"section": "run", "name": "host"}, "value": "abc", "disabled": False},
+                        {"op": "=", "key": {"section": "run", "name": "host"}, "value": "xyz", "disabled": False, "connector": "OR"},
+                    ],
+                    "connector": "AND",
+                },
+            ],
+        }
+        s = filters_v2_to_string(v2_original)
+        tree = expr_to_filters(s)
+        v2_out = filters_tree_to_v2(tree)
+
+        assert v2_out["filterFormat"] == "filterV2"
+        assert len(v2_out["filters"]) == 2
+        assert v2_out["filters"][0]["value"] == "finished"
+        group = v2_out["filters"][1]
+        assert "filters" in group
+        assert group["connector"] == "AND"
+        assert len(group["filters"]) == 2
+        assert group["filters"][0]["value"] == "abc"
+        assert group["filters"][1]["value"] == "xyz"
+        assert group["filters"][1]["connector"] == "OR"
+
+    def test_v2_flat_mixed_round_trip_is_semantically_stable(self):
+        """Flat mixed AND/OR: round-trip may add parens to make precedence explicit.
+
+        Input string:  A and B or C       (implicit AND precedence)
+        Output string: (A and B) or C     (explicit group for the AND)
+
+        A second round-trip should then be completely stable.
+        """
+        from wandb_workspaces.expr import (
+            expr_to_filters,
+            filters_tree_to_v2,
+            filters_v2_to_string,
+        )
+
+        v2_original = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "disabled": False, "connector": "AND"},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.1, "disabled": False, "connector": "OR"},
+            ],
+        }
+        # First round-trip
+        s1 = filters_v2_to_string(v2_original)
+        tree1 = expr_to_filters(s1)
+        v2_rt1 = filters_tree_to_v2(tree1)
+        s2 = filters_v2_to_string(v2_rt1)
+
+        # Second round-trip should be fully stable
+        tree2 = expr_to_filters(s2)
+        v2_rt2 = filters_tree_to_v2(tree2)
+        s3 = filters_v2_to_string(v2_rt2)
+        assert s2 == s3
+
+
+class TestWorkspaceWriteBack:
+    """Test Workspace._to_model() write-back behavior for v2 and legacy filters."""
+
+    def _make_workspace_from_v2(self, v2_filters):
+        """Simulate loading a workspace that has v2 filters."""
+        from copy import deepcopy
+
+        from wandb_workspaces.workspaces.interface import RunsetSettings, Workspace
+        from wandb_workspaces import expr
+
+        filter_string = expr.filters_v2_to_string(v2_filters)
+        ws = Workspace(
+            entity="test",
+            project="test",
+            name="test workspace",
+            runset_settings=RunsetSettings(filters=filter_string),
+        )
+        ws._raw_filters_v2 = deepcopy(v2_filters)
+        ws._original_v2_filter_string = filter_string
+        return ws
+
+    def test_unchanged_v2_uses_raw_dict(self):
+        """If filters haven't been modified, _to_model uses the raw v2 dict."""
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+                {"op": "=", "key": {"section": "config", "name": "lr"}, "value": 0.01, "disabled": False, "connector": "AND"},
+            ],
+        }
+        ws = self._make_workspace_from_v2(v2)
+        model = ws._to_model()
+        assert isinstance(model.spec.section.run_sets[0].filters, dict)
+        assert model.spec.section.run_sets[0].filters["filterFormat"] == "filterV2"
+        assert model.spec.section.run_sets[0].filters == v2
+
+    def test_modified_v2_reconverts_to_v2(self):
+        """If filters are modified, _to_model converts through tree → v2."""
+        from wandb_workspaces import expr
+
+        v2 = {
+            "filterFormat": "filterV2",
+            "filters": [
+                {"op": "=", "key": {"section": "run", "name": "state"}, "value": "finished", "disabled": False},
+            ],
+        }
+        ws = self._make_workspace_from_v2(v2)
+        ws.runset_settings.filters = "Config('lr') == 0.01"
+        model = ws._to_model()
+        filters_out = model.spec.section.run_sets[0].filters
+        assert isinstance(filters_out, dict)
+        assert filters_out["filterFormat"] == "filterV2"
+        assert any(f.get("value") == 0.01 for f in filters_out["filters"])
+
+    def test_legacy_workspace_writes_legacy_tree(self):
+        """A workspace without v2 filters writes a legacy Filters tree."""
+        from wandb_workspaces.workspaces.interface import RunsetSettings, Workspace
+        from wandb_workspaces import expr
+
+        ws = Workspace(
+            entity="test",
+            project="test",
+            name="test workspace",
+            runset_settings=RunsetSettings(
+                filters="Config('lr') == 0.01 and Metric('State') == 'finished'"
+            ),
+        )
+        model = ws._to_model()
+        filters_out = model.spec.section.run_sets[0].filters
+        assert isinstance(filters_out, expr.Filters)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -184,9 +184,7 @@ def test_list_with_dashes_round_trip():
     parsed = expr.expr_to_filters(expr_string)
     assert parsed is not None
 
-    # Verify the values survived the round-trip (nested in OR/AND structure)
-    inner_filter = parsed.filters[0].filters[0]
-    assert inner_filter.value == ["run-one", "two-three", "abc-123-def"]
+    assert parsed.value == ["run-one", "two-three", "abc-123-def"]
 
 
 # ===== Disabled filter state preservation tests =====
@@ -237,9 +235,8 @@ def test_user_constructed_runset_parses_from_string():
     assert rs._filters_internal is None
 
     model = rs._to_model()
-    leaves = model.filters.filters[0].filters
-    assert leaves[0].value == "alice"
-    assert leaves[0].disabled is False
+    assert model.filters.value == "alice"
+    assert model.filters.disabled is False
 
 
 def test_modifying_filters_after_load_uses_new_value():
@@ -269,9 +266,8 @@ def test_modifying_filters_after_load_uses_new_value():
     iface.filters = "Metric('User') == 'bob'"
 
     model = iface._to_model()
-    leaves = model.filters.filters[0].filters
-    assert leaves[0].value == "bob", "New filter value should take effect"
-    assert leaves[0].disabled is False, "New filter should be active"
+    assert model.filters.value == "bob", "New filter value should take effect"
+    assert model.filters.disabled is False, "New filter should be active"
 
 
 # ===== OR filter and v2 deserialization tests =====
@@ -288,10 +284,8 @@ class TestOrStringFilters:
         )
         assert tree.op == "OR"
         assert len(tree.filters) == 2
-        assert tree.filters[0].op == "AND"
-        assert tree.filters[1].op == "AND"
-        assert tree.filters[0].filters[0].value == "finished"
-        assert tree.filters[1].filters[0].value == 0.01
+        assert tree.filters[0].value == "finished"
+        assert tree.filters[1].value == 0.01
 
     def test_and_or_precedence(self):
         from wandb_workspaces import expr
@@ -301,11 +295,10 @@ class TestOrStringFilters:
         )
         assert tree.op == "OR"
         assert len(tree.filters) == 2
-        # First bucket: (State AND lr==0.01)
         assert tree.filters[0].op == "AND"
         assert len(tree.filters[0].filters) == 2
-        # Second bucket: (lr==0.1)
-        assert tree.filters[1].op == "AND"
+        assert tree.filters[1].op == "="
+        assert tree.filters[1].value == 0.1
 
     def test_or_round_trip(self):
         from wandb_workspaces import expr
@@ -322,7 +315,8 @@ class TestOrStringFilters:
         tree = expr.expr_to_filters(
             "(Config('lr') == 0.01 or Config('lr') == 0.1) and Metric('State') == 'finished'"
         )
-        assert tree.op == "OR"
+        assert tree.op == "AND"
+        assert len(tree.filters) == 2
 
 
 class TestOrObjectAPI:
@@ -365,34 +359,6 @@ class TestOrObjectAPI:
         assert tree.filters[1].op == "AND"
         assert len(tree.filters[1].filters) == 1
 
-    @pytest.mark.skip(reason="Or in RunsetSettings is PR2 functionality")
-    def test_or_in_runset_settings(self):
-        import wandb_workspaces.workspaces as ws
-        from wandb_workspaces import expr
-
-        rs = ws.RunsetSettings(
-            filters=expr.Or(
-                expr.Config("lr") == 0.01,
-                expr.Config("lr") == 0.1,
-            )
-        )
-        assert isinstance(rs.filters, str)
-        assert "or" in rs.filters
-
-    @pytest.mark.skip(reason="Or in RunsetSettings is PR2 functionality")
-    def test_or_direct_in_runset_settings(self):
-        """Or should be passed directly, not wrapped in a list."""
-        import wandb_workspaces.workspaces as ws
-        from wandb_workspaces import expr
-
-        rs = ws.RunsetSettings(
-            filters=expr.Or(
-                expr.Config("lr") == 0.01,
-                expr.Config("lr") == 0.1,
-            )
-        )
-        assert isinstance(rs.filters, str)
-        assert "or" in rs.filters
 
 
 class TestV2ToString:
@@ -626,3 +592,38 @@ class TestV2RawStashRoundTrip:
 
         parsed_spec = WorkspaceViewspec.model_validate(spec_dict)
         assert parsed_spec.section.run_sets[0]._raw_filters_v2 is None
+
+
+class TestAlwaysWriteV2:
+    """Test tree-to-v2 conversion and Or/And/Group in RunsetSettings."""
+
+    def test_and_only_tree_converts_to_v2(self):
+        from wandb_workspaces.expr import Filters, Key, filters_tree_to_v2
+
+        tree = Filters(op="OR", filters=[
+            Filters(op="AND", filters=[
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
+            ])
+        ])
+        v2 = filters_tree_to_v2(tree)
+        assert v2["filterFormat"] == "filterV2"
+        assert len(v2["filters"]) == 1
+        assert v2["filters"][0]["value"] == 0.01
+
+    def test_or_tree_converts_to_v2(self):
+        from wandb_workspaces.expr import Filters, Key, filters_tree_to_v2
+
+        tree = Filters(op="OR", filters=[
+            Filters(op="AND", filters=[
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.01),
+            ]),
+            Filters(op="AND", filters=[
+                Filters(op="=", key=Key(section="config", name="lr"), value=0.1),
+            ]),
+        ])
+        v2 = filters_tree_to_v2(tree)
+        assert v2["filterFormat"] == "filterV2"
+        assert len(v2["filters"]) == 2
+        assert "connector" not in v2["filters"][0]
+        assert v2["filters"][1]["connector"] == "OR"
+

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -519,17 +519,14 @@ class TestV2ToString:
         assert "staging" in result
 
 
-class TestV2RawStashRoundTrip:
-    """Test that v2 filters are stashed as raw dicts and replayed on write."""
+class TestV2DirectFilterRoundTrip:
+    """Test that v2 filters are stored directly in Runset.filters and round-trip correctly."""
 
-    def test_v2_stash_and_replay(self):
-        """v2 filter dict should be stashed on read and replayed on write."""
+    def test_v2_filters_stored_as_dict(self):
+        """v2 filter dict should be stored directly in runset.filters."""
         from copy import deepcopy
 
-        from wandb_workspaces.workspaces.internal import (
-            WorkspaceViewspec,
-            _migrate_v2_filters_in_spec,
-        )
+        from wandb_workspaces.workspaces.internal import WorkspaceViewspec
 
         original_v2 = {
             "filterFormat": "filterV2",
@@ -548,27 +545,18 @@ class TestV2RawStashRoundTrip:
             }
         }
 
-        v2_stash = _migrate_v2_filters_in_spec(spec_dict)
-        assert 0 in v2_stash
-        assert v2_stash[0]["filterFormat"] == "filterV2"
-        assert len(v2_stash[0]["filters"]) == 3
-
         parsed_spec = WorkspaceViewspec.model_validate(spec_dict)
-        parsed_spec.section.run_sets[0]._raw_filters_v2 = v2_stash[0]
+        filters = parsed_spec.section.run_sets[0].filters
+        assert isinstance(filters, dict)
+        assert filters["filterFormat"] == "filterV2"
+        assert len(filters["filters"]) == 3
 
         spec_out = parsed_spec.model_dump(by_alias=True, exclude_none=True)
-        for i, rs_model in enumerate(parsed_spec.section.run_sets):
-            if rs_model._raw_filters_v2 is not None:
-                spec_out["section"]["runSets"][i]["filters"] = rs_model._raw_filters_v2
-
         assert spec_out["section"]["runSets"][0]["filters"] == original_v2
 
-    def test_legacy_filters_unchanged(self):
-        """Legacy (non-v2) filters should pass through without stashing."""
-        from wandb_workspaces.workspaces.internal import (
-            WorkspaceViewspec,
-            _migrate_v2_filters_in_spec,
-        )
+    def test_legacy_filters_stored_as_model(self):
+        """Legacy (non-v2) filters should be parsed into Filters model."""
+        from wandb_workspaces.workspaces.internal import WorkspaceViewspec
 
         spec_dict = {
             "section": {
@@ -587,11 +575,10 @@ class TestV2RawStashRoundTrip:
             }
         }
 
-        v2_stash = _migrate_v2_filters_in_spec(spec_dict)
-        assert v2_stash == {}
-
         parsed_spec = WorkspaceViewspec.model_validate(spec_dict)
-        assert parsed_spec.section.run_sets[0]._raw_filters_v2 is None
+        filters = parsed_spec.section.run_sets[0].filters
+        assert not isinstance(filters, dict)
+        assert filters.op == "OR"
 
 
 class TestAlwaysWriteV2:

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -811,10 +811,6 @@ def _flatten_tree_to_v2_items(node: Filters, connector: str) -> list:
     if node.filters is None:
         return []
 
-    if node.op not in ("OR", "AND"):
-        item = _leaf_to_v2_item(node)
-        return [item] if item else []
-
     items: list = []
     for child in node.filters:
         sub_items = _flatten_tree_to_v2_items(child, node.op)
@@ -834,10 +830,6 @@ def _tree_node_to_v2_items(node: Filters) -> list:
     if node.filters is None:
         return []
 
-    if node.op not in ("OR", "AND"):
-        item = _leaf_to_v2_item(node)
-        return [item] if item else []
-
     items: list = []
     for i, child in enumerate(node.filters):
         if child.key is not None:
@@ -848,6 +840,8 @@ def _tree_node_to_v2_items(node: Filters) -> list:
                 item["connector"] = node.op
             items.append(item)
         elif child.filters and len(child.filters) > 1:
+            # V2 supports at most one level of group nesting, so we flatten
+            # the entire subtree into v2 items and wrap them in a single group.
             group_items = _flatten_tree_to_v2_items(child, child.op)
             if not group_items:
                 continue
@@ -856,6 +850,8 @@ def _tree_node_to_v2_items(node: Filters) -> list:
                 group["connector"] = node.op
             items.append(group)
         else:
+            # Single-child or empty node — no point wrapping in a group,
+            # just inline the flattened items directly.
             sub_items = _flatten_tree_to_v2_items(child, node.op)
             for j, si in enumerate(sub_items):
                 if j == 0 and items:

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -346,7 +346,7 @@ def expr_to_filters(expr: str) -> Filters:
     Args:
         expr: A Python-like filter expression string, e.g.,
             ``"Config('learning_rate') == 0.001 and Metric('State') == 'finished'"``
-            or ``"Metric('State') == 'finished' or Config('lr') == 0.01"``
+            or ``"Metric('State') == 'finished' or Metric('CreatedTimestamp') within_last 5 days"``
 
     Returns:
         An internal Filters tree structure.
@@ -609,6 +609,43 @@ def _handle_logical_op(node) -> Filters:
     return Filters(op=op, filters=filters)
 
 
+def _format_filter_leaf(section: str, name: str, op: str, value: Any) -> str:
+    """Format a single filter leaf into a human-readable string.
+
+    Shared by both the legacy tree-to-string path and the v2-to-string path.
+    """
+    frontend_name = _convert_be_to_fe_metric_name(name)
+
+    if op == "WITHINSECONDS":
+        func_name = section_map_reversed.get(section, "Metric")
+        amount, unit = _convert_seconds_to_time(value)
+        if isinstance(amount, float) and amount.is_integer():
+            amount = int(amount)
+        return f'{func_name}("{frontend_name}") within_last {amount} {unit}'
+
+    if section in section_map_reversed:
+        func_name = section_map_reversed[section]
+        key_str = f'{func_name}("{frontend_name}")'
+    else:
+        key_str = frontend_name
+
+    py_op = OPERATOR_MAP.get(op, op)
+
+    if value is None:
+        val_str = "None"
+    elif isinstance(value, list):
+        parts = []
+        for v in value:
+            parts.append(f"'{v}'" if isinstance(v, str) else str(v))
+        val_str = f"[{', '.join(parts)}]"
+    elif isinstance(value, str):
+        val_str = f"'{value}'"
+    else:
+        val_str = str(value)
+
+    return f"{key_str} {py_op} {val_str}"
+
+
 def filters_to_expr(filter_obj: Any, is_root=True) -> str:
     """Convert an internal Filters tree back to a string expression.
 
@@ -619,19 +656,6 @@ def filters_to_expr(filter_obj: Any, is_root=True) -> str:
     Returns:
         A Python-like filter expression string
     """
-    op_map = {
-        ">": ">",
-        "<": "<",
-        "=": "==",
-        "==": "==",
-        "!=": "!=",
-        ">=": ">=",
-        "<=": "<=",
-        "IN": "in",
-        "NIN": "not in",
-        "AND": "and",
-        "OR": "or",
-    }
 
     def _convert_filter(filter: Any, is_root: bool) -> str:
         if hasattr(filter, "filters") and filter.filters is not None:
@@ -648,62 +672,10 @@ def filters_to_expr(filter_obj: Any, is_root=True) -> str:
             return f"({expr})" if not is_root and sub_expressions else expr
         else:
             if not filter.key or not filter.key.name:
-                # Skip filters with empty key names
                 return ""
-
-            # Special handling for WITHINSECONDS operator
-            if filter.op == "WITHINSECONDS":
-                key_name = filter.key.name
-                section = filter.key.section
-
-                # Convert backend metric name to frontend name
-                frontend_key_name = _convert_be_to_fe_metric_name(key_name)
-
-                # Prepend the function name if the section matches
-                if section in section_map_reversed:
-                    function_name = section_map_reversed[section]
-                    metric_expr = f'{function_name}("{frontend_key_name}")'
-                else:
-                    metric_expr = frontend_key_name
-
-                # Convert seconds back to human-readable format
-                amount, unit = _convert_seconds_to_time(filter.value)
-                # Format amount as int if it's a whole number, otherwise as float
-                if isinstance(amount, float) and amount.is_integer():
-                    amount = int(amount)
-
-                # Use operator syntax for output (more readable)
-                return f"{metric_expr} within_last {amount} {unit}"
-
-            key_name = filter.key.name
-            section = filter.key.section
-
-            # Convert backend metric name to frontend name
-            frontend_key_name = _convert_be_to_fe_metric_name(key_name)
-
-            # Prepend the function name if the section matches
-            if section in section_map_reversed:
-                function_name = section_map_reversed[section]
-                key_name = f'{function_name}("{frontend_key_name}")'
-            else:
-                key_name = frontend_key_name
-
-            value = filter.value
-            if value is None:
-                value = "None"
-            elif isinstance(value, list):
-                # Properly quote string elements in lists to avoid parse errors
-                formatted_elements = []
-                for v in value:
-                    if isinstance(v, str):
-                        formatted_elements.append(f"'{v}'")
-                    else:
-                        formatted_elements.append(str(v))
-                value = f"[{', '.join(formatted_elements)}]"
-            elif isinstance(value, str):
-                value = f"'{value}'"
-
-            return f"{key_name} {op_map[filter.op]} {value}"
+            return _format_filter_leaf(
+                filter.key.section, filter.key.name, filter.op, filter.value
+            )
 
     return _convert_filter(filter_obj, is_root)
 
@@ -738,41 +710,12 @@ def _format_v2_leaf(item: dict) -> Optional[str]:
     if not key or not key.get("name"):
         return None
 
-    section = key.get("section", "run")
-    name = key["name"]
-    op = item.get("op", "=")
-    value = item.get("value")
-
-    frontend_name = _convert_be_to_fe_metric_name(name)
-
-    if op == "WITHINSECONDS":
-        func_name = section_map_reversed.get(section, "Metric")
-        amount, unit = _convert_seconds_to_time(value)
-        if isinstance(amount, float) and amount.is_integer():
-            amount = int(amount)
-        return f'{func_name}("{frontend_name}") within_last {amount} {unit}'
-
-    if section in section_map_reversed:
-        func_name = section_map_reversed[section]
-        key_str = f'{func_name}("{frontend_name}")'
-    else:
-        key_str = frontend_name
-
-    py_op = OPERATOR_MAP.get(op, op)
-
-    if value is None:
-        val_str = "None"
-    elif isinstance(value, list):
-        parts = []
-        for v in value:
-            parts.append(f"'{v}'" if isinstance(v, str) else str(v))
-        val_str = f"[{', '.join(parts)}]"
-    elif isinstance(value, str):
-        val_str = f"'{value}'"
-    else:
-        val_str = str(value)
-
-    return f"{key_str} {py_op} {val_str}"
+    return _format_filter_leaf(
+        key.get("section", "run"),
+        key["name"],
+        item.get("op", "="),
+        item.get("value"),
+    )
 
 
 def _v2_items_to_string(items: list) -> str:

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -385,8 +385,15 @@ def expr_to_filters(expr: str) -> Filters:
     if not expr:
         return Filters(op="OR", filters=[Filters(op="AND", filters=[])])
 
+    # Preprocess: Convert within_last operator syntax to function syntax
+    # This must happen first, before other transformations
     expr = _preprocess_within_last_syntax(expr)
+
+    # Preprocess: Replace single '=' with '==' for Python AST parsing
+    # But avoid replacing '==', '!=', '<=', '>='
     expr = _preprocess_equality_operators(expr)
+    
+    # Preprocess: Replace '<' with '<=' and '>' with '>=' for consistency
     expr = _preprocess_comparison_operators(expr)
 
     parsed_expr = ast.parse(expr, mode="eval")

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -349,7 +349,7 @@ def expr_to_filters(expr: str) -> Filters:
             or ``"Metric('State') == 'finished' or Metric('CreatedTimestamp') within_last 5 days"``
 
     Returns:
-        An internal Filters tree structure.
+        An internal Filters tree structure
     """
     if not expr:
         return Filters(op="AND", filters=[])
@@ -361,7 +361,7 @@ def expr_to_filters(expr: str) -> Filters:
     # Preprocess: Replace single '=' with '==' for Python AST parsing
     # But avoid replacing '==', '!=', '<=', '>='
     expr = _preprocess_equality_operators(expr)
-    
+
     # Preprocess: Replace '<' with '<=' and '>' with '>=' for consistency
     expr = _preprocess_comparison_operators(expr)
 
@@ -614,15 +614,22 @@ def _format_filter_leaf(section: str, name: str, op: str, value: Any) -> str:
 
     Shared by both the legacy tree-to-string path and the v2-to-string path.
     """
+    # Convert backend metric name to frontend name
     frontend_name = _convert_be_to_fe_metric_name(name)
 
+    # Special handling for WITHINSECONDS operator
     if op == "WITHINSECONDS":
+        # Prepend the function name if the section matches
         func_name = section_map_reversed.get(section, "Metric")
+        # Convert seconds back to human-readable format
         amount, unit = _convert_seconds_to_time(value)
+        # Format amount as int if it's a whole number, otherwise as float
         if isinstance(amount, float) and amount.is_integer():
             amount = int(amount)
+        # Use operator syntax for output (more readable)
         return f'{func_name}("{frontend_name}") within_last {amount} {unit}'
 
+    # Prepend the function name if the section matches
     if section in section_map_reversed:
         func_name = section_map_reversed[section]
         key_str = f'{func_name}("{frontend_name}")'
@@ -634,6 +641,7 @@ def _format_filter_leaf(section: str, name: str, op: str, value: Any) -> str:
     if value is None:
         val_str = "None"
     elif isinstance(value, list):
+        # Properly quote string elements in lists to avoid parse errors
         parts = []
         for v in value:
             parts.append(f"'{v}'" if isinstance(v, str) else str(v))
@@ -672,6 +680,7 @@ def filters_to_expr(filter_obj: Any, is_root=True) -> str:
             return f"({expr})" if not is_root and sub_expressions else expr
         else:
             if not filter.key or not filter.key.name:
+                # Skip filters with empty key names
                 return ""
             return _format_filter_leaf(
                 filter.key.section, filter.key.name, filter.op, filter.value

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
 from typing import List as LList
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 from wandb_workspaces.utils.invertable_dict import InvertableDict
@@ -49,13 +49,6 @@ class Filters(ReportAPIBaseModel):
     value: Optional[Any] = None
     disabled: Optional[bool] = None
     current: Optional["Filters"] = None
-
-    @model_validator(mode="before")
-    @classmethod
-    def _reject_v2_format(cls, data: Any) -> Any:
-        if isinstance(data, dict) and data.get("filterFormat") == "filterV2":
-            raise ValueError("v2 filter dicts are stored as raw dicts, not Filters trees")
-        return data
 
 
 class SortKeyKey(ReportAPIBaseModel):

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -748,197 +748,109 @@ def is_filter_v2(data: Any) -> bool:
     return False
 
 
-def _is_v2_group(item: dict) -> bool:
-    """A v2 group has a 'filters' list but no 'op' at the item level (or no key)."""
-    return "filters" in item and isinstance(item["filters"], list)
+def _format_v2_leaf(item: dict) -> Optional[str]:
+    """Format a single v2 leaf item as a human-readable string.
 
+    Args:
+        item: A v2 filter item dict with key, op, and value fields.
 
-def _is_valid_v2_leaf(item: dict) -> bool:
-    """A leaf item has a key with a non-empty name and is not disabled."""
+    Returns:
+        A formatted string like ``Config("lr") == 0.01``, or None if the
+        item is disabled or has no valid key.
+    """
     if item.get("disabled", False):
-        return False
+        return None
     key = item.get("key")
-    if not key:
-        return False
-    return bool(key.get("name"))
+    if not key or not key.get("name"):
+        return None
+
+    section = key.get("section", "run")
+    name = key["name"]
+    op = item.get("op", "=")
+    value = item.get("value")
+
+    frontend_name = _convert_be_to_fe_metric_name(name)
+
+    if op == "WITHINSECONDS":
+        func_name = section_map_reversed.get(section, "Metric")
+        amount, unit = _convert_seconds_to_time(value)
+        if isinstance(amount, float) and amount.is_integer():
+            amount = int(amount)
+        return f'{func_name}("{frontend_name}") within_last {amount} {unit}'
+
+    if section in section_map_reversed:
+        func_name = section_map_reversed[section]
+        key_str = f'{func_name}("{frontend_name}")'
+    else:
+        key_str = frontend_name
+
+    py_op = OPERATOR_MAP.get(op, op)
+
+    if value is None:
+        val_str = "None"
+    elif isinstance(value, list):
+        parts = []
+        for v in value:
+            parts.append(f"'{v}'" if isinstance(v, str) else str(v))
+        val_str = f"[{', '.join(parts)}]"
+    elif isinstance(value, str):
+        val_str = f"'{value}'"
+    else:
+        val_str = str(value)
+
+    return f"{key_str} {py_op} {val_str}"
 
 
-def _v2_leaf_to_filters(item: dict) -> Filters:
-    """Convert a single v2 leaf item to a Filters node."""
-    return Filters(
-        op=item.get("op", "="),
-        key=Key(section=item["key"]["section"], name=item["key"]["name"]),
-        value=item.get("value"),
-        disabled=item.get("disabled"),
-    )
+def _v2_items_to_string(items: list) -> str:
+    """Walk a flat v2 filter list and emit a display string.
 
-
-def _split_on_or(items: list) -> list:
-    """Split a flat v2 filter list into segments at OR boundaries.
-
-    Items with connector='OR' start a new segment. Items with connector='AND'
-    or no connector stay in the current segment. The first item never has a
-    connector.
+    Handles connectors (AND/OR), nested groups (parentheses), and skips
+    disabled or empty items.
     """
-    if not items:
-        return []
-    segments = []
-    current = []
+    parts: List[str] = []
     for item in items:
+        if item.get("disabled", False):
+            continue
+
         connector = item.get("connector")
-        if connector == "OR" and current:
-            segments.append(current)
-            current = []
-        current.append(item)
-    if current:
-        segments.append(current)
-    return segments
 
-
-def _segment_to_node(segment: list) -> Optional[Filters]:
-    """Convert one AND-connected segment into a Filters tree node."""
-    if not segment:
-        return None
-
-    children = []
-    for item in segment:
-        if _is_v2_group(item):
-            if item.get("disabled", False):
+        if "filters" in item and isinstance(item["filters"], list):
+            inner = _v2_items_to_string(item["filters"])
+            if not inner:
                 continue
-            node = _derive_tree_from_v2(item)
-            if node:
-                children.append(node)
-        elif _is_valid_v2_leaf(item):
-            children.append(_v2_leaf_to_filters(item))
+            if connector and parts:
+                parts.append(connector.lower())
+            parts.append(f"({inner})")
+        else:
+            formatted = _format_v2_leaf(item)
+            if formatted is None:
+                continue
+            if connector and parts:
+                parts.append(connector.lower())
+            parts.append(formatted)
 
-    if not children:
-        return None
-    if len(children) == 1:
-        return children[0]
-    return Filters(op="AND", filters=children)
+    return " ".join(parts)
 
 
-def _derive_tree_from_v2(node: dict) -> Optional[Filters]:
-    """Derive a Filters tree from a v2 node (root or group).
+def filters_v2_to_string(data: dict) -> str:
+    """Convert a v2 filterFormat dict to a human-readable filter string.
 
-    Mirrors the frontend's deriveTree algorithm:
-    1. Split the flat list on OR boundaries
-    2. Treat each segment as AND-connected
-    3. Recursively derive trees for nested groups
-    4. If more than one segment, combine with OR
+    Args:
+        data: A dict with ``filterFormat='filterV2'`` and a flat ``filters``
+            list, as stored in the view spec by the frontend v2 filter UI.
+
+    Returns:
+        A Python-like filter expression string, e.g.
+        ``"Config('lr') == 0.01 or Metric('State') == 'finished'"``.
+
+    Examples:
+        >>> filters_v2_to_string({"filterFormat": "filterV2", "filters": []})
+        ''
     """
-    items = node.get("filters", [])
+    items = data.get("filters", [])
     if not items:
-        return None
-
-    segments = _split_on_or(items)
-    segment_nodes = []
-
-    for segment in segments:
-        tree_node = _segment_to_node(segment)
-        if tree_node is not None:
-            segment_nodes.append(tree_node)
-
-    if not segment_nodes:
-        return None
-    if len(segment_nodes) == 1:
-        return segment_nodes[0]
-    return Filters(op="OR", filters=segment_nodes)
-
-
-def filters_v2_to_filters_tree(data: dict) -> Filters:
-    """Convert a v2 filterFormat dict to a legacy Filters tree.
-
-    Args:
-        data: A dict with filterFormat='filterV2' and a flat filters list,
-            as stored in the view spec by the frontend v2 filter UI.
-
-    Returns:
-        A Filters tree in the canonical OR -> AND -> leaves structure.
-    """
-    tree = _derive_tree_from_v2(data)
-    if tree is None:
-        return Filters(op="OR", filters=[Filters(op="AND")])
-
-    return _normalize_to_or_and_tree(tree)
-
-
-def _leaf_to_v2_item(leaf: Filters) -> Optional[dict]:
-    """Convert a single Filters leaf node to a v2 flat item dict."""
-    if leaf.key is None or not leaf.key.name:
-        return None
-    item: dict = {
-        "key": {"section": leaf.key.section, "name": leaf.key.name},
-        "op": leaf.op,
-        "value": leaf.value,
-    }
-    if leaf.disabled is not None:
-        item["disabled"] = leaf.disabled
-    return item
-
-
-def _tree_node_to_v2_items(node: Filters, is_first_in_parent: bool) -> list:
-    """Recursively convert a Filters tree node into a flat list of v2 items.
-
-    Handles OR nodes (emit connector='OR' between segments), AND nodes
-    (emit connector='AND' between items), and nested sub-trees (emitted
-    as FilterV2Group objects).
-    """
-    if node.key is not None:
-        item = _leaf_to_v2_item(node)
-        return [item] if item else []
-
-    if node.filters is None:
-        return []
-
-    if node.op == "OR":
-        items: list = []
-        for i, child in enumerate(node.filters):
-            child_items = _tree_node_to_v2_items(child, is_first_in_parent=(i == 0 and is_first_in_parent))
-            if child_items and i > 0:
-                child_items[0]["connector"] = "OR"
-            items.extend(child_items)
-        return items
-
-    if node.op == "AND":
-        items = []
-        for j, child in enumerate(node.filters):
-            is_first = (j == 0) and is_first_in_parent
-            if child.key is not None:
-                child_item = _leaf_to_v2_item(child)
-                if child_item is None:
-                    continue
-                if not is_first:
-                    child_item["connector"] = "AND"
-                items.append(child_item)
-            else:
-                sub_items = _tree_node_to_v2_items(child, is_first_in_parent=True)
-                if not sub_items:
-                    continue
-                group: dict = {"filters": sub_items}
-                if not is_first:
-                    group["connector"] = "AND"
-                items.append(group)
-        return items
-
-    item = _leaf_to_v2_item(node)
-    return [item] if item else []
-
-
-def filters_tree_to_v2(tree: Filters) -> dict:
-    """Convert a Filters tree to the v2 flat filter format.
-
-    This is the inverse of ``filters_v2_to_filters_tree``.  The returned
-    dict is suitable for storing in the view spec as ``filterFormat: "filterV2"``.
-
-    Args:
-        tree: A Filters tree (typically in canonical OR -> AND -> leaves form).
-
-    Returns:
-        A dict with ``filterFormat`` and a flat ``filters`` list.
-    """
-    items = _tree_node_to_v2_items(tree, is_first_in_parent=True)
-    return {"filterFormat": FILTER_FORMAT_V2, "filters": items}
+        return ""
+    return _v2_items_to_string(items)
 
 
 def _key_to_server_path(key: Key):

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
 from typing import List as LList
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.alias_generators import to_camel
 
 from wandb_workspaces.utils.invertable_dict import InvertableDict
@@ -49,6 +49,13 @@ class Filters(ReportAPIBaseModel):
     value: Optional[Any] = None
     disabled: Optional[bool] = None
     current: Optional["Filters"] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_v2_format(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data.get("filterFormat") == "filterV2":
+            raise ValueError("v2 filter dicts are stored as raw dicts, not Filters trees")
+        return data
 
 
 class SortKeyKey(ReportAPIBaseModel):

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -1214,107 +1214,6 @@ class FilterExpr:
         )
 
 
-FilterItem = Union["FilterExpr", "And", "Or", "Group"]
-
-
-@dataclass(frozen=True)
-class And:
-    """Combine multiple filter items with AND logic.
-
-    Example:
-        >>> And(ws.Config("lr") == 0.01, ws.Metric("State") == "finished")
-    """
-
-    items: tuple
-
-    def __init__(self, *items: FilterItem):
-        object.__setattr__(self, "items", items)
-
-    def __repr__(self) -> str:
-        return f"And({', '.join(repr(i) for i in self.items)})"
-
-    def to_model(self) -> Filters:
-        """Convert to an AND Filters node."""
-        children = []
-        for item in self.items:
-            children.append(item.to_model())
-        return Filters(op="AND", filters=children)
-
-
-@dataclass(frozen=True)
-class Or:
-    """Combine multiple filter items with OR logic.
-
-    Each argument becomes a separate OR branch.  Arguments that are plain
-    ``FilterExpr`` or ``And`` groups are treated as individual AND buckets.
-
-    Example:
-        >>> Or(
-        ...     And(ws.Config("lr") == 0.01, ws.Metric("State") == "finished"),
-        ...     ws.Config("lr") == 0.1,
-        ... )
-    """
-
-    items: tuple
-
-    def __init__(self, *items: FilterItem):
-        object.__setattr__(self, "items", items)
-
-    def __repr__(self) -> str:
-        return f"Or({', '.join(repr(i) for i in self.items)})"
-
-    def to_model(self) -> Filters:
-        """Convert to the canonical OR -> AND -> leaves tree."""
-        buckets = []
-        for item in self.items:
-            node = item.to_model()
-            if node.op == "AND" and node.filters is not None:
-                buckets.append(node)
-            elif node.op == "OR" and node.filters is not None:
-                buckets.extend(node.filters)
-            else:
-                buckets.append(Filters(op="AND", filters=[node]))
-        return Filters(op="OR", filters=buckets)
-
-
-@dataclass(frozen=True)
-class Group:
-    """A parenthesised group of filters, preserving precedence.
-
-    Example:
-        >>> Or(
-        ...     Group(Or(ws.Config("lr") == 0.01, ws.Config("lr") == 0.1)),
-        ...     ws.Metric("State") == "finished",
-        ... )
-    """
-
-    inner: FilterItem
-
-    def __repr__(self) -> str:
-        return f"Group({self.inner!r})"
-
-    def to_model(self) -> Filters:
-        """Delegate to inner item's model."""
-        return self.inner.to_model()
-
-
-def _filter_items_to_filters_tree(items) -> Filters:
-    """Convert a list of FilterExpr / And / Or / Group items to a Filters tree.
-
-    Items in the list are AND'd together.  For OR logic, wrap with ``Or()``.
-    """
-    if not items:
-        return Filters(op="AND", filters=[])
-
-    if len(items) == 1:
-        return items[0].to_model()
-
-    and_children = []
-    for item in items:
-        and_children.append(item.to_model())
-    return Filters(op="AND", filters=and_children)
-
-
 def filters_tree_to_filter_expr(tree: Filters) -> List[FilterExpr]:
     def parse_filter(filter: Filters) -> Optional[FilterExpr]:
         if filter.key is None:
@@ -1337,15 +1236,7 @@ def filters_tree_to_filter_expr(tree: Filters) -> List[FilterExpr]:
 
 
 def filter_expr_to_filters_tree(filters) -> Filters:
-    """Convert a list of filter items to a Filters tree.
-
-    Accepts ``List[FilterExpr]`` (legacy AND-only) as well as lists containing
-    ``Or``, ``And``, and ``Group`` combinators.
-    """
-    has_combinators = any(isinstance(f, (Or, And, Group)) for f in filters)
-    if has_combinators:
-        return _filter_items_to_filters_tree(filters)
-
+    """Convert a list of FilterExpr items to a Filters tree."""
     def parse_key(metric: BaseMetric) -> Key:
         section = metric.section
         name = _convert_fe_to_be_metric_name(metric.name)

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -1235,8 +1235,7 @@ def filters_tree_to_filter_expr(tree: Filters) -> List[FilterExpr]:
     return parse_expression(tree)
 
 
-def filter_expr_to_filters_tree(filters) -> Filters:
-    """Convert a list of FilterExpr items to a Filters tree."""
+def filter_expr_to_filters_tree(filters: List[FilterExpr]) -> Filters:
     def parse_key(metric: BaseMetric) -> Key:
         section = metric.section
         name = _convert_fe_to_be_metric_name(metric.name)

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -793,38 +793,36 @@ def _tree_node_to_v2_items(node: Filters, is_first_in_parent: bool) -> list:
     if node.filters is None:
         return []
 
-    if node.op == "OR":
-        items: list = []
-        for i, child in enumerate(node.filters):
-            child_items = _tree_node_to_v2_items(child, is_first_in_parent=(i == 0 and is_first_in_parent))
-            if child_items and i > 0:
-                child_items[0]["connector"] = "OR"
-            items.extend(child_items)
-        return items
+    if node.op not in ("OR", "AND"):
+        item = _leaf_to_v2_item(node)
+        return [item] if item else []
 
-    if node.op == "AND":
-        items = []
-        for j, child in enumerate(node.filters):
-            is_first = (j == 0) and is_first_in_parent
-            if child.key is not None:
-                child_item = _leaf_to_v2_item(child)
-                if child_item is None:
-                    continue
+    items: list = []
+    for i, child in enumerate(node.filters):
+        is_first = (i == 0) and is_first_in_parent
+
+        if child.key is not None:
+            child_item = _leaf_to_v2_item(child)
+            if child_item is None:
+                continue
+            if not is_first:
+                child_item["connector"] = node.op
+            items.append(child_item)
+        else:
+            sub_items = _tree_node_to_v2_items(child, is_first_in_parent=True)
+            if not sub_items:
+                continue
+            if len(sub_items) == 1:
                 if not is_first:
-                    child_item["connector"] = "AND"
-                items.append(child_item)
+                    sub_items[0]["connector"] = node.op
+                items.append(sub_items[0])
             else:
-                sub_items = _tree_node_to_v2_items(child, is_first_in_parent=True)
-                if not sub_items:
-                    continue
                 group: dict = {"filters": sub_items}
                 if not is_first:
-                    group["connector"] = "AND"
+                    group["connector"] = node.op
                 items.append(group)
-        return items
 
-    item = _leaf_to_v2_item(node)
-    return [item] if item else []
+    return items
 
 
 def filters_tree_to_v2(tree: Filters) -> dict:

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -338,41 +338,61 @@ def _preprocess_comparison_operators(expr: str) -> str:
     return expr
 
 
+def _normalize_to_or_and_tree(root: Filters) -> Filters:
+    """Wrap a parsed Filters node into the canonical OR -> AND -> leaves tree.
+
+    The backend expects the root to be an OR node whose children are AND
+    buckets.  This function normalises any shape produced by the AST parser
+    into that form.
+    """
+    if root.op == "OR" and root.filters:
+        buckets = []
+        for child in root.filters:
+            if child.op == "AND" and child.filters is not None:
+                buckets.append(child)
+            elif child.op in ("=", "!=", "<=", ">=", "<", ">", "IN", "NIN",
+                              "==", "WITHINSECONDS"):
+                buckets.append(Filters(op="AND", filters=[child]))
+            elif child.op == "OR" and child.filters:
+                for grandchild in child.filters:
+                    if grandchild.op == "AND" and grandchild.filters is not None:
+                        buckets.append(grandchild)
+                    else:
+                        buckets.append(Filters(op="AND", filters=[grandchild]))
+            else:
+                buckets.append(Filters(op="AND", filters=[child]))
+        return Filters(op="OR", filters=buckets)
+
+    if root.op == "AND" and root.filters is not None:
+        return Filters(op="OR", filters=[root])
+
+    return Filters(op="OR", filters=[Filters(op="AND", filters=[root])])
+
+
 def expr_to_filters(expr: str) -> Filters:
     """Parse a string filter expression into an internal Filters tree.
 
+    Supports ``and``, ``or``, and parenthesised groups.
+
     Args:
         expr: A Python-like filter expression string, e.g.,
-            "Config('learning_rate') == 0.001 and State == 'finished'"
-            or "Metric('CreatedTimestamp') within_last 5 days"
+            ``"Config('learning_rate') == 0.001 and Metric('State') == 'finished'"``
+            or ``"Metric('State') == 'finished' or Config('lr') == 0.01"``
 
     Returns:
-        An internal Filters tree structure
+        An internal Filters tree in canonical OR -> AND -> leaves form.
     """
     if not expr:
-        filters = []
-    else:
-        # Preprocess: Convert within_last operator syntax to function syntax
-        # This must happen first, before other transformations
-        expr = _preprocess_within_last_syntax(expr)
+        return Filters(op="OR", filters=[Filters(op="AND", filters=[])])
 
-        # Preprocess: Replace single '=' with '==' for Python AST parsing
-        # But avoid replacing '==', '!=', '<=', '>='
-        expr = _preprocess_equality_operators(expr)
+    expr = _preprocess_within_last_syntax(expr)
+    expr = _preprocess_equality_operators(expr)
+    expr = _preprocess_comparison_operators(expr)
 
-        # Preprocess: Replace '<' with '<=' and '>' with '>=' for consistency
-        expr = _preprocess_comparison_operators(expr)
+    parsed_expr = ast.parse(expr, mode="eval")
+    root_filter = _parse_node(parsed_expr.body)
 
-        parsed_expr = ast.parse(expr, mode="eval")
-        root_filter = _parse_node(parsed_expr.body)
-
-        # If the root operation is an AND, unpack its child filters
-        if root_filter.op == "AND" and root_filter.filters:
-            filters = root_filter.filters
-        else:
-            filters = [root_filter]
-
-    return Filters(op="OR", filters=[Filters(op="AND", filters=filters)])
+    return _normalize_to_or_and_tree(root_filter)
 
 
 def _parse_node(node) -> Filters:
@@ -712,6 +732,213 @@ def filters_to_expr(filter_obj: Any, is_root=True) -> str:
             return f"{key_name} {op_map[filter.op]} {value}"
 
     return _convert_filter(filter_obj, is_root)
+
+
+# ---------------------------------------------------------------------------
+# FilterV2 (flat format) → Filters tree conversion
+# ---------------------------------------------------------------------------
+
+FILTER_FORMAT_V2 = "filterV2"
+
+
+def is_filter_v2(data: Any) -> bool:
+    """Check if a dict/object uses the v2 flat filter format."""
+    if isinstance(data, dict):
+        return data.get("filterFormat") == FILTER_FORMAT_V2
+    return False
+
+
+def _is_v2_group(item: dict) -> bool:
+    """A v2 group has a 'filters' list but no 'op' at the item level (or no key)."""
+    return "filters" in item and isinstance(item["filters"], list)
+
+
+def _is_valid_v2_leaf(item: dict) -> bool:
+    """A leaf item has a key with a non-empty name and is not disabled."""
+    if item.get("disabled", False):
+        return False
+    key = item.get("key")
+    if not key:
+        return False
+    return bool(key.get("name"))
+
+
+def _v2_leaf_to_filters(item: dict) -> Filters:
+    """Convert a single v2 leaf item to a Filters node."""
+    return Filters(
+        op=item.get("op", "="),
+        key=Key(section=item["key"]["section"], name=item["key"]["name"]),
+        value=item.get("value"),
+        disabled=item.get("disabled"),
+    )
+
+
+def _split_on_or(items: list) -> list:
+    """Split a flat v2 filter list into segments at OR boundaries.
+
+    Items with connector='OR' start a new segment. Items with connector='AND'
+    or no connector stay in the current segment. The first item never has a
+    connector.
+    """
+    if not items:
+        return []
+    segments = []
+    current = []
+    for item in items:
+        connector = item.get("connector")
+        if connector == "OR" and current:
+            segments.append(current)
+            current = []
+        current.append(item)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _segment_to_node(segment: list) -> Optional[Filters]:
+    """Convert one AND-connected segment into a Filters tree node."""
+    if not segment:
+        return None
+
+    children = []
+    for item in segment:
+        if _is_v2_group(item):
+            if item.get("disabled", False):
+                continue
+            node = _derive_tree_from_v2(item)
+            if node:
+                children.append(node)
+        elif _is_valid_v2_leaf(item):
+            children.append(_v2_leaf_to_filters(item))
+
+    if not children:
+        return None
+    if len(children) == 1:
+        return children[0]
+    return Filters(op="AND", filters=children)
+
+
+def _derive_tree_from_v2(node: dict) -> Optional[Filters]:
+    """Derive a Filters tree from a v2 node (root or group).
+
+    Mirrors the frontend's deriveTree algorithm:
+    1. Split the flat list on OR boundaries
+    2. Treat each segment as AND-connected
+    3. Recursively derive trees for nested groups
+    4. If more than one segment, combine with OR
+    """
+    items = node.get("filters", [])
+    if not items:
+        return None
+
+    segments = _split_on_or(items)
+    segment_nodes = []
+
+    for segment in segments:
+        tree_node = _segment_to_node(segment)
+        if tree_node is not None:
+            segment_nodes.append(tree_node)
+
+    if not segment_nodes:
+        return None
+    if len(segment_nodes) == 1:
+        return segment_nodes[0]
+    return Filters(op="OR", filters=segment_nodes)
+
+
+def filters_v2_to_filters_tree(data: dict) -> Filters:
+    """Convert a v2 filterFormat dict to a legacy Filters tree.
+
+    Args:
+        data: A dict with filterFormat='filterV2' and a flat filters list,
+            as stored in the view spec by the frontend v2 filter UI.
+
+    Returns:
+        A Filters tree in the canonical OR -> AND -> leaves structure.
+    """
+    tree = _derive_tree_from_v2(data)
+    if tree is None:
+        return Filters(op="OR", filters=[Filters(op="AND")])
+
+    return _normalize_to_or_and_tree(tree)
+
+
+def _leaf_to_v2_item(leaf: Filters) -> Optional[dict]:
+    """Convert a single Filters leaf node to a v2 flat item dict."""
+    if leaf.key is None or not leaf.key.name:
+        return None
+    item: dict = {
+        "key": {"section": leaf.key.section, "name": leaf.key.name},
+        "op": leaf.op,
+        "value": leaf.value,
+    }
+    if leaf.disabled is not None:
+        item["disabled"] = leaf.disabled
+    return item
+
+
+def _tree_node_to_v2_items(node: Filters, is_first_in_parent: bool) -> list:
+    """Recursively convert a Filters tree node into a flat list of v2 items.
+
+    Handles OR nodes (emit connector='OR' between segments), AND nodes
+    (emit connector='AND' between items), and nested sub-trees (emitted
+    as FilterV2Group objects).
+    """
+    if node.key is not None:
+        item = _leaf_to_v2_item(node)
+        return [item] if item else []
+
+    if node.filters is None:
+        return []
+
+    if node.op == "OR":
+        items: list = []
+        for i, child in enumerate(node.filters):
+            child_items = _tree_node_to_v2_items(child, is_first_in_parent=(i == 0 and is_first_in_parent))
+            if child_items and i > 0:
+                child_items[0]["connector"] = "OR"
+            items.extend(child_items)
+        return items
+
+    if node.op == "AND":
+        items = []
+        for j, child in enumerate(node.filters):
+            is_first = (j == 0) and is_first_in_parent
+            if child.key is not None:
+                child_item = _leaf_to_v2_item(child)
+                if child_item is None:
+                    continue
+                if not is_first:
+                    child_item["connector"] = "AND"
+                items.append(child_item)
+            else:
+                sub_items = _tree_node_to_v2_items(child, is_first_in_parent=True)
+                if not sub_items:
+                    continue
+                group: dict = {"filters": sub_items}
+                if not is_first:
+                    group["connector"] = "AND"
+                items.append(group)
+        return items
+
+    item = _leaf_to_v2_item(node)
+    return [item] if item else []
+
+
+def filters_tree_to_v2(tree: Filters) -> dict:
+    """Convert a Filters tree to the v2 flat filter format.
+
+    This is the inverse of ``filters_v2_to_filters_tree``.  The returned
+    dict is suitable for storing in the view spec as ``filterFormat: "filterV2"``.
+
+    Args:
+        tree: A Filters tree (typically in canonical OR -> AND -> leaves form).
+
+    Returns:
+        A dict with ``filterFormat`` and a flat ``filters`` list.
+    """
+    items = _tree_node_to_v2_items(tree, is_first_in_parent=True)
+    return {"filterFormat": FILTER_FORMAT_V2, "filters": items}
 
 
 def _key_to_server_path(key: Key):
@@ -1083,6 +1310,112 @@ class FilterExpr:
         )
 
 
+FilterItem = Union["FilterExpr", "And", "Or", "Group"]
+
+
+@dataclass(frozen=True)
+class And:
+    """Combine multiple filter items with AND logic.
+
+    Example:
+        >>> And(ws.Config("lr") == 0.01, ws.Metric("State") == "finished")
+    """
+
+    items: tuple
+
+    def __init__(self, *items: FilterItem):
+        object.__setattr__(self, "items", items)
+
+    def __repr__(self) -> str:
+        return f"And({', '.join(repr(i) for i in self.items)})"
+
+    def to_model(self) -> Filters:
+        """Convert to an AND Filters node."""
+        children = []
+        for item in self.items:
+            children.append(item.to_model())
+        return Filters(op="AND", filters=children)
+
+
+@dataclass(frozen=True)
+class Or:
+    """Combine multiple filter items with OR logic.
+
+    Each argument becomes a separate OR branch.  Arguments that are plain
+    ``FilterExpr`` or ``And`` groups are treated as individual AND buckets.
+
+    Example:
+        >>> Or(
+        ...     And(ws.Config("lr") == 0.01, ws.Metric("State") == "finished"),
+        ...     ws.Config("lr") == 0.1,
+        ... )
+    """
+
+    items: tuple
+
+    def __init__(self, *items: FilterItem):
+        object.__setattr__(self, "items", items)
+
+    def __repr__(self) -> str:
+        return f"Or({', '.join(repr(i) for i in self.items)})"
+
+    def to_model(self) -> Filters:
+        """Convert to the canonical OR -> AND -> leaves tree."""
+        buckets = []
+        for item in self.items:
+            node = item.to_model()
+            if node.op == "AND" and node.filters is not None:
+                buckets.append(node)
+            elif node.op == "OR" and node.filters is not None:
+                buckets.extend(node.filters)
+            else:
+                buckets.append(Filters(op="AND", filters=[node]))
+        return Filters(op="OR", filters=buckets)
+
+
+@dataclass(frozen=True)
+class Group:
+    """A parenthesised group of filters, preserving precedence.
+
+    Example:
+        >>> Or(
+        ...     Group(Or(ws.Config("lr") == 0.01, ws.Config("lr") == 0.1)),
+        ...     ws.Metric("State") == "finished",
+        ... )
+    """
+
+    inner: FilterItem
+
+    def __repr__(self) -> str:
+        return f"Group({self.inner!r})"
+
+    def to_model(self) -> Filters:
+        """Delegate to inner item's model."""
+        return self.inner.to_model()
+
+
+def _filter_items_to_filters_tree(items) -> Filters:
+    """Convert a list of FilterExpr / And / Or / Group items to a Filters tree.
+
+    Items in the list are AND'd together.  For OR logic, wrap with ``Or()``.
+    """
+    if not items:
+        return Filters(op="OR", filters=[Filters(op="AND", filters=[])])
+
+    if len(items) == 1:
+        item = items[0]
+        if isinstance(item, Or):
+            return item.to_model()
+        node = item.to_model()
+        return _normalize_to_or_and_tree(node)
+
+    and_children = []
+    for item in items:
+        and_children.append(item.to_model())
+    and_node = Filters(op="AND", filters=and_children)
+    return Filters(op="OR", filters=[and_node])
+
+
 def filters_tree_to_filter_expr(tree: Filters) -> List[FilterExpr]:
     def parse_filter(filter: Filters) -> Optional[FilterExpr]:
         if filter.key is None:
@@ -1104,7 +1437,16 @@ def filters_tree_to_filter_expr(tree: Filters) -> List[FilterExpr]:
     return parse_expression(tree)
 
 
-def filter_expr_to_filters_tree(filters: List[FilterExpr]) -> Filters:
+def filter_expr_to_filters_tree(filters) -> Filters:
+    """Convert a list of filter items to a Filters tree.
+
+    Accepts ``List[FilterExpr]`` (legacy AND-only) as well as lists containing
+    ``Or``, ``And``, and ``Group`` combinators.
+    """
+    has_combinators = any(isinstance(f, (Or, And, Group)) for f in filters)
+    if has_combinators:
+        return _filter_items_to_filters_tree(filters)
+
     def parse_key(metric: BaseMetric) -> Key:
         section = metric.section
         name = _convert_fe_to_be_metric_name(metric.name)
@@ -1183,25 +1525,22 @@ def filterexpr_list_to_string(filters: List[FilterExpr]) -> str:
 def normalize_filters_to_string(instance):
     """Shared model validator that normalizes filters to string format.
 
-    Converts List[FilterExpr] → str while preserving string inputs.
-    This creates a unified internal representation across Workspaces and Reports.
+    Converts ``List[FilterExpr]`` (and lists containing ``Or``/``And``/``Group``)
+    to a string expression.  Preserves string inputs as-is.
 
     Args:
         instance: The model instance with a 'filters' attribute
 
     Returns:
         The instance with normalized filters
-
-    Usage:
-        @model_validator(mode="after")
-        def convert_filterexpr_list_to_string(self):
-            return normalize_filters_to_string(self)
     """
     if isinstance(instance.filters, list):
-        # Convert FilterExpr list to string
-        # This unifies internal representation as string
-        filter_string = filterexpr_list_to_string(instance.filters)
-        # Update the filters field
+        filters_tree = filter_expr_to_filters_tree(instance.filters)
+        filter_string = filters_to_expr(filters_tree)
+        object.__setattr__(instance, "filters", filter_string)
+    elif isinstance(instance.filters, (Or, And, Group)):
+        filters_tree = instance.filters.to_model()
+        filter_string = filters_to_expr(filters_tree)
         object.__setattr__(instance, "filters", filter_string)
     return instance
 

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -620,14 +620,20 @@ def _format_filter_leaf(section: str, name: str, op: str, value: Any) -> str:
     # Special handling for WITHINSECONDS operator
     if op == "WITHINSECONDS":
         # Prepend the function name if the section matches
-        func_name = section_map_reversed.get(section, "Metric")
+        if section in section_map_reversed:
+            function_name = section_map_reversed[section]
+            metric_expr = f'{function_name}("{frontend_name}")'
+        else:
+            metric_expr = frontend_name
+
         # Convert seconds back to human-readable format
         amount, unit = _convert_seconds_to_time(value)
         # Format amount as int if it's a whole number, otherwise as float
         if isinstance(amount, float) and amount.is_integer():
             amount = int(amount)
+
         # Use operator syntax for output (more readable)
-        return f'{func_name}("{frontend_name}") within_last {amount} {unit}'
+        return f"{metric_expr} within_last {amount} {unit}"
 
     # Prepend the function name if the section matches
     if section in section_map_reversed:
@@ -642,10 +648,13 @@ def _format_filter_leaf(section: str, name: str, op: str, value: Any) -> str:
         val_str = "None"
     elif isinstance(value, list):
         # Properly quote string elements in lists to avoid parse errors
-        parts = []
+        formatted_elements = []
         for v in value:
-            parts.append(f"'{v}'" if isinstance(v, str) else str(v))
-        val_str = f"[{', '.join(parts)}]"
+            if isinstance(v, str):
+                formatted_elements.append(f"'{v}'")
+            else:
+                formatted_elements.append(str(v))
+        val_str = f"[{', '.join(formatted_elements)}]"
     elif isinstance(value, str):
         val_str = f"'{value}'"
     else:

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -822,7 +822,28 @@ def _flatten_tree_to_v2_items(node: Filters, connector: str) -> list:
 
 
 def _tree_node_to_v2_items(node: Filters) -> list:
-    """Convert a Filters tree node into a flat list of v2 items (one level of groups max)."""
+    """Convert a Filters tree node into a flat list of v2 items (one level of groups max).
+
+    Groups in the v2 output arise from two sources:
+
+    1. Explicit parentheses in the filter string — e.g. ``(A or B) and C``
+       creates an OR subtree nested inside an AND, which becomes a v2 group.
+
+    2. Python's ast.parse operator precedence — AND binds tighter than OR,
+       so ``A and B or C`` is parsed as ``Or([And([A, B]), C])``.  The AND
+       subtree has multiple children under an OR parent, so it also becomes
+       a v2 group.  This matches the frontend's own precedence behavior.
+
+    The frontend already applies its own AND-before-OR precedence when
+    reading flat v2 items, so the groups from case (2) are redundant — but
+    they are unavoidable because Python's ast.parse groups AND operands
+    into their own node when mixed with OR (e.g. ``A and B or C`` becomes
+    ``Or([And([A, B]), C])``).  The frontend handles them correctly either
+    way.
+
+    In both cases, any child node with multiple sub-filters becomes a v2
+    group (``{"filters": [...]}``) while leaf nodes are inlined directly.
+    """
     if node.key is not None:
         item = _leaf_to_v2_item(node)
         return [item] if item else []

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -853,6 +853,76 @@ def filters_v2_to_string(data: dict) -> str:
     return _v2_items_to_string(items)
 
 
+def _leaf_to_v2_item(leaf: Filters) -> Optional[dict]:
+    """Convert a single Filters leaf node to a v2 flat item dict."""
+    if leaf.key is None or not leaf.key.name:
+        return None
+    item: dict = {
+        "key": {"section": leaf.key.section, "name": leaf.key.name},
+        "op": leaf.op,
+        "value": leaf.value,
+    }
+    if leaf.disabled is not None:
+        item["disabled"] = leaf.disabled
+    return item
+
+
+def _tree_node_to_v2_items(node: Filters, is_first_in_parent: bool) -> list:
+    """Recursively convert a Filters tree node into a flat list of v2 items."""
+    if node.key is not None:
+        item = _leaf_to_v2_item(node)
+        return [item] if item else []
+
+    if node.filters is None:
+        return []
+
+    if node.op == "OR":
+        items: list = []
+        for i, child in enumerate(node.filters):
+            child_items = _tree_node_to_v2_items(child, is_first_in_parent=(i == 0 and is_first_in_parent))
+            if child_items and i > 0:
+                child_items[0]["connector"] = "OR"
+            items.extend(child_items)
+        return items
+
+    if node.op == "AND":
+        items = []
+        for j, child in enumerate(node.filters):
+            is_first = (j == 0) and is_first_in_parent
+            if child.key is not None:
+                child_item = _leaf_to_v2_item(child)
+                if child_item is None:
+                    continue
+                if not is_first:
+                    child_item["connector"] = "AND"
+                items.append(child_item)
+            else:
+                sub_items = _tree_node_to_v2_items(child, is_first_in_parent=True)
+                if not sub_items:
+                    continue
+                group: dict = {"filters": sub_items}
+                if not is_first:
+                    group["connector"] = "AND"
+                items.append(group)
+        return items
+
+    item = _leaf_to_v2_item(node)
+    return [item] if item else []
+
+
+def filters_tree_to_v2(tree: Filters) -> dict:
+    """Convert a Filters tree to the v2 flat filter format.
+
+    Args:
+        tree: A Filters tree (typically in canonical OR -> AND -> leaves form).
+
+    Returns:
+        A dict with ``filterFormat`` and a flat ``filters`` list.
+    """
+    items = _tree_node_to_v2_items(tree, is_first_in_parent=True)
+    return {"filterFormat": FILTER_FORMAT_V2, "filters": items}
+
+
 def _key_to_server_path(key: Key):
     name = key.name
     section = key.section

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -1315,22 +1315,25 @@ def filterexpr_list_to_string(filters: List[FilterExpr]) -> str:
 def normalize_filters_to_string(instance):
     """Shared model validator that normalizes filters to string format.
 
-    Converts ``List[FilterExpr]`` (and lists containing ``Or``/``And``/``Group``)
-    to a string expression.  Preserves string inputs as-is.
+    Converts List[FilterExpr] → str while preserving string inputs.
+    This creates a unified internal representation across Workspaces and Reports.
 
     Args:
         instance: The model instance with a 'filters' attribute
 
     Returns:
         The instance with normalized filters
+
+    Usage:
+        @model_validator(mode="after")
+        def convert_filterexpr_list_to_string(self):
+            return normalize_filters_to_string(self)
     """
     if isinstance(instance.filters, list):
-        filters_tree = filter_expr_to_filters_tree(instance.filters)
-        filter_string = filters_to_expr(filters_tree)
-        object.__setattr__(instance, "filters", filter_string)
-    elif isinstance(instance.filters, (Or, And, Group)):
-        filters_tree = instance.filters.to_model()
-        filter_string = filters_to_expr(filters_tree)
+        # Convert FilterExpr list to string
+        # This unifies internal representation as string
+        filter_string = filterexpr_list_to_string(instance.filters)
+        # Update the filters field
         object.__setattr__(instance, "filters", filter_string)
     return instance
 

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -369,6 +369,21 @@ def expr_to_filters(expr: str) -> Filters:
     return _parse_node(parsed_expr.body)
 
 
+def wrap_as_legacy_tree(tree: Filters) -> Filters:
+    """Wrap a raw parse tree into the canonical OR → AND → leaves structure.
+
+    The legacy frontend filter reader (legacyFiltersFromJSON) requires filters
+    in the shape ``OR([AND([...leaves...])])``.  This helper normalises any
+    ``Filters`` tree produced by ``expr_to_filters`` into that shape so it can
+    be safely written to the backend for non-v2 workspaces and reports.
+    """
+    if tree.op == "AND" and tree.filters:
+        children = tree.filters
+    else:
+        children = [tree]
+    return Filters(op="OR", filters=[Filters(op="AND", filters=children)])
+
+
 def _parse_node(node) -> Filters:
     # Check if this is a WithinLast function call (not inside a comparison)
     if isinstance(node, ast.Call):

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -338,37 +338,6 @@ def _preprocess_comparison_operators(expr: str) -> str:
     return expr
 
 
-def _normalize_tree(root: Filters) -> Filters:
-    """Wrap a parsed Filters node into the canonical OR -> AND -> leaves tree.
-
-    The backend expects the root to be an OR node whose children are AND
-    buckets.  This function normalises any shape produced by the AST parser
-    into that form.
-    """
-    if root.op == "OR" and root.filters:
-        buckets = []
-        for child in root.filters:
-            if child.op == "AND" and child.filters is not None:
-                buckets.append(child)
-            elif child.op in ("=", "!=", "<=", ">=", "<", ">", "IN", "NIN",
-                              "==", "WITHINSECONDS"):
-                buckets.append(Filters(op="AND", filters=[child]))
-            elif child.op == "OR" and child.filters:
-                for grandchild in child.filters:
-                    if grandchild.op == "AND" and grandchild.filters is not None:
-                        buckets.append(grandchild)
-                    else:
-                        buckets.append(Filters(op="AND", filters=[grandchild]))
-            else:
-                buckets.append(Filters(op="AND", filters=[child]))
-        return Filters(op="OR", filters=buckets)
-
-    if root.op == "AND" and root.filters is not None:
-        return Filters(op="OR", filters=[root])
-
-    return Filters(op="OR", filters=[Filters(op="AND", filters=[root])])
-
-
 def expr_to_filters(expr: str) -> Filters:
     """Parse a string filter expression into an internal Filters tree.
 
@@ -380,10 +349,10 @@ def expr_to_filters(expr: str) -> Filters:
             or ``"Metric('State') == 'finished' or Config('lr') == 0.01"``
 
     Returns:
-        An internal Filters tree in canonical OR -> AND -> leaves form.
+        An internal Filters tree structure.
     """
     if not expr:
-        return Filters(op="OR", filters=[Filters(op="AND", filters=[])])
+        return Filters(op="AND", filters=[])
 
     # Preprocess: Convert within_last operator syntax to function syntax
     # This must happen first, before other transformations
@@ -397,9 +366,7 @@ def expr_to_filters(expr: str) -> Filters:
     expr = _preprocess_comparison_operators(expr)
 
     parsed_expr = ast.parse(expr, mode="eval")
-    root_filter = _parse_node(parsed_expr.body)
-
-    return _normalize_tree(root_filter)
+    return _parse_node(parsed_expr.body)
 
 
 def _parse_node(node) -> Filters:
@@ -1389,20 +1356,15 @@ def _filter_items_to_filters_tree(items) -> Filters:
     Items in the list are AND'd together.  For OR logic, wrap with ``Or()``.
     """
     if not items:
-        return Filters(op="OR", filters=[Filters(op="AND", filters=[])])
+        return Filters(op="AND", filters=[])
 
     if len(items) == 1:
-        item = items[0]
-        if isinstance(item, Or):
-            return item.to_model()
-        node = item.to_model()
-        return _normalize_tree(node)
+        return items[0].to_model()
 
     and_children = []
     for item in items:
         and_children.append(item.to_model())
-    and_node = Filters(op="AND", filters=and_children)
-    return Filters(op="OR", filters=[and_node])
+    return Filters(op="AND", filters=and_children)
 
 
 def filters_tree_to_filter_expr(tree: Filters) -> List[FilterExpr]:

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -338,7 +338,7 @@ def _preprocess_comparison_operators(expr: str) -> str:
     return expr
 
 
-def _normalize_to_or_and_tree(root: Filters) -> Filters:
+def _normalize_tree(root: Filters) -> Filters:
     """Wrap a parsed Filters node into the canonical OR -> AND -> leaves tree.
 
     The backend expects the root to be an OR node whose children are AND
@@ -399,7 +399,7 @@ def expr_to_filters(expr: str) -> Filters:
     parsed_expr = ast.parse(expr, mode="eval")
     root_filter = _parse_node(parsed_expr.body)
 
-    return _normalize_to_or_and_tree(root_filter)
+    return _normalize_tree(root_filter)
 
 
 def _parse_node(node) -> Filters:
@@ -1396,7 +1396,7 @@ def _filter_items_to_filters_tree(items) -> Filters:
         if isinstance(item, Or):
             return item.to_model()
         node = item.to_model()
-        return _normalize_to_or_and_tree(node)
+        return _normalize_tree(node)
 
     and_children = []
     for item in items:

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -791,8 +791,31 @@ def _leaf_to_v2_item(leaf: Filters) -> Optional[dict]:
     return item
 
 
-def _tree_node_to_v2_items(node: Filters, is_first_in_parent: bool) -> list:
-    """Recursively convert a Filters tree node into a flat list of v2 items."""
+def _flatten_tree_to_v2_items(node: Filters, connector: str) -> list:
+    """Flatten a Filters tree node into v2 items with the given connector. No groups."""
+    if node.key is not None:
+        item = _leaf_to_v2_item(node)
+        return [item] if item else []
+
+    if node.filters is None:
+        return []
+
+    if node.op not in ("OR", "AND"):
+        item = _leaf_to_v2_item(node)
+        return [item] if item else []
+
+    items: list = []
+    for child in node.filters:
+        sub_items = _flatten_tree_to_v2_items(child, node.op)
+        for si in sub_items:
+            if items and "connector" not in si:
+                si["connector"] = node.op
+            items.append(si)
+    return items
+
+
+def _tree_node_to_v2_items(node: Filters) -> list:
+    """Convert a Filters tree node into a flat list of v2 items (one level of groups max)."""
     if node.key is not None:
         item = _leaf_to_v2_item(node)
         return [item] if item else []
@@ -806,28 +829,27 @@ def _tree_node_to_v2_items(node: Filters, is_first_in_parent: bool) -> list:
 
     items: list = []
     for i, child in enumerate(node.filters):
-        is_first = (i == 0) and is_first_in_parent
-
         if child.key is not None:
-            child_item = _leaf_to_v2_item(child)
-            if child_item is None:
+            item = _leaf_to_v2_item(child)
+            if item is None:
                 continue
-            if not is_first:
-                child_item["connector"] = node.op
-            items.append(child_item)
+            if items:
+                item["connector"] = node.op
+            items.append(item)
+        elif child.filters and len(child.filters) > 1:
+            group_items = _flatten_tree_to_v2_items(child, child.op)
+            if not group_items:
+                continue
+            group: dict = {"filters": group_items}
+            if items:
+                group["connector"] = node.op
+            items.append(group)
         else:
-            sub_items = _tree_node_to_v2_items(child, is_first_in_parent=True)
-            if not sub_items:
-                continue
-            if len(sub_items) == 1:
-                if not is_first:
-                    sub_items[0]["connector"] = node.op
-                items.append(sub_items[0])
-            else:
-                group: dict = {"filters": sub_items}
-                if not is_first:
-                    group["connector"] = node.op
-                items.append(group)
+            sub_items = _flatten_tree_to_v2_items(child, node.op)
+            for j, si in enumerate(sub_items):
+                if j == 0 and items:
+                    si["connector"] = node.op
+                items.append(si)
 
     return items
 
@@ -841,7 +863,7 @@ def filters_tree_to_v2(tree: Filters) -> dict:
     Returns:
         A dict with ``filterFormat`` and a flat ``filters`` list.
     """
-    items = _tree_node_to_v2_items(tree, is_first_in_parent=True)
+    items = _tree_node_to_v2_items(tree)
     return {"filterFormat": FILTER_FORMAT_V2, "filters": items}
 
 

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -1085,7 +1085,7 @@ class Runset(Base):
         if filters_unchanged:
             filters = self._filters_internal
         else:
-            filters = expr.expr_to_filters(self.filters)
+            filters = expr.wrap_as_legacy_tree(expr.expr_to_filters(self.filters))
 
         obj = internal.Runset(
             project=project,

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -1011,6 +1011,8 @@ class Runset(Base):
     _filters_internal: Optional["expr.Filters"] = Field(
         default=None, init=False, repr=False
     )
+    _raw_filters_v2: Optional[dict] = Field(None, init=False, repr=False)
+    _original_v2_filter_string: str = Field("", init=False, repr=False)
 
     @model_validator(mode="after")
     def merge_custom_run_colors_into_run_settings(self):
@@ -1075,14 +1077,20 @@ class Runset(Base):
                 if settings.disabled
             ]
 
-        # Use the stashed Filters tree when the string hasn't been changed
-        # since loading.  This preserves per-filter metadata (e.g. disabled
-        # state) that the lossy string representation cannot express.
-        filters_unchanged = (
+        # Use the stashed filters when the string hasn't been changed since
+        # loading.  For v2 filters this preserves the raw dict; for legacy
+        # filters it preserves per-filter metadata (e.g. disabled state) that
+        # the lossy string representation cannot express.
+        if self._raw_filters_v2 is not None:
+            if self.filters == self._original_v2_filter_string:
+                filters = self._raw_filters_v2
+            else:
+                tree = expr.expr_to_filters(self.filters)
+                filters = expr.filters_tree_to_v2(tree)
+        elif (
             self._filters_internal is not None
             and self.filters == expr.filters_to_expr(self._filters_internal)
-        )
-        if filters_unchanged:
+        ):
             filters = self._filters_internal
         else:
             filters = expr.wrap_as_legacy_tree(expr.expr_to_filters(self.filters))
@@ -1125,19 +1133,28 @@ class Runset(Base):
                 for child_id in item.children:
                     run_settings[child_id] = RunSettings(disabled=is_disabled)
 
+        if isinstance(model.filters, dict) and expr.is_filter_v2(model.filters):
+            filter_string = expr.filters_v2_to_string(model.filters)
+        else:
+            filter_string = expr.filters_to_expr(model.filters)
+
         obj = cls(
             entity=entity,
             project=project,
             name=model.name,
             query=model.search.query if model.search else "",
-            filters=expr.filters_to_expr(model.filters),
+            filters=filter_string,
             groupby=[expr.to_frontend_name(k.name) for k in model.grouping],
             order=[OrderBy._from_model(s) for s in model.sort.keys],
             run_settings=run_settings,
         )
         obj._id = model.id
         obj._selections_root = model.selections.root
-        obj._filters_internal = model.filters
+        if isinstance(model.filters, dict) and expr.is_filter_v2(model.filters):
+            obj._raw_filters_v2 = model.filters
+            obj._original_v2_filter_string = filter_string
+        else:
+            obj._filters_internal = model.filters
         return obj
 
 

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -20,12 +20,13 @@ from pydantic import (
     Field,
     StringConstraints,
     computed_field,
+    field_validator,
     root_validator,
     validator,
 )
 from pydantic.alias_generators import to_camel
 
-from ...expr import Filters, Key, SortKey, SortKeyKey
+from ...expr import Filters, Key, SortKey, SortKeyKey, is_filter_v2
 
 
 def _generate_name(length: int = 12) -> str:
@@ -368,6 +369,13 @@ class Runset(ReportAPIBaseModel):
     sort: Sort = Field(default_factory=Sort)
     selections: RunsetSelections = Field(default_factory=RunsetSelections)
     expanded_row_addresses: list = Field(default_factory=list)
+
+    @field_validator("filters", mode="wrap")
+    @classmethod
+    def _keep_v2_as_dict(cls, v, handler):
+        if isinstance(v, dict) and is_filter_v2(v):
+            return v
+        return handler(v)
 
 
 class CodeLine(ReportAPIBaseModel):

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -18,7 +18,6 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    PrivateAttr,
     StringConstraints,
     computed_field,
     root_validator,
@@ -362,15 +361,13 @@ class Runset(ReportAPIBaseModel):
     project: Optional[Project] = None
     name: str = "Run set"
     search: RunsetSearch = Field(default_factory=RunsetSearch)
-    filters: Filters = Field(
+    filters: Union[Filters, dict] = Field(
         default_factory=lambda: Filters(filters=[Filters(op="AND")])
     )
     grouping: LList[Key] = Field(default_factory=list)
     sort: Sort = Field(default_factory=Sort)
     selections: RunsetSelections = Field(default_factory=RunsetSelections)
     expanded_row_addresses: list = Field(default_factory=list)
-
-    _raw_filters_v2: Optional[dict] = PrivateAttr(default=None)
 
 
 class CodeLine(ReportAPIBaseModel):

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -18,6 +18,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    PrivateAttr,
     StringConstraints,
     computed_field,
     root_validator,
@@ -368,6 +369,8 @@ class Runset(ReportAPIBaseModel):
     sort: Sort = Field(default_factory=Sort)
     selections: RunsetSelections = Field(default_factory=RunsetSelections)
     expanded_row_addresses: list = Field(default_factory=list)
+
+    _raw_filters_v2: Optional[dict] = PrivateAttr(default=None)
 
 
 class CodeLine(ReportAPIBaseModel):

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -409,8 +409,12 @@ class RunsetSettings(Base):
     def convert_filterexpr_list_to_string(self):
         """Convert FilterExpr list to string (unified internal format)."""
         if isinstance(self.filters, list):
+            # Import locally to avoid circular import at module level
+            # Convert FilterExpr list to internal Filters tree
             filters_tree = expr.filter_expr_to_filters_tree(self.filters)
+            # Convert Filters tree to string expression
             filter_string = expr.filters_to_expr(filters_tree)
+            # Update the filters field
             object.__setattr__(self, "filters", filter_string)
         return self
 

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -407,7 +407,8 @@ class RunsetSettings(Base):
 
     @model_validator(mode="after")
     def convert_filterexpr_list_to_string(self):
-        """Convert FilterExpr list to string (unified internal format)."""
+        """Convert FilterExpr list to string expression (unified internal format)."""
+        # Inline the normalization logic to avoid circular import with expr module
         if isinstance(self.filters, list):
             # Import locally to avoid circular import at module level
             # Convert FilterExpr list to internal Filters tree
@@ -570,6 +571,7 @@ class Workspace(Base):
         else:
             filter_string = expr.filters_to_expr(runset_model.filters)
 
+        # then construct the Workspace object
         obj = cls(
             entity=model.entity,
             project=model.project,
@@ -654,14 +656,14 @@ class Workspace(Base):
                 column_pinned=column_pinned_dict,
                 column_visible=column_visible_dict,
                 column_order=column_order,
-                column_widths={},
+                column_widths={},  # No column widths support
             ),
             search=internal.RunsetSearch(
                 query=self.runset_settings.query,
                 is_regex=is_regex,
             ),
             filters=expr.expr_to_filters(
-                self.runset_settings.filters  # type: ignore[arg-type]
+                self.runset_settings.filters  # type: ignore[arg-type]  # validator ensures this is always str
             ),
             grouping=[g.to_key() for g in self.runset_settings.groupby],
             sort=internal.Sort(

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -655,7 +655,7 @@ class Workspace(Base):
                 filters_value = self._raw_filters_v2
             else:
                 tree = expr.expr_to_filters(
-                    self.runset_settings.filters  # type: ignore[arg-type]
+                    self.runset_settings.filters  # type: ignore[arg-type] # validator ensures this is always str
                 )
                 filters_value = expr.filters_tree_to_v2(tree)
         else:

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -678,11 +678,11 @@ class Workspace(Base):
             ),
         )
 
-        if (
-            self._raw_filters_v2 is not None
-            and self.runset_settings.filters == self._original_v2_filter_string
-        ):
-            runset._raw_filters_v2 = self._raw_filters_v2
+        if self._raw_filters_v2 is not None:
+            if self.runset_settings.filters == self._original_v2_filter_string:
+                runset._raw_filters_v2 = self._raw_filters_v2
+            else:
+                runset._raw_filters_v2 = expr.filters_tree_to_v2(runset.filters)
 
         return internal.View(
             entity=self.entity,

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -660,7 +660,7 @@ class Workspace(Base):
                 filters_value = expr.filters_tree_to_v2(tree)
         else:
             filters_value = expr.expr_to_filters(
-                self.runset_settings.filters  # type: ignore[arg-type]
+                self.runset_settings.filters  # type: ignore[arg-type] # validator ensures this is always str
             )
 
         runset = internal.Runset(

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -565,9 +565,8 @@ class Workspace(Base):
         ]
 
         runset_model = model.spec.section.run_sets[0]
-        raw_v2 = runset_model._raw_filters_v2
-        if raw_v2 is not None:
-            filter_string = expr.filters_v2_to_string(raw_v2)
+        if isinstance(runset_model.filters, dict) and expr.is_filter_v2(runset_model.filters):
+            filter_string = expr.filters_v2_to_string(runset_model.filters)
         else:
             filter_string = expr.filters_to_expr(runset_model.filters)
 
@@ -598,8 +597,9 @@ class Workspace(Base):
         obj._internal_name = model.name
         obj._internal_id = model.id
         obj._internal_runset_id = runset_model.id
-        obj._raw_filters_v2 = raw_v2
-        obj._original_v2_filter_string = filter_string if raw_v2 is not None else ""
+        if isinstance(runset_model.filters, dict):
+            obj._raw_filters_v2 = runset_model.filters
+            obj._original_v2_filter_string = filter_string
         return obj
 
     def _to_model(self) -> internal.View:
@@ -650,6 +650,19 @@ class Workspace(Base):
             else list(self.runset_settings.pinned_columns)
         )
 
+        if self._raw_filters_v2 is not None:
+            if self.runset_settings.filters == self._original_v2_filter_string:
+                filters_value = self._raw_filters_v2
+            else:
+                tree = expr.expr_to_filters(
+                    self.runset_settings.filters  # type: ignore[arg-type]
+                )
+                filters_value = expr.filters_tree_to_v2(tree)
+        else:
+            filters_value = expr.expr_to_filters(
+                self.runset_settings.filters  # type: ignore[arg-type]
+            )
+
         runset = internal.Runset(
             id=self._internal_runset_id,
             run_feed=internal.RunFeed(
@@ -662,9 +675,7 @@ class Workspace(Base):
                 query=self.runset_settings.query,
                 is_regex=is_regex,
             ),
-            filters=expr.expr_to_filters(
-                self.runset_settings.filters  # type: ignore[arg-type]  # validator ensures this is always str
-            ),
+            filters=filters_value,
             grouping=[g.to_key() for g in self.runset_settings.groupby],
             sort=internal.Sort(
                 keys=[o.to_key() for o in self.runset_settings.order]
@@ -677,12 +688,6 @@ class Workspace(Base):
                 ],
             ),
         )
-
-        if self._raw_filters_v2 is not None:
-            if self.runset_settings.filters == self._original_v2_filter_string:
-                runset._raw_filters_v2 = self._raw_filters_v2
-            else:
-                runset._raw_filters_v2 = expr.filters_tree_to_v2(runset.filters)
 
         return internal.View(
             entity=self.entity,

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -659,9 +659,10 @@ class Workspace(Base):
                 )
                 filters_value = expr.filters_tree_to_v2(tree)
         else:
-            filters_value = expr.expr_to_filters(
+            tree = expr.expr_to_filters(
                 self.runset_settings.filters  # type: ignore[arg-type] # validator ensures this is always str
             )
+            filters_value = expr.wrap_as_legacy_tree(tree)
 
         runset = internal.Runset(
             id=self._internal_runset_id,

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -324,10 +324,10 @@ class RunsetSettings(Base):
     Attributes:
         query (str): A query to filter the runset (can be a regex expr, see next param).
         regex_query (bool): Controls whether the query (above) is a regex expr. Default is set to `False`.
-        filters (Union[str, LList[FilterExpr]]): Filters for the runset.
-            - As a list of FilterExpr: filters are AND'd together.
-            - As a string: Python-like expressions, e.g., "Config('lr') = 0.001 and State = 'finished'"
-              Supports operators: =, ==, !=, <, >, <=, >=, in, not in, and
+        filters (Union[str, LList[expr.FilterExpr]]): A list of filters to apply to the runset or a string expression.
+            - As a list: Filters are AND'd together. See FilterExpr for more information on creating filters.
+            - As a string: Use Python-like expressions, e.g., "Config('lr') = 0.001 and State = 'finished'"
+              Supports operators: =, ==, !=, <, >, <=, >=, in, not in
         groupby (LList[expr.MetricType]): A list of metrics to group by in the runset. Set to
             `Metric`, `Summary`, `Config`, `Tags`, or `KeysInfo`.
         order (LList[expr.Ordering]): A list of metrics and ordering to apply to the runset.

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -324,10 +324,10 @@ class RunsetSettings(Base):
     Attributes:
         query (str): A query to filter the runset (can be a regex expr, see next param).
         regex_query (bool): Controls whether the query (above) is a regex expr. Default is set to `False`.
-        filters (Union[str, LList[expr.FilterExpr]]): A list of filters to apply to the runset or a string expression.
-            - As a list: Filters are AND'd together. See FilterExpr for more information on creating filters.
-            - As a string: Use Python-like expressions, e.g., "Config('lr') = 0.001 and State = 'finished'"
-              Supports operators: =, ==, !=, <, >, <=, >=, in, not in
+        filters (Union[str, LList[FilterExpr]]): Filters for the runset.
+            - As a list of FilterExpr: filters are AND'd together.
+            - As a string: Python-like expressions, e.g., "Config('lr') = 0.001 and State = 'finished'"
+              Supports operators: =, ==, !=, <, >, <=, >=, in, not in, and
         groupby (LList[expr.MetricType]): A list of metrics to group by in the runset. Set to
             `Metric`, `Summary`, `Config`, `Tags`, or `KeysInfo`.
         order (LList[expr.Ordering]): A list of metrics and ordering to apply to the runset.
@@ -407,15 +407,10 @@ class RunsetSettings(Base):
 
     @model_validator(mode="after")
     def convert_filterexpr_list_to_string(self):
-        """Convert FilterExpr list to string expression (unified internal format)."""
-        # Inline the normalization logic to avoid circular import with expr module
+        """Convert FilterExpr list to string (unified internal format)."""
         if isinstance(self.filters, list):
-            # Import locally to avoid circular import at module level
-            # Convert FilterExpr list to internal Filters tree
             filters_tree = expr.filter_expr_to_filters_tree(self.filters)
-            # Convert Filters tree to string expression
             filter_string = expr.filters_to_expr(filters_tree)
-            # Update the filters field
             object.__setattr__(self, "filters", filter_string)
         return self
 
@@ -674,7 +669,7 @@ class Workspace(Base):
                                 is_regex=is_regex,
                             ),
                             filters=expr.expr_to_filters(
-                                self.runset_settings.filters  # type: ignore[arg-type]  # validator ensures this is always str
+                                self.runset_settings.filters  # type: ignore[arg-type]
                             ),
                             grouping=[g.to_key() for g in self.runset_settings.groupby],
                             sort=internal.Sort(

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -454,6 +454,9 @@ class Workspace(Base):
     _internal_runset_id: str = Field("", init=False, repr=False)
     "The runset ID of the workspace."
 
+    _raw_filters_v2: Optional[dict] = Field(None, init=False, repr=False)
+    _original_v2_filter_string: str = Field("", init=False, repr=False)
+
     @property
     def auto_generate_panels(self) -> bool:
         return self._auto_generate_panels
@@ -556,7 +559,13 @@ class Workspace(Base):
             col for col, is_pinned in run_feed.column_pinned.items() if is_pinned
         ]
 
-        # then construct the Workspace object
+        runset_model = model.spec.section.run_sets[0]
+        raw_v2 = runset_model._raw_filters_v2
+        if raw_v2 is not None:
+            filter_string = expr.filters_v2_to_string(raw_v2)
+        else:
+            filter_string = expr.filters_to_expr(runset_model.filters)
+
         obj = cls(
             entity=model.entity,
             project=model.project,
@@ -567,16 +576,14 @@ class Workspace(Base):
             ],
             settings=workspace_settings,
             runset_settings=RunsetSettings(
-                query=model.spec.section.run_sets[0].search.query,
+                query=runset_model.search.query,
                 regex_query=regex_query,
-                filters=expr.filters_to_expr(model.spec.section.run_sets[0].filters),
+                filters=filter_string,
                 groupby=[
-                    expr.BaseMetric.from_key(v)
-                    for v in model.spec.section.run_sets[0].grouping
+                    expr.BaseMetric.from_key(v) for v in runset_model.grouping
                 ],
                 order=[
-                    expr.Ordering.from_key(s)
-                    for s in model.spec.section.run_sets[0].sort.keys
+                    expr.Ordering.from_key(s) for s in runset_model.sort.keys
                 ],
                 run_settings=run_settings,
                 pinned_columns=pinned_columns,
@@ -584,7 +591,9 @@ class Workspace(Base):
         )
         obj._internal_name = model.name
         obj._internal_id = model.id
-        obj._internal_runset_id = model.spec.section.run_sets[0].id
+        obj._internal_runset_id = runset_model.id
+        obj._raw_filters_v2 = raw_v2
+        obj._original_v2_filter_string = filter_string if raw_v2 is not None else ""
         return obj
 
     def _to_model(self) -> internal.View:
@@ -635,6 +644,40 @@ class Workspace(Base):
             else list(self.runset_settings.pinned_columns)
         )
 
+        runset = internal.Runset(
+            id=self._internal_runset_id,
+            run_feed=internal.RunFeed(
+                column_pinned=column_pinned_dict,
+                column_visible=column_visible_dict,
+                column_order=column_order,
+                column_widths={},
+            ),
+            search=internal.RunsetSearch(
+                query=self.runset_settings.query,
+                is_regex=is_regex,
+            ),
+            filters=expr.expr_to_filters(
+                self.runset_settings.filters  # type: ignore[arg-type]
+            ),
+            grouping=[g.to_key() for g in self.runset_settings.groupby],
+            sort=internal.Sort(
+                keys=[o.to_key() for o in self.runset_settings.order]
+            ),
+            selections=internal.RunsetSelections(
+                tree=[
+                    id
+                    for id, config in self.runset_settings.run_settings.items()
+                    if config.disabled
+                ],
+            ),
+        )
+
+        if (
+            self._raw_filters_v2 is not None
+            and self.runset_settings.filters == self._original_v2_filter_string
+        ):
+            runset._raw_filters_v2 = self._raw_filters_v2
+
         return internal.View(
             entity=self.entity,
             project=self.project,
@@ -655,35 +698,7 @@ class Workspace(Base):
                         pinned=False
                     ),
                     settings=internal_settings,
-                    run_sets=[
-                        internal.Runset(
-                            id=self._internal_runset_id,
-                            run_feed=internal.RunFeed(
-                                column_pinned=column_pinned_dict,
-                                column_visible=column_visible_dict,
-                                column_order=column_order,
-                                column_widths={},  # No column widths support
-                            ),
-                            search=internal.RunsetSearch(
-                                query=self.runset_settings.query,
-                                is_regex=is_regex,
-                            ),
-                            filters=expr.expr_to_filters(
-                                self.runset_settings.filters  # type: ignore[arg-type]
-                            ),
-                            grouping=[g.to_key() for g in self.runset_settings.groupby],
-                            sort=internal.Sort(
-                                keys=[o.to_key() for o in self.runset_settings.order]
-                            ),
-                            selections=internal.RunsetSelections(
-                                tree=[
-                                    id
-                                    for id, config in self.runset_settings.run_settings.items()
-                                    if config.disabled
-                                ],
-                            ),
-                        ),
-                    ],
+                    run_sets=[runset],
                     custom_run_colors={
                         id: config.color
                         for id, config in self.runset_settings.run_settings.items()

--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -7,6 +7,9 @@ from annotated_types import Annotated, Ge
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 from pydantic.alias_generators import to_camel
 from wandb_gql import gql
+
+# these internal objects should be factored out into a separate module as a
+# shared dependency between Workspaces and Reports API
 from wandb_workspaces.reports.v2.internal import *  # noqa: F403
 from wandb_workspaces.reports.v2.internal import (
     PanelBankConfig,
@@ -83,7 +86,6 @@ class WorkspaceViewspec(WorkspaceAPIBaseModel):
     library_expanded: bool = True
 
 
-
 class View(WorkspaceAPIBaseModel):
     entity: str
     project: str
@@ -104,9 +106,7 @@ class View(WorkspaceAPIBaseModel):
         spec = view_dict["spec"]
         display_name = view_dict["displayName"]
         id = view_dict["id"]
-
-        spec_dict = json.loads(spec) if isinstance(spec, str) else spec
-        parsed_spec = WorkspaceViewspec.model_validate(spec_dict)
+        parsed_spec = WorkspaceViewspec.model_validate_json(spec)
 
         return cls(
             entity=entity,
@@ -136,9 +136,7 @@ def upsert_view2(view: View) -> Dict[str, Any]:
     )
 
     api = wandb.Api()
-
-    spec_dict = view.spec.model_dump(by_alias=True, exclude_none=True)
-    spec_str = json.dumps(spec_dict)
+    spec_str = view.spec.model_dump_json(by_alias=True, exclude_none=True)
 
     # Default: assume a new view being created, so no `id` yet
     variables = {

--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 from typing import Any, Dict, Optional
 from typing import List as LList
 
@@ -10,12 +11,7 @@ from wandb_gql import gql
 
 # these internal objects should be factored out into a separate module as a
 # shared dependency between Workspaces and Reports API
-from wandb_workspaces.expr import (
-    Filters,
-    filters_tree_to_v2,
-    filters_v2_to_filters_tree,
-    is_filter_v2,
-)
+from wandb_workspaces.expr import is_filter_v2
 from wandb_workspaces.reports.v2.internal import *  # noqa: F403
 from wandb_workspaces.reports.v2.internal import (
     PanelBankConfig,
@@ -29,8 +25,6 @@ from wandb_workspaces.utils.validators import validate_spec_version
 
 CLIENT_SPEC_VERSION = -1
 SPEC_VERSION_KEY = "version"
-
-_v2_runset_ids: set = set()
 
 
 class WorkspaceAPIBaseModel(BaseModel):
@@ -94,27 +88,24 @@ class WorkspaceViewspec(WorkspaceAPIBaseModel):
     library_expanded: bool = True
 
 
-def _migrate_v2_filters_in_spec(spec_dict: dict) -> dict:
-    """Pre-process a spec dict, converting any v2-format filters to the legacy tree.
+def _migrate_v2_filters_in_spec(spec_dict: dict) -> Dict[int, dict]:
+    """Stash raw v2 filter dicts and replace with an empty tree for Pydantic.
 
     The frontend v2 filter UI stores filters as a flat list with inline
     connector fields.  Pydantic can't parse that into the legacy Filters
-    model correctly, so we convert before validation.
+    model, so we stash the raw dict and swap in a default empty tree.
 
-    Runset IDs whose filters were originally v2 are tracked in the module-level
-    ``_v2_runset_ids`` set so that ``upsert_view2`` can write them back in v2
-    format.
+    Returns:
+        A mapping from runset index to the original raw v2 filter dict.
     """
+    v2_stash: Dict[int, dict] = {}
     run_sets = spec_dict.get("section", {}).get("runSets", [])
-    for rs in run_sets:
+    for i, rs in enumerate(run_sets):
         filters_data = rs.get("filters")
         if filters_data and is_filter_v2(filters_data):
-            tree = filters_v2_to_filters_tree(filters_data)
-            rs["filters"] = tree.model_dump(by_alias=True, exclude_none=True)
-            rs_id = rs.get("id")
-            if rs_id:
-                _v2_runset_ids.add(rs_id)
-    return spec_dict
+            v2_stash[i] = deepcopy(filters_data)
+            rs["filters"] = {"op": "OR", "filters": [{"op": "AND"}]}
+    return v2_stash
 
 
 class View(WorkspaceAPIBaseModel):
@@ -139,8 +130,11 @@ class View(WorkspaceAPIBaseModel):
         id = view_dict["id"]
 
         spec_dict = json.loads(spec) if isinstance(spec, str) else spec
-        spec_dict = _migrate_v2_filters_in_spec(spec_dict)
+        v2_stash = _migrate_v2_filters_in_spec(spec_dict)
         parsed_spec = WorkspaceViewspec.model_validate(spec_dict)
+
+        for i, raw_v2 in v2_stash.items():
+            parsed_spec.section.run_sets[i]._raw_filters_v2 = raw_v2
 
         return cls(
             entity=entity,
@@ -173,11 +167,9 @@ def upsert_view2(view: View) -> Dict[str, Any]:
 
     spec_dict = view.spec.model_dump(by_alias=True, exclude_none=True)
 
-    for rs in spec_dict.get("section", {}).get("runSets", []):
-        rs_id = rs.get("id")
-        if rs_id and rs_id in _v2_runset_ids:
-            tree = Filters.model_validate(rs["filters"])
-            rs["filters"] = filters_tree_to_v2(tree)
+    for i, rs_model in enumerate(view.spec.section.run_sets):
+        if rs_model._raw_filters_v2 is not None:
+            spec_dict["section"]["runSets"][i]["filters"] = rs_model._raw_filters_v2
 
     spec_str = json.dumps(spec_dict)
 

--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -10,6 +10,12 @@ from wandb_gql import gql
 
 # these internal objects should be factored out into a separate module as a
 # shared dependency between Workspaces and Reports API
+from wandb_workspaces.expr import (
+    Filters,
+    filters_tree_to_v2,
+    filters_v2_to_filters_tree,
+    is_filter_v2,
+)
 from wandb_workspaces.reports.v2.internal import *  # noqa: F403
 from wandb_workspaces.reports.v2.internal import (
     PanelBankConfig,
@@ -23,6 +29,8 @@ from wandb_workspaces.utils.validators import validate_spec_version
 
 CLIENT_SPEC_VERSION = -1
 SPEC_VERSION_KEY = "version"
+
+_v2_runset_ids: set = set()
 
 
 class WorkspaceAPIBaseModel(BaseModel):
@@ -86,6 +94,29 @@ class WorkspaceViewspec(WorkspaceAPIBaseModel):
     library_expanded: bool = True
 
 
+def _migrate_v2_filters_in_spec(spec_dict: dict) -> dict:
+    """Pre-process a spec dict, converting any v2-format filters to the legacy tree.
+
+    The frontend v2 filter UI stores filters as a flat list with inline
+    connector fields.  Pydantic can't parse that into the legacy Filters
+    model correctly, so we convert before validation.
+
+    Runset IDs whose filters were originally v2 are tracked in the module-level
+    ``_v2_runset_ids`` set so that ``upsert_view2`` can write them back in v2
+    format.
+    """
+    run_sets = spec_dict.get("section", {}).get("runSets", [])
+    for rs in run_sets:
+        filters_data = rs.get("filters")
+        if filters_data and is_filter_v2(filters_data):
+            tree = filters_v2_to_filters_tree(filters_data)
+            rs["filters"] = tree.model_dump(by_alias=True, exclude_none=True)
+            rs_id = rs.get("id")
+            if rs_id:
+                _v2_runset_ids.add(rs_id)
+    return spec_dict
+
+
 class View(WorkspaceAPIBaseModel):
     entity: str
     project: str
@@ -106,7 +137,10 @@ class View(WorkspaceAPIBaseModel):
         spec = view_dict["spec"]
         display_name = view_dict["displayName"]
         id = view_dict["id"]
-        parsed_spec = WorkspaceViewspec.model_validate_json(spec)
+
+        spec_dict = json.loads(spec) if isinstance(spec, str) else spec
+        spec_dict = _migrate_v2_filters_in_spec(spec_dict)
+        parsed_spec = WorkspaceViewspec.model_validate(spec_dict)
 
         return cls(
             entity=entity,
@@ -136,7 +170,16 @@ def upsert_view2(view: View) -> Dict[str, Any]:
     )
 
     api = wandb.Api()
-    spec_str = view.spec.model_dump_json(by_alias=True, exclude_none=True)
+
+    spec_dict = view.spec.model_dump(by_alias=True, exclude_none=True)
+
+    for rs in spec_dict.get("section", {}).get("runSets", []):
+        rs_id = rs.get("id")
+        if rs_id and rs_id in _v2_runset_ids:
+            tree = Filters.model_validate(rs["filters"])
+            rs["filters"] = filters_tree_to_v2(tree)
+
+    spec_str = json.dumps(spec_dict)
 
     # Default: assume a new view being created, so no `id` yet
     variables = {

--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -1,5 +1,4 @@
 import json
-from copy import deepcopy
 from typing import Any, Dict, Optional
 from typing import List as LList
 
@@ -8,10 +7,6 @@ from annotated_types import Annotated, Ge
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 from pydantic.alias_generators import to_camel
 from wandb_gql import gql
-
-# these internal objects should be factored out into a separate module as a
-# shared dependency between Workspaces and Reports API
-from wandb_workspaces.expr import is_filter_v2
 from wandb_workspaces.reports.v2.internal import *  # noqa: F403
 from wandb_workspaces.reports.v2.internal import (
     PanelBankConfig,
@@ -88,25 +83,6 @@ class WorkspaceViewspec(WorkspaceAPIBaseModel):
     library_expanded: bool = True
 
 
-def _migrate_v2_filters_in_spec(spec_dict: dict) -> Dict[int, dict]:
-    """Stash raw v2 filter dicts and replace with an empty tree for Pydantic.
-
-    The frontend v2 filter UI stores filters as a flat list with inline
-    connector fields.  Pydantic can't parse that into the legacy Filters
-    model, so we stash the raw dict and swap in a default empty tree.
-
-    Returns:
-        A mapping from runset index to the original raw v2 filter dict.
-    """
-    v2_stash: Dict[int, dict] = {}
-    run_sets = spec_dict.get("section", {}).get("runSets", [])
-    for i, rs in enumerate(run_sets):
-        filters_data = rs.get("filters")
-        if filters_data and is_filter_v2(filters_data):
-            v2_stash[i] = deepcopy(filters_data)
-            rs["filters"] = {"op": "OR", "filters": [{"op": "AND"}]}
-    return v2_stash
-
 
 class View(WorkspaceAPIBaseModel):
     entity: str
@@ -130,11 +106,7 @@ class View(WorkspaceAPIBaseModel):
         id = view_dict["id"]
 
         spec_dict = json.loads(spec) if isinstance(spec, str) else spec
-        v2_stash = _migrate_v2_filters_in_spec(spec_dict)
         parsed_spec = WorkspaceViewspec.model_validate(spec_dict)
-
-        for i, raw_v2 in v2_stash.items():
-            parsed_spec.section.run_sets[i]._raw_filters_v2 = raw_v2
 
         return cls(
             entity=entity,
@@ -166,11 +138,6 @@ def upsert_view2(view: View) -> Dict[str, Any]:
     api = wandb.Api()
 
     spec_dict = view.spec.model_dump(by_alias=True, exclude_none=True)
-
-    for i, rs_model in enumerate(view.spec.section.run_sets):
-        if rs_model._raw_filters_v2 is not None:
-            spec_dict["section"]["runSets"][i]["filters"] = rs_model._raw_filters_v2
-
     spec_str = json.dumps(spec_dict)
 
     # Default: assume a new view being created, so no `id` yet


### PR DESCRIPTION
###Jira 


### Description
The wandb-workspaces SDK couldn't handle the new "v2 filter format" used by the frontend. Workspaces with v2 filters (which support OR connectors and nested groups) would silently corrupt filters on save (AND connectors were dropped and defaulted to OR because the SDK's Filters model ignores the v2 connector field).

- String filters: Users can write `or`, `and`, and `parentheses` (groups) — full v2-style expressions. Python's AST parser handles precedence and grouping, and filters_tree_to_v2 writes them correctly to the backend in v2 format.
- FilterExpr list: AND-only. [ws.Config("lr") == 0.01, ws.Metric("State") == "finished"] always produces an AND of all conditions. No way to express OR or groups.
- Read path: v2 filters (with ORs, groups) now load correctly and display as a readable string with or, and, and parentheses.
- Write path: Unchanged v2 workspaces write back the original raw dict. Modified v2 workspaces re-convert through the tree and write back as v2. New/legacy workspaces still write the legacy tree format (if the v2 flag is on, we auto-convert these in the UI).

PR2 adds the programmatic API — Or(), And(), Group() objects that let you express the same things without strings, and simplifies the write path to always use v2.

Example starts with these filters:
<img width="1165" height="504" alt="Screenshot 2026-04-27 at 3 02 22 PM" src="https://github.com/user-attachments/assets/3dbc743f-3bff-4fa9-af93-61f72eb6c141" />

Before (v2 flag ON):
Trying to load and modify v2 workspaces replaces AND connectors with default OR:
```
class Filters(ReportAPIBaseModel):
    op: Ops = "OR"
...
```

Raw v2 dict from backend:
```
    {
      "filterFormat": "filterV2",
      "filters": [
        {
          "key": {
            "section": "run",
            "name": "displayName"
          },
          "op": "=",
          "value": "willow",
          "disabled": false
        },
        {
          "key": {
            "section": "run",
            "name": "displayName"
          },
          "op": "=",
          "value": "champagne-problems",
          "disabled": false,
          "connector": "OR"
        },
        {
          "filters": [
            {
              "key": {
                "section": "run",
                "name": "displayName"
              },
              "op": "=",
              "value": "gold-rush",
              "disabled": false
            },
            {
              "key": {
                "section": "run",
                "name": "state"
              },
              "op": "=",
              "value": "finished",
              "disabled": false,
              "connector": "AND"
            }
          ],
          "connector": "OR"
        }
      ]
    }

```

Load a v2 workspace, AND connector is dropped and defaulted to OR:
```
{
  "op": "OR",
  "key": null,
  "filters": [
    {
      "op": "=",
      "key": {
        "section": "run",
        "name": "displayName"
      },
      "filters": null,
      "value": "willow",
      "disabled": false,
      "current": null
    },
    {
      "op": "=",
      "key": {
        "section": "run",
        "name": "displayName"
      },
      "filters": null,
      "value": "champagne-problems",
      "disabled": false,
      "current": null
    },
    {
      "op": "OR", <--- should be "AND"!
      "key": null,
      "filters": [
        {
          "op": "=",
          "key": {
            "section": "run",
            "name": "displayName"
          },
          "filters": null,
          "value": "gold-rush",
          "disabled": false,
          "current": null
        },
        {
          "op": "=",
          "key": {
            "section": "run",
            "name": "state"
          },
          "filters": null,
          "value": "finished",
          "disabled": false,
          "current": null
        }
      ],
      "value": null,
      "disabled": null,
      "current": null
    }
  ],
  "value": null,
  "disabled": null,
  "current": null
}

```

If we try to modify the filters
<img width="1165" height="504" alt="Screenshot 2026-04-27 at 3 02 22 PM" src="https://github.com/user-attachments/assets/3dbc743f-3bff-4fa9-af93-61f72eb6c141" />


with 

```
workspace.runset_settings.filters = (
    'Metric(\"Name\") == \"willow\"'
    ' and Metric(\"Name\") == \"champagne-problems\"'
    ' and (Metric(\"Name\") == \"folklore\" or Metric(\"State\") == \"finished\")'
)

```
We get the legacy version written back (which is then converted to v2 filters in the UI, but in a flattened format):
<img width="1000" height="445" alt="Screenshot 2026-04-27 at 3 10 17 PM" src="https://github.com/user-attachments/assets/ccb9338f-025e-4c14-be61-423a43b99200" />



After (v2 flag ON):
Load a v2 workspace, verify OR connectors are preserved in the string
Filters loaded from backend:
```
 {
  "filterFormat": "filterV2",
  "filters": [
    {
      "key": {
        "section": "run",
        "name": "displayName"
      },
      "op": "=",
      "value": "willow",
      "disabled": false
    },
    {
      "key": {
        "section": "run",
        "name": "displayName"
      },
      "op": "=",
      "value": "champagne-problems",
      "disabled": false,
      "connector": "OR"
    },
    {
      "filters": [
        {
          "key": {
            "section": "run",
            "name": "displayName"
          },
          "op": "=",
          "value": "gold-rush",
          "disabled": false
        },
        {
          "key": {
            "section": "run",
            "name": "state"
          },
          "op": "=",
          "value": "finished",
          "disabled": false,
          "connector": "AND"
        }
      ],
      "connector": "OR"
    }
  ]
}
```

Modify a v2 workspace with new OR/group filters, verify v2 format written back
We run

```
workspace.runset_settings.filters = (
    'Metric(\"Name\") == \"willow\"'
    ' and Metric(\"Name\") == \"champagne-problems\"'
    ' and (Metric(\"Name\") == \"folklore\" or Metric(\"State\") == \"finished\")'
)

```
and get:
<img width="1152" height="489" alt="Screenshot 2026-04-27 at 3 19 03 PM" src="https://github.com/user-attachments/assets/292e7d19-c2c0-46af-ad5b-9cbddfd5f8d9" />

Creating a new workspace with v2 filters produces flattened filters and converts to v2 in the UI through migration code:

https://github.com/user-attachments/assets/4db2fece-da45-4487-9c46-ccb07df658a4


## Test plan

- [x] Existing filter tests pass (AND-only filters unchanged)
- [x] New v2 round-trip tests pass (v2 → tree → v2)
- [x] OR string parsing tests pass
- [x] Or/And/Group object API tests pass (internal, not in RunsetSettings)
- [x] Manual end-to-end test: load v2 workspace, verify OR filters preserved, save back in v2 format
- [x] Manual end-to-end test: load legacy workspace, verify AND-only filters preserved, save back in legacy format
