### PR TITLE
fix: Attempts to handle all R/T errors with reports migrations

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -582,6 +582,43 @@ def test_media_browser_explicit_mode_with_both_axes():
     assert restored.mode == "grid"
 
 
+def test_media_browser_extra_config_round_trip():
+    """Known MediaBrowser panels must preserve frontend-owned config fields."""
+    from wandb_workspaces.reports.v2 import internal
+
+    payload = {
+        "viewType": "Media Browser",
+        "config": {
+            "chartTitle": "Image Samples",
+            "columnCount": 5,
+            "mediaKeys": ["examples/image"],
+            "mode": "grid",
+            "gridSettings": {"xAxis": "step", "yAxis": "run"},
+            "actualSize": True,
+            "fitToDimension": "width",
+            "pixelated": True,
+            "stepIndex": 5,
+            "maxGalleryItems": 100,
+            "maxRuns": 20,
+            "videoPlaybackSyncEnabled": True,
+        },
+        "layout": {"x": 0, "y": 0, "w": 12, "h": 8},
+    }
+
+    parsed = internal._validate_panel_from_dict(payload)
+    assert isinstance(parsed, internal.MediaBrowser)
+
+    round_tripped = wr.MediaBrowser._from_model(parsed)._to_model()
+    config = round_tripped.config.model_dump(by_alias=True, exclude_none=True)
+    assert config["actualSize"] is True
+    assert config["fitToDimension"] == "width"
+    assert config["pixelated"] is True
+    assert config["stepIndex"] == 5
+    assert config["maxGalleryItems"] == 100
+    assert config["maxRuns"] == 20
+    assert config["videoPlaybackSyncEnabled"] is True
+
+
 def test_runset_query_parameter():
     """Test that Runset query parameter is properly passed through to internal model"""
     from wandb_workspaces.reports.v2 import internal
@@ -611,6 +648,142 @@ def test_runset_query_parameter():
     mock_runset_empty_search = internal.Runset(name="test", search=mock_empty_search)
     reconstructed_empty_search = wr.Runset._from_model(mock_runset_empty_search)
     assert reconstructed_empty_search.query == ""
+
+
+def test_runset_round_trip_preserves_unmodeled_fields():
+    """Loaded runset fields without public SDK attrs should not reset on save."""
+    from wandb_workspaces.reports.v2 import internal
+
+    model = internal.Runset.model_validate(
+        {
+            "id": "rs-test",
+            "runFeed": {
+                "version": 2,
+                "columnVisible": {"run:name": True, "config:lr": True},
+                "columnPinned": {"run:displayName": True, "config:lr": True},
+                "columnWidths": {"run:name": 200},
+                "columnOrder": ["run:displayName", "config:lr"],
+                "pageSize": 25,
+                "onlyShowSelected": True,
+            },
+            "enabled": False,
+            "name": "Custom Run Set",
+            "search": {"query": "best", "isRegex": True},
+            "filters": {"op": "OR", "filters": [{"op": "AND", "filters": []}]},
+            "grouping": [{"section": "config", "name": "epochs"}],
+            "sort": {
+                "keys": [
+                    {"key": {"section": "summary", "name": "loss"}, "ascending": True}
+                ]
+            },
+            "selections": {
+                "root": 1,
+                "bounds": [{"key": {"section": "run", "name": "createdAt"}}],
+                "tree": ["run-abc"],
+            },
+            "expandedRowAddresses": ["0/run-abc"],
+        }
+    )
+
+    round_tripped = wr.Runset._from_model(model)._to_model()
+    dumped = round_tripped.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["runFeed"]["columnVisible"] == {
+        "run:name": True,
+        "config:lr": True,
+    }
+    assert dumped["runFeed"]["columnPinned"] == {
+        "run:displayName": True,
+        "config:lr": True,
+    }
+    assert dumped["runFeed"]["columnWidths"] == {"run:name": 200}
+    assert dumped["runFeed"]["columnOrder"] == ["run:displayName", "config:lr"]
+    assert dumped["runFeed"]["pageSize"] == 25
+    assert dumped["runFeed"]["onlyShowSelected"] is True
+    assert dumped["enabled"] is False
+    assert dumped["search"]["isRegex"] is True
+    assert dumped["grouping"] == [{"section": "config", "name": "epochs"}]
+    assert dumped["selections"]["bounds"] == [
+        {"key": {"section": "run", "name": "createdAt"}}
+    ]
+    assert dumped["expandedRowAddresses"] == ["0/run-abc"]
+
+
+def test_runset_additive_selection_tree_round_trip_preserves_shape():
+    """Additive grouped selections should not be flattened on an unchanged save."""
+    from wandb_workspaces.reports.v2 import internal
+
+    model = internal.Runset.model_validate(
+        {
+            "id": "rs-test",
+            "selections": {
+                "root": 0,
+                "bounds": [],
+                "tree": [
+                    {
+                        "value": "group-a",
+                        "children": ["run-a", "run-b"],
+                        "skip": False,
+                    }
+                ],
+            },
+        }
+    )
+
+    round_tripped = wr.Runset._from_model(model)._to_model()
+    dumped = round_tripped.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["selections"]["root"] == 0
+    assert dumped["selections"]["tree"] == [
+        {
+            "value": "group-a",
+            "children": ["run-a", "run-b"],
+            "skip": False,
+        }
+    ]
+
+
+def test_runset_config_sort_preserves_backend_value_position():
+    """Config sort keys should keep exact backend paths unless order changes."""
+    from wandb_workspaces.reports.v2 import internal
+
+    model = internal.Runset.model_validate(
+        {
+            "id": "rs-test",
+            "sort": {
+                "keys": [
+                    {
+                        "key": {
+                            "section": "config",
+                            "name": "pbt.workspace.value",
+                        },
+                        "ascending": True,
+                    },
+                    {
+                        "key": {
+                            "section": "config",
+                            "name": "pbt.value.workspace",
+                        },
+                        "ascending": False,
+                    },
+                ]
+            },
+        }
+    )
+
+    round_tripped = wr.Runset._from_model(model)._to_model()
+    dumped = round_tripped.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["sort"]["keys"] == [
+        {
+            "key": {"section": "config", "name": "pbt.workspace.value"},
+            "ascending": True,
+        },
+        {
+            "key": {"section": "config", "name": "pbt.value.workspace"},
+            "ascending": False,
+        },
+    ]
 
 
 def test_metric_to_backend_groupby():

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -618,6 +618,43 @@ def test_media_browser_explicit_mode_with_both_axes():
     assert restored.mode == "grid"
 
 
+def test_media_browser_extra_config_round_trip():
+    """Known MediaBrowser panels must preserve frontend-owned config fields."""
+    from wandb_workspaces.reports.v2 import internal
+
+    payload = {
+        "viewType": "Media Browser",
+        "config": {
+            "chartTitle": "Image Samples",
+            "columnCount": 5,
+            "mediaKeys": ["examples/image"],
+            "mode": "grid",
+            "gridSettings": {"xAxis": "step", "yAxis": "run"},
+            "actualSize": True,
+            "fitToDimension": "width",
+            "pixelated": True,
+            "stepIndex": 5,
+            "maxGalleryItems": 100,
+            "maxRuns": 20,
+            "videoPlaybackSyncEnabled": True,
+        },
+        "layout": {"x": 0, "y": 0, "w": 12, "h": 8},
+    }
+
+    parsed = internal._validate_panel_from_dict(payload)
+    assert isinstance(parsed, internal.MediaBrowser)
+
+    round_tripped = wr.MediaBrowser._from_model(parsed)._to_model()
+    config = round_tripped.config.model_dump(by_alias=True, exclude_none=True)
+    assert config["actualSize"] is True
+    assert config["fitToDimension"] == "width"
+    assert config["pixelated"] is True
+    assert config["stepIndex"] == 5
+    assert config["maxGalleryItems"] == 100
+    assert config["maxRuns"] == 20
+    assert config["videoPlaybackSyncEnabled"] is True
+
+
 def test_runset_query_parameter():
     """Test that Runset query parameter is properly passed through to internal model"""
     from wandb_workspaces.reports.v2 import internal
@@ -647,6 +684,142 @@ def test_runset_query_parameter():
     mock_runset_empty_search = internal.Runset(name="test", search=mock_empty_search)
     reconstructed_empty_search = wr.Runset._from_model(mock_runset_empty_search)
     assert reconstructed_empty_search.query == ""
+
+
+def test_runset_round_trip_preserves_unmodeled_fields():
+    """Loaded runset fields without public SDK attrs should not reset on save."""
+    from wandb_workspaces.reports.v2 import internal
+
+    model = internal.Runset.model_validate(
+        {
+            "id": "rs-test",
+            "runFeed": {
+                "version": 2,
+                "columnVisible": {"run:name": True, "config:lr": True},
+                "columnPinned": {"run:displayName": True, "config:lr": True},
+                "columnWidths": {"run:name": 200},
+                "columnOrder": ["run:displayName", "config:lr"],
+                "pageSize": 25,
+                "onlyShowSelected": True,
+            },
+            "enabled": False,
+            "name": "Custom Run Set",
+            "search": {"query": "best", "isRegex": True},
+            "filters": {"op": "OR", "filters": [{"op": "AND", "filters": []}]},
+            "grouping": [{"section": "config", "name": "epochs"}],
+            "sort": {
+                "keys": [
+                    {"key": {"section": "summary", "name": "loss"}, "ascending": True}
+                ]
+            },
+            "selections": {
+                "root": 1,
+                "bounds": [{"key": {"section": "run", "name": "createdAt"}}],
+                "tree": ["run-abc"],
+            },
+            "expandedRowAddresses": ["0/run-abc"],
+        }
+    )
+
+    round_tripped = wr.Runset._from_model(model)._to_model()
+    dumped = round_tripped.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["runFeed"]["columnVisible"] == {
+        "run:name": True,
+        "config:lr": True,
+    }
+    assert dumped["runFeed"]["columnPinned"] == {
+        "run:displayName": True,
+        "config:lr": True,
+    }
+    assert dumped["runFeed"]["columnWidths"] == {"run:name": 200}
+    assert dumped["runFeed"]["columnOrder"] == ["run:displayName", "config:lr"]
+    assert dumped["runFeed"]["pageSize"] == 25
+    assert dumped["runFeed"]["onlyShowSelected"] is True
+    assert dumped["enabled"] is False
+    assert dumped["search"]["isRegex"] is True
+    assert dumped["grouping"] == [{"section": "config", "name": "epochs"}]
+    assert dumped["selections"]["bounds"] == [
+        {"key": {"section": "run", "name": "createdAt"}}
+    ]
+    assert dumped["expandedRowAddresses"] == ["0/run-abc"]
+
+
+def test_runset_additive_selection_tree_round_trip_preserves_shape():
+    """Additive grouped selections should not be flattened on an unchanged save."""
+    from wandb_workspaces.reports.v2 import internal
+
+    model = internal.Runset.model_validate(
+        {
+            "id": "rs-test",
+            "selections": {
+                "root": 0,
+                "bounds": [],
+                "tree": [
+                    {
+                        "value": "group-a",
+                        "children": ["run-a", "run-b"],
+                        "skip": False,
+                    }
+                ],
+            },
+        }
+    )
+
+    round_tripped = wr.Runset._from_model(model)._to_model()
+    dumped = round_tripped.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["selections"]["root"] == 0
+    assert dumped["selections"]["tree"] == [
+        {
+            "value": "group-a",
+            "children": ["run-a", "run-b"],
+            "skip": False,
+        }
+    ]
+
+
+def test_runset_config_sort_preserves_backend_value_position():
+    """Config sort keys should keep exact backend paths unless order changes."""
+    from wandb_workspaces.reports.v2 import internal
+
+    model = internal.Runset.model_validate(
+        {
+            "id": "rs-test",
+            "sort": {
+                "keys": [
+                    {
+                        "key": {
+                            "section": "config",
+                            "name": "pbt.workspace.value",
+                        },
+                        "ascending": True,
+                    },
+                    {
+                        "key": {
+                            "section": "config",
+                            "name": "pbt.value.workspace",
+                        },
+                        "ascending": False,
+                    },
+                ]
+            },
+        }
+    )
+
+    round_tripped = wr.Runset._from_model(model)._to_model()
+    dumped = round_tripped.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["sort"]["keys"] == [
+        {
+            "key": {"section": "config", "name": "pbt.workspace.value"},
+            "ascending": True,
+        },
+        {
+            "key": {"section": "config", "name": "pbt.value.workspace"},
+            "ascending": False,
+        },
+    ]
 
 
 def test_metric_to_backend_groupby():

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -779,6 +779,23 @@ def test_runset_additive_selection_tree_round_trip_preserves_shape():
     ]
 
 
+def test_runset_additive_selection_tree_adds_new_visible_run():
+    """With root=0, a new enabled run setting must be added to selections.tree."""
+    from wandb_workspaces.reports.v2 import internal
+
+    model = internal.Runset(
+        id="rs-test",
+        selections=internal.RunsetSelections(root=0, tree=["run-a"]),
+    )
+    runset = wr.Runset._from_model(model)
+    runset.run_settings["run-b"] = wr.RunSettings(disabled=False)
+
+    round_tripped = runset._to_model()
+
+    assert round_tripped.selections.root == 0
+    assert sorted(round_tripped.selections.tree) == ["run-a", "run-b"]
+
+
 def test_runset_config_sort_preserves_backend_value_position():
     """Config sort keys should keep exact backend paths unless order changes."""
     from wandb_workspaces.reports.v2 import internal

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -251,6 +251,307 @@ def test_save_workspace():
         assert gql_definition.operation == "mutation"
 
 
+def test_workspace_viewspec_preserves_frontend_owned_fields():
+    """Workspace parsing should not drop current frontend-owned spec fields."""
+    from wandb_workspaces.workspaces import internal
+
+    spec = internal.WorkspaceViewspec.model_validate(
+        {
+            "section": {
+                "version": 9,
+                "panelBankConfig": {"state": 1, "settings": {}, "sections": []},
+                "panelBankSectionConfig": {},
+                "customRunColors": {},
+                "customRunNames": {"run-a": "Best Run"},
+                "workspaceSettings": {
+                    "linePlot": {"showLegend": False},
+                    "media": {"maxRuns": 5},
+                },
+                "semanticLegendSettings": {
+                    "runColorOptions": "semantic-legend",
+                    "excludedRunColor": "#cccccc",
+                },
+                "settings": {"shouldAutoGeneratePanels": "pending"},
+                "runSets": [{"id": "rs1"}],
+            },
+            "vizExpanded": True,
+            "libraryExpanded": False,
+            "slowWarningHiddenAt": "2026-01-01T00:00:00Z",
+        }
+    )
+
+    dumped = spec.model_dump(by_alias=True, exclude_none=True)
+    assert dumped["section"]["version"] == 9
+    assert dumped["section"]["customRunNames"] == {"run-a": "Best Run"}
+    assert dumped["section"]["workspaceSettings"]["linePlot"]["showLegend"] is False
+    assert dumped["section"]["workspaceSettings"]["media"]["maxRuns"] == 5
+    assert (
+        dumped["section"]["semanticLegendSettings"]["runColorOptions"]
+        == "semantic-legend"
+    )
+    assert dumped["section"]["settings"]["shouldAutoGeneratePanels"] == "pending"
+    assert dumped["slowWarningHiddenAt"] == "2026-01-01T00:00:00Z"
+
+
+def test_panel_bank_sparse_overrides_validate_and_round_trip():
+    """Current frontend sparse override fields are structured objects, not colors."""
+    model = _wr.PanelBankConfig.model_validate(
+        {
+            "state": 1,
+            "settings": {},
+            "sections": [],
+            "panelPlacementOverrides": {
+                "loss": {"sectionId": "section-1", "orderKey": "a0"}
+            },
+            "panelConfigOverrides": {
+                "loss": {
+                    "config": {"chartTitle": "Loss"},
+                    "layout": {"w": 8},
+                }
+            },
+        }
+    )
+
+    dumped = model.model_dump(by_alias=True, exclude_none=True)
+    assert dumped["panelPlacementOverrides"] == {
+        "loss": {"sectionId": "section-1", "orderKey": "a0"}
+    }
+    assert dumped["panelConfigOverrides"] == {
+        "loss": {"config": {"chartTitle": "Loss"}, "layout": {"w": 8}}
+    }
+
+
+def test_loaded_workspace_round_trip_preserves_frontend_state():
+    """Saving a loaded workspace should preserve fields the SDK does not expose."""
+    from wandb_workspaces.workspaces import internal
+
+    spec = internal.WorkspaceViewspec.model_validate(
+        {
+            "section": {
+                "name": "Original Wrapper",
+                "version": 9,
+                "panelBankConfig": {
+                    "state": 1,
+                    "settings": {
+                        "autoOrganizePrefix": 1,
+                        "showEmptySections": True,
+                        "sortAlphabetically": True,
+                        "searchQuery": "loss",
+                    },
+                    "panelPlacementOverrides": {
+                        "loss": {"sectionId": "section-1", "orderKey": "a0"}
+                    },
+                    "sections": [
+                        {
+                            "__id__": "section-1",
+                            "defaultName": "Charts",
+                            "name": "Charts",
+                            "isOpen": True,
+                            "type": "flow",
+                            "flowConfig": {
+                                "snapToColumns": False,
+                                "columnsPerPage": 4,
+                                "rowsPerPage": 5,
+                                "gutterWidth": 24,
+                                "boxWidth": 500,
+                                "boxHeight": 320,
+                                "mobileColumnsPerPage": 1,
+                            },
+                            "sorted": 1,
+                            "localPanelSettings": {
+                                "smoothingWeight": 9,
+                                "smoothingType": "gaussian",
+                                "xAxis": "_runtime",
+                                "ignoreOutliers": True,
+                            },
+                            "sectionSettings": {"linePlot": {"showLegend": False}},
+                            "panels": [],
+                            "pinned": True,
+                        }
+                    ],
+                },
+                "panelBankSectionConfig": {"pinned": False},
+                "customRunColors": {"run-a": "#ff0000"},
+                "customRunNames": {"run-a": "Best Run"},
+                "workspaceSettings": {
+                    "linePlot": {"showLegend": False},
+                    "media": {"maxRuns": 5},
+                },
+                "semanticLegendSettings": {
+                    "runColorOptions": "semantic-legend",
+                    "excludedRunColor": "#cccccc",
+                },
+                "runSets": [
+                    {
+                        "id": "rs1",
+                        "enabled": False,
+                        "runFeed": {
+                            "version": 2,
+                            "columnVisible": {"run:name": True, "config:lr": True},
+                            "columnPinned": {
+                                "run:displayName": True,
+                                "config:lr": True,
+                            },
+                            "columnWidths": {"run:name": 222},
+                            "columnOrder": [
+                                "run:displayName",
+                                "config:lr",
+                                "summary:loss",
+                            ],
+                            "pageSize": 50,
+                            "onlyShowSelected": True,
+                        },
+                        "search": {"query": "abc", "isRegex": True},
+                        "filters": {"op": "OR", "filters": [{"op": "AND"}]},
+                        "grouping": [],
+                        "sort": {
+                            "keys": [
+                                {
+                                    "key": {
+                                        "section": "run",
+                                        "name": "createdAt",
+                                    },
+                                    "ascending": False,
+                                }
+                            ]
+                        },
+                        "selections": {
+                            "root": 1,
+                            "bounds": [
+                                {"key": {"section": "run", "name": "createdAt"}}
+                            ],
+                            "tree": ["run-b"],
+                        },
+                        "expandedRowAddresses": ["0/run-b"],
+                    }
+                ],
+                "settings": {
+                    "xAxis": "_runtime",
+                    "xAxisMin": 1,
+                    "xAxisMax": 9,
+                    "smoothingType": "gaussian",
+                    "smoothingWeight": 4,
+                    "ignoreOutliers": True,
+                    "shouldAutoGeneratePanels": "pending",
+                },
+                "openRunSet": 3,
+                "openViz": False,
+            },
+            "vizExpanded": True,
+            "libraryExpanded": False,
+            "slowWarningHiddenAt": "2026-01-01T00:00:00Z",
+        }
+    )
+    view = internal.View(
+        entity="test-entity",
+        project="test-project",
+        display_name="Loaded Workspace",
+        name="nw-loaded-v",
+        id="view-id",
+        spec=spec,
+    )
+
+    workspace = ws.Workspace._from_model(view)
+    dumped = workspace._to_model().spec.model_dump(by_alias=True, exclude_none=True)
+    section = dumped["section"]
+    runset = section["runSets"][0]
+    run_feed = runset["runFeed"]
+
+    assert dumped["vizExpanded"] is True
+    assert dumped["libraryExpanded"] is False
+    assert dumped["slowWarningHiddenAt"] == "2026-01-01T00:00:00Z"
+    assert section["version"] == 9
+    assert section["openRunSet"] == 3
+    assert section["openViz"] is False
+    assert section["customRunNames"] == {"run-a": "Best Run"}
+    assert section["workspaceSettings"]["linePlot"]["showLegend"] is False
+    assert section["semanticLegendSettings"]["excludedRunColor"] == "#cccccc"
+    assert section["settings"]["shouldAutoGeneratePanels"] == "pending"
+    assert section["panelBankConfig"]["settings"]["showEmptySections"] is True
+    assert section["panelBankConfig"]["settings"]["searchQuery"] == "loss"
+    assert section["panelBankConfig"]["panelPlacementOverrides"] == {
+        "loss": {"sectionId": "section-1", "orderKey": "a0"}
+    }
+    assert (
+        section["panelBankConfig"]["sections"][0]["flowConfig"]["snapToColumns"]
+        is False
+    )
+    assert (
+        section["panelBankConfig"]["sections"][0]["flowConfig"]["mobileColumnsPerPage"]
+        == 1
+    )
+    assert section["panelBankConfig"]["sections"][0]["sorted"] == 1
+    assert section["panelBankConfig"]["sections"][0]["sectionSettings"] == {
+        "linePlot": {"showLegend": False}
+    }
+    assert runset["enabled"] is False
+    assert runset["expandedRowAddresses"] == ["0/run-b"]
+    assert runset["selections"]["bounds"] == [
+        {"key": {"section": "run", "name": "createdAt"}}
+    ]
+    assert run_feed["columnVisible"] == {"run:name": True, "config:lr": True}
+    assert run_feed["columnWidths"] == {"run:name": 222}
+    assert run_feed["pageSize"] == 50
+    assert run_feed["onlyShowSelected"] is True
+    assert section["customRunColors"] == {"run-a": "#ff0000"}
+
+
+def test_loaded_workspace_preserves_additive_selection_tree():
+    """Color-only run settings should not flatten additive grouped selections."""
+    from wandb_workspaces.workspaces import internal
+
+    spec = internal.WorkspaceViewspec.model_validate(
+        {
+            "section": {
+                "panelBankConfig": {"state": 1, "settings": {}, "sections": []},
+                "panelBankSectionConfig": {},
+                "customRunColors": {"run-color": "#00ff00"},
+                "runSets": [
+                    {
+                        "id": "rs1",
+                        "selections": {
+                            "root": 0,
+                            "bounds": [],
+                            "tree": [
+                                {
+                                    "value": "group-a",
+                                    "children": ["run-a", "run-b"],
+                                    "skip": False,
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        }
+    )
+    view = internal.View(
+        entity="test-entity",
+        project="test-project",
+        display_name="Loaded Workspace",
+        name="nw-loaded-v",
+        id="view-id",
+        spec=spec,
+    )
+
+    dumped = (
+        ws.Workspace._from_model(view)
+        ._to_model()
+        .spec.model_dump(by_alias=True, exclude_none=True)
+    )
+    selections = dumped["section"]["runSets"][0]["selections"]
+
+    assert selections["root"] == 0
+    assert selections["tree"] == [
+        {
+            "value": "group-a",
+            "children": ["run-a", "run-b"],
+            "skip": False,
+        }
+    ]
+    assert dumped["section"]["customRunColors"] == {"run-color": "#00ff00"}
+
+
 @pytest.mark.parametrize(
     "example, should_pass",
     [

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -514,7 +514,7 @@ def test_loaded_workspace_round_trip_preserves_frontend_state():
 
 
 def test_loaded_workspace_preserves_additive_selection_tree():
-    """Color-only run settings should not flatten additive grouped selections."""
+    """Unchanged additive grouped selections should not be flattened."""
     from wandb_workspaces.workspaces import internal
 
     spec = internal.WorkspaceViewspec.model_validate(
@@ -522,7 +522,7 @@ def test_loaded_workspace_preserves_additive_selection_tree():
             "section": {
                 "panelBankConfig": {"state": 1, "settings": {}, "sections": []},
                 "panelBankSectionConfig": {},
-                "customRunColors": {"run-color": "#00ff00"},
+                "customRunColors": {},
                 "runSets": [
                     {
                         "id": "rs1",
@@ -566,7 +566,73 @@ def test_loaded_workspace_preserves_additive_selection_tree():
             "skip": False,
         }
     ]
-    assert dumped["section"]["customRunColors"] == {"run-color": "#00ff00"}
+
+
+def test_loaded_workspace_additive_selection_tree_adds_new_visible_run():
+    """With root=0, a new enabled run setting must be added to selections.tree."""
+    from wandb_workspaces.workspaces import internal
+
+    spec = internal.WorkspaceViewspec.model_validate(
+        {
+            "section": {
+                "panelBankConfig": {"state": 1, "settings": {}, "sections": []},
+                "panelBankSectionConfig": {},
+                "customRunColors": {},
+                "runSets": [
+                    {
+                        "id": "rs1",
+                        "selections": {"root": 0, "bounds": [], "tree": ["run-a"]},
+                    }
+                ],
+            }
+        }
+    )
+    view = internal.View(
+        entity="test-entity",
+        project="test-project",
+        display_name="Loaded Workspace",
+        name="nw-loaded-v",
+        id="view-id",
+        spec=spec,
+    )
+    workspace = ws.Workspace._from_model(view)
+    workspace.runset_settings.run_settings["run-b"] = ws.RunSettings(disabled=False)
+
+    dumped = workspace._to_model().spec.model_dump(by_alias=True, exclude_none=True)
+    selections = dumped["section"]["runSets"][0]["selections"]
+
+    assert selections["root"] == 0
+    assert sorted(selections["tree"]) == ["run-a", "run-b"]
+
+
+def test_loaded_workspace_clears_existing_custom_run_color():
+    """Clearing a run setting color should remove the old viewspec color."""
+    from wandb_workspaces.workspaces import internal
+
+    spec = internal.WorkspaceViewspec.model_validate(
+        {
+            "section": {
+                "panelBankConfig": {"state": 1, "settings": {}, "sections": []},
+                "panelBankSectionConfig": {},
+                "customRunColors": {"run-a": "#ff0000"},
+                "runSets": [{"id": "rs1"}],
+            }
+        }
+    )
+    view = internal.View(
+        entity="test-entity",
+        project="test-project",
+        display_name="Loaded Workspace",
+        name="nw-loaded-v",
+        id="view-id",
+        spec=spec,
+    )
+    workspace = ws.Workspace._from_model(view)
+    workspace.runset_settings.run_settings["run-a"].color = ""
+
+    dumped = workspace._to_model().spec.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["section"]["customRunColors"] == {}
 
 
 @pytest.mark.parametrize(
@@ -703,6 +769,59 @@ def test_column_pinning():
         "run:displayName",
         "summary:accuracy",
     ]
+
+
+def test_loaded_workspace_updated_pinned_columns_replace_column_order():
+    """Changing pinned columns after load should write the new pinned order."""
+    from wandb_workspaces.workspaces import internal
+
+    spec = internal.WorkspaceViewspec.model_validate(
+        {
+            "section": {
+                "panelBankConfig": {"state": 1, "settings": {}, "sections": []},
+                "panelBankSectionConfig": {},
+                "customRunColors": {},
+                "runSets": [
+                    {
+                        "id": "rs1",
+                        "runFeed": {
+                            "columnVisible": {
+                                "run:displayName": True,
+                                "summary:old": True,
+                            },
+                            "columnPinned": {
+                                "run:displayName": True,
+                                "summary:old": True,
+                            },
+                            "columnOrder": ["run:displayName", "summary:old"],
+                        },
+                    }
+                ],
+            }
+        }
+    )
+    view = internal.View(
+        entity="test-entity",
+        project="test-project",
+        display_name="Loaded Workspace",
+        name="nw-loaded-v",
+        id="view-id",
+        spec=spec,
+    )
+    workspace = ws.Workspace._from_model(view)
+    workspace.runset_settings.pinned_columns = ["run:displayName", "summary:new"]
+
+    run_feed = workspace._to_model().spec.section.run_sets[0].run_feed
+
+    assert run_feed.column_pinned == {
+        "run:displayName": True,
+        "summary:new": True,
+    }
+    assert run_feed.column_visible == {
+        "run:displayName": True,
+        "summary:new": True,
+    }
+    assert run_feed.column_order == ["run:displayName", "summary:new"]
 
 
 def test_empty_column_settings():

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -514,7 +514,7 @@ def test_loaded_workspace_round_trip_preserves_frontend_state():
 
 
 def test_loaded_workspace_preserves_additive_selection_tree():
-    """Unchanged additive grouped selections should not be flattened."""
+    """Color-only run settings should not flatten additive grouped selections."""
     from wandb_workspaces.workspaces import internal
 
     spec = internal.WorkspaceViewspec.model_validate(
@@ -522,7 +522,7 @@ def test_loaded_workspace_preserves_additive_selection_tree():
             "section": {
                 "panelBankConfig": {"state": 1, "settings": {}, "sections": []},
                 "panelBankSectionConfig": {},
-                "customRunColors": {},
+                "customRunColors": {"run-color": "#00ff00"},
                 "runSets": [
                     {
                         "id": "rs1",
@@ -566,6 +566,7 @@ def test_loaded_workspace_preserves_additive_selection_tree():
             "skip": False,
         }
     ]
+    assert dumped["section"]["customRunColors"] == {"run-color": "#00ff00"}
 
 
 def test_loaded_workspace_additive_selection_tree_adds_new_visible_run():

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -268,6 +268,307 @@ def test_workspace_url_uses_service_api_app_url_without_client():
         assert workspace.url == "https://service.wandb.test/ent/proj?nw=abc123"
 
 
+def test_workspace_viewspec_preserves_frontend_owned_fields():
+    """Workspace parsing should not drop current frontend-owned spec fields."""
+    from wandb_workspaces.workspaces import internal
+
+    spec = internal.WorkspaceViewspec.model_validate(
+        {
+            "section": {
+                "version": 9,
+                "panelBankConfig": {"state": 1, "settings": {}, "sections": []},
+                "panelBankSectionConfig": {},
+                "customRunColors": {},
+                "customRunNames": {"run-a": "Best Run"},
+                "workspaceSettings": {
+                    "linePlot": {"showLegend": False},
+                    "media": {"maxRuns": 5},
+                },
+                "semanticLegendSettings": {
+                    "runColorOptions": "semantic-legend",
+                    "excludedRunColor": "#cccccc",
+                },
+                "settings": {"shouldAutoGeneratePanels": "pending"},
+                "runSets": [{"id": "rs1"}],
+            },
+            "vizExpanded": True,
+            "libraryExpanded": False,
+            "slowWarningHiddenAt": "2026-01-01T00:00:00Z",
+        }
+    )
+
+    dumped = spec.model_dump(by_alias=True, exclude_none=True)
+    assert dumped["section"]["version"] == 9
+    assert dumped["section"]["customRunNames"] == {"run-a": "Best Run"}
+    assert dumped["section"]["workspaceSettings"]["linePlot"]["showLegend"] is False
+    assert dumped["section"]["workspaceSettings"]["media"]["maxRuns"] == 5
+    assert (
+        dumped["section"]["semanticLegendSettings"]["runColorOptions"]
+        == "semantic-legend"
+    )
+    assert dumped["section"]["settings"]["shouldAutoGeneratePanels"] == "pending"
+    assert dumped["slowWarningHiddenAt"] == "2026-01-01T00:00:00Z"
+
+
+def test_panel_bank_sparse_overrides_validate_and_round_trip():
+    """Current frontend sparse override fields are structured objects, not colors."""
+    model = _wr.PanelBankConfig.model_validate(
+        {
+            "state": 1,
+            "settings": {},
+            "sections": [],
+            "panelPlacementOverrides": {
+                "loss": {"sectionId": "section-1", "orderKey": "a0"}
+            },
+            "panelConfigOverrides": {
+                "loss": {
+                    "config": {"chartTitle": "Loss"},
+                    "layout": {"w": 8},
+                }
+            },
+        }
+    )
+
+    dumped = model.model_dump(by_alias=True, exclude_none=True)
+    assert dumped["panelPlacementOverrides"] == {
+        "loss": {"sectionId": "section-1", "orderKey": "a0"}
+    }
+    assert dumped["panelConfigOverrides"] == {
+        "loss": {"config": {"chartTitle": "Loss"}, "layout": {"w": 8}}
+    }
+
+
+def test_loaded_workspace_round_trip_preserves_frontend_state():
+    """Saving a loaded workspace should preserve fields the SDK does not expose."""
+    from wandb_workspaces.workspaces import internal
+
+    spec = internal.WorkspaceViewspec.model_validate(
+        {
+            "section": {
+                "name": "Original Wrapper",
+                "version": 9,
+                "panelBankConfig": {
+                    "state": 1,
+                    "settings": {
+                        "autoOrganizePrefix": 1,
+                        "showEmptySections": True,
+                        "sortAlphabetically": True,
+                        "searchQuery": "loss",
+                    },
+                    "panelPlacementOverrides": {
+                        "loss": {"sectionId": "section-1", "orderKey": "a0"}
+                    },
+                    "sections": [
+                        {
+                            "__id__": "section-1",
+                            "defaultName": "Charts",
+                            "name": "Charts",
+                            "isOpen": True,
+                            "type": "flow",
+                            "flowConfig": {
+                                "snapToColumns": False,
+                                "columnsPerPage": 4,
+                                "rowsPerPage": 5,
+                                "gutterWidth": 24,
+                                "boxWidth": 500,
+                                "boxHeight": 320,
+                                "mobileColumnsPerPage": 1,
+                            },
+                            "sorted": 1,
+                            "localPanelSettings": {
+                                "smoothingWeight": 9,
+                                "smoothingType": "gaussian",
+                                "xAxis": "_runtime",
+                                "ignoreOutliers": True,
+                            },
+                            "sectionSettings": {"linePlot": {"showLegend": False}},
+                            "panels": [],
+                            "pinned": True,
+                        }
+                    ],
+                },
+                "panelBankSectionConfig": {"pinned": False},
+                "customRunColors": {"run-a": "#ff0000"},
+                "customRunNames": {"run-a": "Best Run"},
+                "workspaceSettings": {
+                    "linePlot": {"showLegend": False},
+                    "media": {"maxRuns": 5},
+                },
+                "semanticLegendSettings": {
+                    "runColorOptions": "semantic-legend",
+                    "excludedRunColor": "#cccccc",
+                },
+                "runSets": [
+                    {
+                        "id": "rs1",
+                        "enabled": False,
+                        "runFeed": {
+                            "version": 2,
+                            "columnVisible": {"run:name": True, "config:lr": True},
+                            "columnPinned": {
+                                "run:displayName": True,
+                                "config:lr": True,
+                            },
+                            "columnWidths": {"run:name": 222},
+                            "columnOrder": [
+                                "run:displayName",
+                                "config:lr",
+                                "summary:loss",
+                            ],
+                            "pageSize": 50,
+                            "onlyShowSelected": True,
+                        },
+                        "search": {"query": "abc", "isRegex": True},
+                        "filters": {"op": "OR", "filters": [{"op": "AND"}]},
+                        "grouping": [],
+                        "sort": {
+                            "keys": [
+                                {
+                                    "key": {
+                                        "section": "run",
+                                        "name": "createdAt",
+                                    },
+                                    "ascending": False,
+                                }
+                            ]
+                        },
+                        "selections": {
+                            "root": 1,
+                            "bounds": [
+                                {"key": {"section": "run", "name": "createdAt"}}
+                            ],
+                            "tree": ["run-b"],
+                        },
+                        "expandedRowAddresses": ["0/run-b"],
+                    }
+                ],
+                "settings": {
+                    "xAxis": "_runtime",
+                    "xAxisMin": 1,
+                    "xAxisMax": 9,
+                    "smoothingType": "gaussian",
+                    "smoothingWeight": 4,
+                    "ignoreOutliers": True,
+                    "shouldAutoGeneratePanels": "pending",
+                },
+                "openRunSet": 3,
+                "openViz": False,
+            },
+            "vizExpanded": True,
+            "libraryExpanded": False,
+            "slowWarningHiddenAt": "2026-01-01T00:00:00Z",
+        }
+    )
+    view = internal.View(
+        entity="test-entity",
+        project="test-project",
+        display_name="Loaded Workspace",
+        name="nw-loaded-v",
+        id="view-id",
+        spec=spec,
+    )
+
+    workspace = ws.Workspace._from_model(view)
+    dumped = workspace._to_model().spec.model_dump(by_alias=True, exclude_none=True)
+    section = dumped["section"]
+    runset = section["runSets"][0]
+    run_feed = runset["runFeed"]
+
+    assert dumped["vizExpanded"] is True
+    assert dumped["libraryExpanded"] is False
+    assert dumped["slowWarningHiddenAt"] == "2026-01-01T00:00:00Z"
+    assert section["version"] == 9
+    assert section["openRunSet"] == 3
+    assert section["openViz"] is False
+    assert section["customRunNames"] == {"run-a": "Best Run"}
+    assert section["workspaceSettings"]["linePlot"]["showLegend"] is False
+    assert section["semanticLegendSettings"]["excludedRunColor"] == "#cccccc"
+    assert section["settings"]["shouldAutoGeneratePanels"] == "pending"
+    assert section["panelBankConfig"]["settings"]["showEmptySections"] is True
+    assert section["panelBankConfig"]["settings"]["searchQuery"] == "loss"
+    assert section["panelBankConfig"]["panelPlacementOverrides"] == {
+        "loss": {"sectionId": "section-1", "orderKey": "a0"}
+    }
+    assert (
+        section["panelBankConfig"]["sections"][0]["flowConfig"]["snapToColumns"]
+        is False
+    )
+    assert (
+        section["panelBankConfig"]["sections"][0]["flowConfig"]["mobileColumnsPerPage"]
+        == 1
+    )
+    assert section["panelBankConfig"]["sections"][0]["sorted"] == 1
+    assert section["panelBankConfig"]["sections"][0]["sectionSettings"] == {
+        "linePlot": {"showLegend": False}
+    }
+    assert runset["enabled"] is False
+    assert runset["expandedRowAddresses"] == ["0/run-b"]
+    assert runset["selections"]["bounds"] == [
+        {"key": {"section": "run", "name": "createdAt"}}
+    ]
+    assert run_feed["columnVisible"] == {"run:name": True, "config:lr": True}
+    assert run_feed["columnWidths"] == {"run:name": 222}
+    assert run_feed["pageSize"] == 50
+    assert run_feed["onlyShowSelected"] is True
+    assert section["customRunColors"] == {"run-a": "#ff0000"}
+
+
+def test_loaded_workspace_preserves_additive_selection_tree():
+    """Color-only run settings should not flatten additive grouped selections."""
+    from wandb_workspaces.workspaces import internal
+
+    spec = internal.WorkspaceViewspec.model_validate(
+        {
+            "section": {
+                "panelBankConfig": {"state": 1, "settings": {}, "sections": []},
+                "panelBankSectionConfig": {},
+                "customRunColors": {"run-color": "#00ff00"},
+                "runSets": [
+                    {
+                        "id": "rs1",
+                        "selections": {
+                            "root": 0,
+                            "bounds": [],
+                            "tree": [
+                                {
+                                    "value": "group-a",
+                                    "children": ["run-a", "run-b"],
+                                    "skip": False,
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        }
+    )
+    view = internal.View(
+        entity="test-entity",
+        project="test-project",
+        display_name="Loaded Workspace",
+        name="nw-loaded-v",
+        id="view-id",
+        spec=spec,
+    )
+
+    dumped = (
+        ws.Workspace._from_model(view)
+        ._to_model()
+        .spec.model_dump(by_alias=True, exclude_none=True)
+    )
+    selections = dumped["section"]["runSets"][0]["selections"]
+
+    assert selections["root"] == 0
+    assert selections["tree"] == [
+        {
+            "value": "group-a",
+            "children": ["run-a", "run-b"],
+            "skip": False,
+        }
+    ]
+    assert dumped["section"]["customRunColors"] == {"run-color": "#00ff00"}
+
+
 @pytest.mark.parametrize(
     "example, should_pass",
     [

--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -33,6 +33,7 @@ class ReportAPIBaseModel(BaseModel):
         validate_assignment=True,
         populate_by_name=True,
         arbitrary_types_allowed=True,
+        extra="allow",
     )
 
 

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -943,6 +943,59 @@ class OrderBy(Base):
         )
 
 
+def _groupby_key_to_frontend(key: internal.Key) -> str:
+    if key.section == "config":
+        parts = key.name.split(".")
+        if "value" in parts:
+            parts.remove("value")
+        return f"config.{'.'.join(parts)}"
+    if key.section == "summary":
+        return f"summary.{expr.to_frontend_name(key.name)}"
+    if key.section == "run":
+        return expr.to_frontend_name(key.name)
+    return f"{key.section}.{expr.to_frontend_name(key.name)}"
+
+
+def _order_by_identity(order: OrderBy) -> Tuple[str, str, bool]:
+    name = order.name
+    if isinstance(name, Config):
+        return ("config", name.name, order.ascending)
+    if isinstance(name, SummaryMetric):
+        return ("summary", name.name, order.ascending)
+    if isinstance(name, Metric):
+        return ("run", name.name, order.ascending)
+    return ("run", str(name), order.ascending)
+
+
+def _sort_key_to_order_identity(sort_key: internal.SortKey) -> Tuple[str, str, bool]:
+    return _order_by_identity(OrderBy._from_model(sort_key))
+
+
+def _selection_disabled_map(
+    selections: internal.RunsetSelections,
+) -> Dict[str, bool]:
+    is_disabled = selections.root != 0
+    disabled = {}
+    for item in selections.tree:
+        if isinstance(item, str):
+            disabled[item] = is_disabled
+        else:
+            for child_id in item.children:
+                disabled[child_id] = is_disabled
+    return disabled
+
+
+def _current_selection_disabled_map(
+    run_settings: Dict[str, "RunSettings"],
+    original_disabled: Dict[str, bool],
+) -> Dict[str, bool]:
+    return {
+        run_id: settings.disabled
+        for run_id, settings in run_settings.items()
+        if settings.disabled or run_id in original_disabled
+    }
+
+
 @dataclass(config=dataclass_config, repr=False)
 class Runset(Base):
     """A set of runs to display in a panel grid.
@@ -1009,6 +1062,9 @@ class Runset(Base):
     _selections_root: int = Field(default=1, init=False, repr=False)
 
     _filters_internal: Optional["expr.Filters"] = Field(
+        default=None, init=False, repr=False
+    )
+    _runset_internal: Optional[internal.Runset] = Field(
         default=None, init=False, repr=False
     )
 
@@ -1087,17 +1143,53 @@ class Runset(Base):
         else:
             filters = expr.expr_to_filters(self.filters)
 
-        obj = internal.Runset(
-            project=project,
-            name=self.name,
-            search=internal.RunsetSearch(query=self.query),
-            filters=filters,
-            grouping=[expr.groupby_str_to_key(g) for g in self.groupby],
-            sort=internal.Sort(keys=[o._to_model() for o in self.order]),
-            selections=internal.RunsetSelections(
-                root=self._selections_root, tree=tree_ids
-            ),
+        obj = (
+            self._runset_internal.model_copy(deep=True)
+            if self._runset_internal is not None
+            else internal.Runset()
         )
+        obj.project = project
+        obj.name = self.name
+
+        search = (
+            obj.search.model_copy(deep=True)
+            if obj.search is not None
+            else internal.RunsetSearch()
+        )
+        search.query = self.query
+        obj.search = search
+
+        grouping_unchanged = self._runset_internal is not None and self.groupby == [
+            _groupby_key_to_frontend(k) for k in self._runset_internal.grouping
+        ]
+        if not grouping_unchanged:
+            obj.grouping = [expr.groupby_str_to_key(g) for g in self.groupby]
+
+        selections = (
+            obj.selections.model_copy(deep=True)
+            if obj.selections is not None
+            else internal.RunsetSelections()
+        )
+        original_disabled = (
+            _selection_disabled_map(self._runset_internal.selections)
+            if self._runset_internal is not None
+            else {}
+        )
+        current_disabled = _current_selection_disabled_map(
+            self.run_settings, original_disabled
+        )
+        if self._runset_internal is None or current_disabled != original_disabled:
+            selections.root = self._selections_root
+            selections.tree = tree_ids
+
+        sort_unchanged = self._runset_internal is not None and [
+            _order_by_identity(o) for o in self.order
+        ] == [_sort_key_to_order_identity(s) for s in self._runset_internal.sort.keys]
+        if not sort_unchanged:
+            obj.sort = internal.Sort(keys=[o._to_model() for o in self.order])
+
+        obj.filters = filters
+        obj.selections = selections
         obj.id = self._id
         return obj
 
@@ -1131,13 +1223,14 @@ class Runset(Base):
             name=model.name,
             query=model.search.query if model.search else "",
             filters=expr.filters_to_expr(model.filters),
-            groupby=[expr.to_frontend_name(k.name) for k in model.grouping],
+            groupby=[_groupby_key_to_frontend(k) for k in model.grouping],
             order=[OrderBy._from_model(s) for s in model.sort.keys],
             run_settings=run_settings,
         )
         obj._id = model.id
         obj._selections_root = model.selections.root
         obj._filters_internal = model.filters
+        obj._runset_internal = model
         return obj
 
 
@@ -1189,6 +1282,9 @@ class PanelGrid(Block):
     _panel_bank_sections: LList[Dict] = Field(
         default_factory=list, init=False, repr=False
     )
+    _metadata_internal: Optional[internal.PanelGridMetadata] = Field(
+        default=None, init=False, repr=False
+    )
 
     def _to_model(self):
         # Merge custom_run_colors from runsets, with PanelGrid colors taking precedence
@@ -1202,20 +1298,26 @@ class PanelGrid(Block):
             merged_colors.update(rs.custom_run_colors)
         merged_colors.update(self.custom_run_colors)
 
-        return internal.PanelGrid(
-            metadata=internal.PanelGridMetadata(
-                run_sets=[rs._to_model() for rs in self.runsets],
-                hide_run_sets=self.hide_run_sets,
-                panel_bank_section_config=internal.PanelBankSectionConfig(
-                    panels=[p._to_model() for p in self.panels],
-                ),
-                panels=internal.PanelGridMetadataPanels(
-                    panel_bank_config=internal.PanelBankConfig(),
-                    open_viz=self._open_viz,
-                ),
-                custom_run_colors=_to_color_dict(merged_colors, self.runsets),
-            )
+        metadata = (
+            self._metadata_internal.model_copy(deep=True)
+            if self._metadata_internal is not None
+            else internal.PanelGridMetadata()
         )
+        panel_bank_section_config = (
+            metadata.panel_bank_section_config.model_copy(deep=True)
+            if metadata.panel_bank_section_config is not None
+            else internal.PanelBankSectionConfig()
+        )
+        panel_bank_section_config.panels = [p._to_model() for p in self.panels]
+
+        metadata.run_sets = [rs._to_model() for rs in self.runsets]
+        metadata.hide_run_sets = self.hide_run_sets
+        metadata.open_run_set = self.active_runset
+        metadata.open_viz = self._open_viz
+        metadata.panel_bank_section_config = panel_bank_section_config
+        metadata.custom_run_colors = _to_color_dict(merged_colors, self.runsets)
+
+        return internal.PanelGrid(metadata=metadata)
 
     @classmethod
     def _from_model(cls, model: internal.PanelGrid):
@@ -1250,6 +1352,7 @@ class PanelGrid(Block):
             # _panel_bank_sections=model.metadata.panel_bank_config.sections,
         )
         obj._open_viz = model.metadata.open_viz
+        obj._metadata_internal = model.metadata
         return obj
 
     @validator("panels")
@@ -2015,46 +2118,54 @@ class LinePlot(Panel):
     line_colors: Optional[Dict[str, Any]] = None
     line_widths: Optional[Dict[str, float]] = None
     line_marks: Optional[Dict[str, Mark]] = None
+    _config_internal: Optional[internal.LinePlotConfig] = Field(
+        default=None, init=False, repr=False
+    )
 
     def _to_model(self):
+        config = (
+            self._config_internal.model_copy(deep=True)
+            if self._config_internal is not None
+            else internal.LinePlotConfig()
+        )
+        config.chart_title = self.title
+        config.x_axis = _metric_to_backend(self.x)
+        config.metrics = [_metric_to_backend(name) for name in _listify(self.y)]
+        config.x_axis_min = self.range_x[0]
+        config.x_axis_max = self.range_x[1]
+        config.y_axis_min = self.range_y[0]
+        config.y_axis_max = self.range_y[1]
+        config.x_log_scale = self.log_x
+        config.y_log_scale = self.log_y
+        config.x_axis_title = self.title_x
+        config.y_axis_title = self.title_y
+        config.ignore_outliers = self.ignore_outliers
+        config.group_by = _metric_to_backend_groupby(self.groupby)
+        config.group_agg = self.groupby_aggfunc
+        config.group_area = self.groupby_rangefunc
+        config.smoothing_weight = self.smoothing_factor
+        config.smoothing_type = self.smoothing_type
+        config.show_original_after_smoothing = self.smoothing_show_original
+        config.limit = self.max_runs_to_show
+        config.expressions = self.custom_expressions
+        config.plot_type = self.plot_type
+        config.font_size = self.font_size
+        config.legend_position = self.legend_position
+        config.legend_template = self.legend_template
+        config.aggregate = self.groupby not in (None, "None") or self.aggregate
+        config.x_expression = self.xaxis_expression
+        config.x_axis_format = self.xaxis_format
+        config.legend_fields = self.legend_fields
+        config.metric_regex = self.metric_regex
+        config.use_metric_regex = True if self.metric_regex else None
+        config.point_visualization_method = self.point_visualization_method
+        config.override_series_titles = self.line_titles
+        config.override_colors = _normalize_color_overrides(self.line_colors)
+        config.override_line_widths = self.line_widths
+        config.override_marks = self.line_marks
+
         return internal.LinePlot(
-            config=internal.LinePlotConfig(
-                chart_title=self.title,
-                x_axis=_metric_to_backend(self.x),
-                metrics=[_metric_to_backend(name) for name in _listify(self.y)],
-                x_axis_min=self.range_x[0],
-                x_axis_max=self.range_x[1],
-                y_axis_min=self.range_y[0],
-                y_axis_max=self.range_y[1],
-                x_log_scale=self.log_x,
-                y_log_scale=self.log_y,
-                x_axis_title=self.title_x,
-                y_axis_title=self.title_y,
-                ignore_outliers=self.ignore_outliers,
-                group_by=_metric_to_backend_groupby(self.groupby),
-                group_agg=self.groupby_aggfunc,
-                group_area=self.groupby_rangefunc,
-                smoothing_weight=self.smoothing_factor,
-                smoothing_type=self.smoothing_type,
-                show_original_after_smoothing=self.smoothing_show_original,
-                limit=self.max_runs_to_show,
-                expressions=self.custom_expressions,
-                plot_type=self.plot_type,
-                font_size=self.font_size,
-                legend_position=self.legend_position,
-                legend_template=self.legend_template,
-                aggregate=self.groupby not in (None, "None") or self.aggregate,
-                x_expression=self.xaxis_expression,
-                x_axis_format=self.xaxis_format,
-                legend_fields=self.legend_fields,
-                metric_regex=self.metric_regex,
-                use_metric_regex=True if self.metric_regex else None,
-                point_visualization_method=self.point_visualization_method,
-                override_series_titles=self.line_titles,
-                override_colors=_normalize_color_overrides(self.line_colors),
-                override_line_widths=self.line_widths,
-                override_marks=self.line_marks,
-            ),
+            config=config,
             id=self._id,
             layout=self.layout._to_model(),
         )
@@ -2110,6 +2221,7 @@ class LinePlot(Panel):
         object.__setattr__(obj, "line_colors", model.config.override_colors)
         object.__setattr__(obj, "line_widths", model.config.override_line_widths)
         object.__setattr__(obj, "line_marks", model.config.override_marks)
+        object.__setattr__(obj, "_config_internal", model.config)
         return obj
 
 
@@ -2158,35 +2270,43 @@ class ScatterPlot(Panel):
     gradient: Optional[LList[GradientPoint]] = None
     font_size: Optional[FontSize] = None
     regression: Optional[bool] = None
+    _config_internal: Optional[internal.ScatterPlotConfig] = Field(
+        default=None, init=False, repr=False
+    )
 
     def _to_model(self):
         custom_gradient = self.gradient
         if custom_gradient is not None:
             custom_gradient = [cgp._to_model() for cgp in self.gradient]
 
+        config = (
+            self._config_internal.model_copy(deep=True)
+            if self._config_internal is not None
+            else internal.ScatterPlotConfig()
+        )
+        config.chart_title = self.title
+        config.x_axis = _metric_to_backend_pc(self.x)
+        config.y_axis = _metric_to_backend_pc(self.y)
+        config.z_axis = _metric_to_backend_pc(self.z)
+        config.x_axis_min = self.range_x[0]
+        config.x_axis_max = self.range_x[1]
+        config.y_axis_min = self.range_y[0]
+        config.y_axis_max = self.range_y[1]
+        config.z_axis_min = self.range_z[0]
+        config.z_axis_max = self.range_z[1]
+        config.x_axis_log_scale = self.log_x
+        config.y_axis_log_scale = self.log_y
+        config.z_axis_log_scale = self.log_z
+        config.show_min_y_axis_line = self.running_ymin
+        config.show_max_y_axis_line = self.running_ymax
+        config.show_avg_y_axis_line = self.running_ymean
+        config.legend_template = self.legend_template
+        config.custom_gradient = custom_gradient
+        config.font_size = self.font_size
+        config.show_linear_regression = self.regression
+
         return internal.ScatterPlot(
-            config=internal.ScatterPlotConfig(
-                chart_title=self.title,
-                x_axis=_metric_to_backend_pc(self.x),
-                y_axis=_metric_to_backend_pc(self.y),
-                z_axis=_metric_to_backend_pc(self.z),
-                x_axis_min=self.range_x[0],
-                x_axis_max=self.range_x[1],
-                y_axis_min=self.range_y[0],
-                y_axis_max=self.range_y[1],
-                z_axis_min=self.range_z[0],
-                z_axis_max=self.range_z[1],
-                x_axis_log_scale=self.log_x,
-                y_axis_log_scale=self.log_y,
-                z_axis_log_scale=self.log_z,
-                show_min_y_axis_line=self.running_ymin,
-                show_max_y_axis_line=self.running_ymax,
-                show_avg_y_axis_line=self.running_ymean,
-                legend_template=self.legend_template,
-                custom_gradient=custom_gradient,
-                font_size=self.font_size,
-                show_linear_regression=self.regression,
-            ),
+            config=config,
             layout=self.layout._to_model(),
             id=self._id,
         )
@@ -2218,6 +2338,7 @@ class ScatterPlot(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._config_internal = model.config
         return obj
 
 
@@ -2267,29 +2388,37 @@ class BarPlot(Panel):
     line_titles: Optional[dict] = None
     line_colors: Optional[dict] = None
     aggregate: Optional[bool] = None
+    _config_internal: Optional[internal.BarPlotConfig] = Field(
+        default=None, init=False, repr=False
+    )
 
     def _to_model(self):
+        config = (
+            self._config_internal.model_copy(deep=True)
+            if self._config_internal is not None
+            else internal.BarPlotConfig()
+        )
+        config.chart_title = self.title
+        config.metrics = [_metric_to_backend(name) for name in _listify(self.metrics)]
+        config.vertical = self.orientation == "v"
+        config.x_axis_min = self.range_x[0]
+        config.x_axis_max = self.range_x[1]
+        config.x_axis_title = self.title_x
+        config.y_axis_title = self.title_y
+        config.group_by = _metric_to_backend_groupby(self.groupby)
+        config.group_agg = self.groupby_aggfunc
+        config.group_area = self.groupby_rangefunc
+        config.limit = self.max_runs_to_show
+        config.bar_limit = self.max_bars_to_show
+        config.expressions = self.custom_expressions
+        config.legend_template = self.legend_template
+        config.font_size = self.font_size
+        config.override_series_titles = self.line_titles
+        config.override_colors = _normalize_color_overrides(self.line_colors)
+        config.aggregate = self.groupby not in (None, "None") or self.aggregate
+
         return internal.BarPlot(
-            config=internal.BarPlotConfig(
-                chart_title=self.title,
-                metrics=[_metric_to_backend(name) for name in _listify(self.metrics)],
-                vertical=self.orientation == "v",
-                x_axis_min=self.range_x[0],
-                x_axis_max=self.range_x[1],
-                x_axis_title=self.title_x,
-                y_axis_title=self.title_y,
-                group_by=_metric_to_backend_groupby(self.groupby),
-                group_agg=self.groupby_aggfunc,
-                group_area=self.groupby_rangefunc,
-                limit=self.max_runs_to_show,
-                bar_limit=self.max_bars_to_show,
-                expressions=self.custom_expressions,
-                legend_template=self.legend_template,
-                font_size=self.font_size,
-                override_series_titles=self.line_titles,
-                override_colors=_normalize_color_overrides(self.line_colors),
-                aggregate=self.groupby not in (None, "None") or self.aggregate,
-            ),
+            config=config,
             layout=self.layout._to_model(),
             id=self._id,
         )
@@ -2317,6 +2446,7 @@ class BarPlot(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._config_internal = model.config
         return obj
 
 
@@ -2591,6 +2721,9 @@ class MediaBrowser(Panel):
     gallery_axis: Optional[Literal["step", "index", "run"]] = None
     grid_x_axis: Optional[Literal["step", "index", "run"]] = None
     grid_y_axis: Optional[Literal["step", "index", "run"]] = None
+    _config_internal: Optional[internal.MediaBrowserConfig] = Field(
+        default=None, init=False, repr=False
+    )
 
     def _to_model(self):
         gallery_settings = None
@@ -2620,15 +2753,20 @@ class MediaBrowser(Panel):
             if mode is None:
                 mode = "grid"
 
+        config = (
+            self._config_internal.model_copy(deep=True)
+            if self._config_internal is not None
+            else internal.MediaBrowserConfig()
+        )
+        config.chart_title = self.title
+        config.column_count = self.num_columns
+        config.media_keys = self.media_keys
+        config.mode = mode
+        config.gallery_settings = gallery_settings
+        config.grid_settings = grid_settings
+
         return internal.MediaBrowser(
-            config=internal.MediaBrowserConfig(
-                chart_title=self.title,
-                column_count=self.num_columns,
-                media_keys=self.media_keys,
-                mode=mode,
-                gallery_settings=gallery_settings,
-                grid_settings=grid_settings,
-            ),
+            config=config,
             layout=self.layout._to_model(),
             id=self._id,
         )
@@ -2657,6 +2795,7 @@ class MediaBrowser(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._config_internal = model.config
 
         return obj
 

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -951,6 +951,59 @@ class OrderBy(Base):
         )
 
 
+def _groupby_key_to_frontend(key: internal.Key) -> str:
+    if key.section == "config":
+        parts = key.name.split(".")
+        if "value" in parts:
+            parts.remove("value")
+        return f"config.{'.'.join(parts)}"
+    if key.section == "summary":
+        return f"summary.{expr.to_frontend_name(key.name)}"
+    if key.section == "run":
+        return expr.to_frontend_name(key.name)
+    return f"{key.section}.{expr.to_frontend_name(key.name)}"
+
+
+def _order_by_identity(order: OrderBy) -> Tuple[str, str, bool]:
+    name = order.name
+    if isinstance(name, Config):
+        return ("config", name.name, order.ascending)
+    if isinstance(name, SummaryMetric):
+        return ("summary", name.name, order.ascending)
+    if isinstance(name, Metric):
+        return ("run", name.name, order.ascending)
+    return ("run", str(name), order.ascending)
+
+
+def _sort_key_to_order_identity(sort_key: internal.SortKey) -> Tuple[str, str, bool]:
+    return _order_by_identity(OrderBy._from_model(sort_key))
+
+
+def _selection_disabled_map(
+    selections: internal.RunsetSelections,
+) -> Dict[str, bool]:
+    is_disabled = selections.root != 0
+    disabled = {}
+    for item in selections.tree:
+        if isinstance(item, str):
+            disabled[item] = is_disabled
+        else:
+            for child_id in item.children:
+                disabled[child_id] = is_disabled
+    return disabled
+
+
+def _current_selection_disabled_map(
+    run_settings: Dict[str, "RunSettings"],
+    original_disabled: Dict[str, bool],
+) -> Dict[str, bool]:
+    return {
+        run_id: settings.disabled
+        for run_id, settings in run_settings.items()
+        if settings.disabled or run_id in original_disabled
+    }
+
+
 @dataclass(config=dataclass_config, repr=False)
 class Runset(Base):
     """A set of runs to display in a panel grid.
@@ -1060,6 +1113,9 @@ class Runset(Base):
 
     # Stashed RunFeed; lets _to_model preserve non-column fields on round-trip.
     _run_feed_loaded: Optional["internal.RunFeed"] = Field(
+        default=None, init=False, repr=False
+    )
+    _runset_internal: Optional[internal.Runset] = Field(
         default=None, init=False, repr=False
     )
 
@@ -1203,22 +1259,94 @@ class Runset(Base):
         # Start from the stashed RunFeed so non-column fields (page_size,
         # only_show_selected, future additions) survive round-trip.
         if self._run_feed_loaded is not None:
-            run_feed = self._run_feed_loaded.model_copy(update=col_fields)
+            loaded_rf = self._run_feed_loaded
+            loaded_pinned = [
+                col for col, is_pinned in loaded_rf.column_pinned.items() if is_pinned
+            ]
+            loaded_pinned_set = set(loaded_pinned)
+            loaded_hidden = [
+                col
+                for col, is_visible in loaded_rf.column_visible.items()
+                if is_visible is False
+            ]
+            loaded_hidden_set = set(loaded_hidden)
+            loaded_visible_from_order = [
+                col
+                for col in loaded_rf.column_order
+                if col not in loaded_pinned_set and col not in loaded_hidden_set
+            ]
+            loaded_visible_from_dict = [
+                col
+                for col, is_visible in loaded_rf.column_visible.items()
+                if is_visible is True
+                and col not in loaded_pinned_set
+                and col not in set(loaded_visible_from_order)
+            ]
+            columns_unchanged = (
+                self.pinned_columns == loaded_pinned
+                and self.visible_columns
+                == loaded_visible_from_order + loaded_visible_from_dict
+                and self.hidden_columns == loaded_hidden
+                and self.column_order == list(loaded_rf.column_order)
+                and self.column_widths == dict(loaded_rf.column_widths)
+                and self.lock_columns == loaded_rf.lock_columns
+            )
+            run_feed = (
+                loaded_rf.model_copy(deep=True)
+                if columns_unchanged
+                else loaded_rf.model_copy(deep=True, update=col_fields)
+            )
         else:
             run_feed = internal.RunFeed(**col_fields)
 
-        obj = internal.Runset(
-            project=project,
-            name=self.name,
-            search=internal.RunsetSearch(query=self.query),
-            filters=filters_value,
-            grouping=[expr.groupby_str_to_key(g) for g in self.groupby],
-            sort=internal.Sort(keys=[o._to_model() for o in self.order]),
-            selections=internal.RunsetSelections(
-                root=self._selections_root, tree=tree_ids
-            ),
-            run_feed=run_feed,
+        obj = (
+            self._runset_internal.model_copy(deep=True)
+            if self._runset_internal is not None
+            else internal.Runset()
         )
+        obj.project = project
+        obj.name = self.name
+
+        search = (
+            obj.search.model_copy(deep=True)
+            if obj.search is not None
+            else internal.RunsetSearch()
+        )
+        search.query = self.query
+        obj.search = search
+
+        grouping_unchanged = self._runset_internal is not None and self.groupby == [
+            _groupby_key_to_frontend(k) for k in self._runset_internal.grouping
+        ]
+        if not grouping_unchanged:
+            obj.grouping = [expr.groupby_str_to_key(g) for g in self.groupby]
+
+        selections = (
+            obj.selections.model_copy(deep=True)
+            if obj.selections is not None
+            else internal.RunsetSelections()
+        )
+        original_disabled = (
+            _selection_disabled_map(self._runset_internal.selections)
+            if self._runset_internal is not None
+            else {}
+        )
+        current_disabled = _current_selection_disabled_map(
+            self.run_settings, original_disabled
+        )
+        if self._runset_internal is None or current_disabled != original_disabled:
+            selections.root = self._selections_root
+            selections.tree = tree_ids
+
+        sort_unchanged = self._runset_internal is not None and [
+            _order_by_identity(o) for o in self.order
+        ] == [_sort_key_to_order_identity(s) for s in self._runset_internal.sort.keys]
+        if not sort_unchanged:
+            obj.sort = internal.Sort(keys=[o._to_model() for o in self.order])
+
+        obj.filters = filters_value
+        obj.selections = selections
+        obj.run_feed = run_feed
         obj.id = self._id
         return obj
 
@@ -1283,7 +1411,7 @@ class Runset(Base):
             name=model.name,
             query=model.search.query if model.search else "",
             filters=filter_string,
-            groupby=[expr.to_frontend_name(k.name) for k in model.grouping],
+            groupby=[_groupby_key_to_frontend(k) for k in model.grouping],
             order=[OrderBy._from_model(s) for s in model.sort.keys],
             run_settings=run_settings,
             pinned_columns=pinned_columns,
@@ -1298,6 +1426,7 @@ class Runset(Base):
         obj._stashed_filters_v2 = stashed_v2
         obj._stashed_filter_string = filter_string
         obj._run_feed_loaded = rf.model_copy(deep=True)
+        obj._runset_internal = model
         return obj
 
 
@@ -1349,6 +1478,9 @@ class PanelGrid(Block):
     _panel_bank_sections: LList[Dict] = Field(
         default_factory=list, init=False, repr=False
     )
+    _metadata_internal: Optional[internal.PanelGridMetadata] = Field(
+        default=None, init=False, repr=False
+    )
 
     def _to_model(self):
         # Merge custom_run_colors from runsets, with PanelGrid colors taking precedence
@@ -1362,20 +1494,26 @@ class PanelGrid(Block):
             merged_colors.update(rs.custom_run_colors)
         merged_colors.update(self.custom_run_colors)
 
-        return internal.PanelGrid(
-            metadata=internal.PanelGridMetadata(
-                run_sets=[rs._to_model() for rs in self.runsets],
-                hide_run_sets=self.hide_run_sets,
-                panel_bank_section_config=internal.PanelBankSectionConfig(
-                    panels=[p._to_model() for p in self.panels],
-                ),
-                panels=internal.PanelGridMetadataPanels(
-                    panel_bank_config=internal.PanelBankConfig(),
-                    open_viz=self._open_viz,
-                ),
-                custom_run_colors=_to_color_dict(merged_colors, self.runsets),
-            )
+        metadata = (
+            self._metadata_internal.model_copy(deep=True)
+            if self._metadata_internal is not None
+            else internal.PanelGridMetadata()
         )
+        panel_bank_section_config = (
+            metadata.panel_bank_section_config.model_copy(deep=True)
+            if metadata.panel_bank_section_config is not None
+            else internal.PanelBankSectionConfig()
+        )
+        panel_bank_section_config.panels = [p._to_model() for p in self.panels]
+
+        metadata.run_sets = [rs._to_model() for rs in self.runsets]
+        metadata.hide_run_sets = self.hide_run_sets
+        metadata.open_run_set = self.active_runset
+        metadata.open_viz = self._open_viz
+        metadata.panel_bank_section_config = panel_bank_section_config
+        metadata.custom_run_colors = _to_color_dict(merged_colors, self.runsets)
+
+        return internal.PanelGrid(metadata=metadata)
 
     @classmethod
     def _from_model(cls, model: internal.PanelGrid):
@@ -1410,6 +1548,7 @@ class PanelGrid(Block):
             # _panel_bank_sections=model.metadata.panel_bank_config.sections,
         )
         obj._open_viz = model.metadata.open_viz
+        obj._metadata_internal = model.metadata
         return obj
 
     @validator("panels")
@@ -2175,46 +2314,54 @@ class LinePlot(Panel):
     line_colors: Optional[Dict[str, Any]] = None
     line_widths: Optional[Dict[str, float]] = None
     line_marks: Optional[Dict[str, Mark]] = None
+    _config_internal: Optional[internal.LinePlotConfig] = Field(
+        default=None, init=False, repr=False
+    )
 
     def _to_model(self):
+        config = (
+            self._config_internal.model_copy(deep=True)
+            if self._config_internal is not None
+            else internal.LinePlotConfig()
+        )
+        config.chart_title = self.title
+        config.x_axis = _metric_to_backend(self.x)
+        config.metrics = [_metric_to_backend(name) for name in _listify(self.y)]
+        config.x_axis_min = self.range_x[0]
+        config.x_axis_max = self.range_x[1]
+        config.y_axis_min = self.range_y[0]
+        config.y_axis_max = self.range_y[1]
+        config.x_log_scale = self.log_x
+        config.y_log_scale = self.log_y
+        config.x_axis_title = self.title_x
+        config.y_axis_title = self.title_y
+        config.ignore_outliers = self.ignore_outliers
+        config.group_by = _metric_to_backend_groupby(self.groupby)
+        config.group_agg = self.groupby_aggfunc
+        config.group_area = self.groupby_rangefunc
+        config.smoothing_weight = self.smoothing_factor
+        config.smoothing_type = self.smoothing_type
+        config.show_original_after_smoothing = self.smoothing_show_original
+        config.limit = self.max_runs_to_show
+        config.expressions = self.custom_expressions
+        config.plot_type = self.plot_type
+        config.font_size = self.font_size
+        config.legend_position = self.legend_position
+        config.legend_template = self.legend_template
+        config.aggregate = self.groupby not in (None, "None") or self.aggregate
+        config.x_expression = self.xaxis_expression
+        config.x_axis_format = self.xaxis_format
+        config.legend_fields = self.legend_fields
+        config.metric_regex = self.metric_regex
+        config.use_metric_regex = True if self.metric_regex else None
+        config.point_visualization_method = self.point_visualization_method
+        config.override_series_titles = self.line_titles
+        config.override_colors = _normalize_color_overrides(self.line_colors)
+        config.override_line_widths = self.line_widths
+        config.override_marks = self.line_marks
+
         return internal.LinePlot(
-            config=internal.LinePlotConfig(
-                chart_title=self.title,
-                x_axis=_metric_to_backend(self.x),
-                metrics=[_metric_to_backend(name) for name in _listify(self.y)],
-                x_axis_min=self.range_x[0],
-                x_axis_max=self.range_x[1],
-                y_axis_min=self.range_y[0],
-                y_axis_max=self.range_y[1],
-                x_log_scale=self.log_x,
-                y_log_scale=self.log_y,
-                x_axis_title=self.title_x,
-                y_axis_title=self.title_y,
-                ignore_outliers=self.ignore_outliers,
-                group_by=_metric_to_backend_groupby(self.groupby),
-                group_agg=self.groupby_aggfunc,
-                group_area=self.groupby_rangefunc,
-                smoothing_weight=self.smoothing_factor,
-                smoothing_type=self.smoothing_type,
-                show_original_after_smoothing=self.smoothing_show_original,
-                limit=self.max_runs_to_show,
-                expressions=self.custom_expressions,
-                plot_type=self.plot_type,
-                font_size=self.font_size,
-                legend_position=self.legend_position,
-                legend_template=self.legend_template,
-                aggregate=self.groupby not in (None, "None") or self.aggregate,
-                x_expression=self.xaxis_expression,
-                x_axis_format=self.xaxis_format,
-                legend_fields=self.legend_fields,
-                metric_regex=self.metric_regex,
-                use_metric_regex=True if self.metric_regex else None,
-                point_visualization_method=self.point_visualization_method,
-                override_series_titles=self.line_titles,
-                override_colors=_normalize_color_overrides(self.line_colors),
-                override_line_widths=self.line_widths,
-                override_marks=self.line_marks,
-            ),
+            config=config,
             id=self._id,
             layout=self.layout._to_model(),
         )
@@ -2270,6 +2417,7 @@ class LinePlot(Panel):
         object.__setattr__(obj, "line_colors", model.config.override_colors)
         object.__setattr__(obj, "line_widths", model.config.override_line_widths)
         object.__setattr__(obj, "line_marks", model.config.override_marks)
+        object.__setattr__(obj, "_config_internal", model.config)
         return obj
 
 
@@ -2318,35 +2466,43 @@ class ScatterPlot(Panel):
     gradient: Optional[LList[GradientPoint]] = None
     font_size: Optional[FontSize] = None
     regression: Optional[bool] = None
+    _config_internal: Optional[internal.ScatterPlotConfig] = Field(
+        default=None, init=False, repr=False
+    )
 
     def _to_model(self):
         custom_gradient = self.gradient
         if custom_gradient is not None:
             custom_gradient = [cgp._to_model() for cgp in self.gradient]
 
+        config = (
+            self._config_internal.model_copy(deep=True)
+            if self._config_internal is not None
+            else internal.ScatterPlotConfig()
+        )
+        config.chart_title = self.title
+        config.x_axis = _metric_to_backend_pc(self.x)
+        config.y_axis = _metric_to_backend_pc(self.y)
+        config.z_axis = _metric_to_backend_pc(self.z)
+        config.x_axis_min = self.range_x[0]
+        config.x_axis_max = self.range_x[1]
+        config.y_axis_min = self.range_y[0]
+        config.y_axis_max = self.range_y[1]
+        config.z_axis_min = self.range_z[0]
+        config.z_axis_max = self.range_z[1]
+        config.x_axis_log_scale = self.log_x
+        config.y_axis_log_scale = self.log_y
+        config.z_axis_log_scale = self.log_z
+        config.show_min_y_axis_line = self.running_ymin
+        config.show_max_y_axis_line = self.running_ymax
+        config.show_avg_y_axis_line = self.running_ymean
+        config.legend_template = self.legend_template
+        config.custom_gradient = custom_gradient
+        config.font_size = self.font_size
+        config.show_linear_regression = self.regression
+
         return internal.ScatterPlot(
-            config=internal.ScatterPlotConfig(
-                chart_title=self.title,
-                x_axis=_metric_to_backend_pc(self.x),
-                y_axis=_metric_to_backend_pc(self.y),
-                z_axis=_metric_to_backend_pc(self.z),
-                x_axis_min=self.range_x[0],
-                x_axis_max=self.range_x[1],
-                y_axis_min=self.range_y[0],
-                y_axis_max=self.range_y[1],
-                z_axis_min=self.range_z[0],
-                z_axis_max=self.range_z[1],
-                x_axis_log_scale=self.log_x,
-                y_axis_log_scale=self.log_y,
-                z_axis_log_scale=self.log_z,
-                show_min_y_axis_line=self.running_ymin,
-                show_max_y_axis_line=self.running_ymax,
-                show_avg_y_axis_line=self.running_ymean,
-                legend_template=self.legend_template,
-                custom_gradient=custom_gradient,
-                font_size=self.font_size,
-                show_linear_regression=self.regression,
-            ),
+            config=config,
             layout=self.layout._to_model(),
             id=self._id,
         )
@@ -2378,6 +2534,7 @@ class ScatterPlot(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._config_internal = model.config
         return obj
 
 
@@ -2427,29 +2584,37 @@ class BarPlot(Panel):
     line_titles: Optional[dict] = None
     line_colors: Optional[dict] = None
     aggregate: Optional[bool] = None
+    _config_internal: Optional[internal.BarPlotConfig] = Field(
+        default=None, init=False, repr=False
+    )
 
     def _to_model(self):
+        config = (
+            self._config_internal.model_copy(deep=True)
+            if self._config_internal is not None
+            else internal.BarPlotConfig()
+        )
+        config.chart_title = self.title
+        config.metrics = [_metric_to_backend(name) for name in _listify(self.metrics)]
+        config.vertical = self.orientation == "v"
+        config.x_axis_min = self.range_x[0]
+        config.x_axis_max = self.range_x[1]
+        config.x_axis_title = self.title_x
+        config.y_axis_title = self.title_y
+        config.group_by = _metric_to_backend_groupby(self.groupby)
+        config.group_agg = self.groupby_aggfunc
+        config.group_area = self.groupby_rangefunc
+        config.limit = self.max_runs_to_show
+        config.bar_limit = self.max_bars_to_show
+        config.expressions = self.custom_expressions
+        config.legend_template = self.legend_template
+        config.font_size = self.font_size
+        config.override_series_titles = self.line_titles
+        config.override_colors = _normalize_color_overrides(self.line_colors)
+        config.aggregate = self.groupby not in (None, "None") or self.aggregate
+
         return internal.BarPlot(
-            config=internal.BarPlotConfig(
-                chart_title=self.title,
-                metrics=[_metric_to_backend(name) for name in _listify(self.metrics)],
-                vertical=self.orientation == "v",
-                x_axis_min=self.range_x[0],
-                x_axis_max=self.range_x[1],
-                x_axis_title=self.title_x,
-                y_axis_title=self.title_y,
-                group_by=_metric_to_backend_groupby(self.groupby),
-                group_agg=self.groupby_aggfunc,
-                group_area=self.groupby_rangefunc,
-                limit=self.max_runs_to_show,
-                bar_limit=self.max_bars_to_show,
-                expressions=self.custom_expressions,
-                legend_template=self.legend_template,
-                font_size=self.font_size,
-                override_series_titles=self.line_titles,
-                override_colors=_normalize_color_overrides(self.line_colors),
-                aggregate=self.groupby not in (None, "None") or self.aggregate,
-            ),
+            config=config,
             layout=self.layout._to_model(),
             id=self._id,
         )
@@ -2477,6 +2642,7 @@ class BarPlot(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._config_internal = model.config
         return obj
 
 
@@ -2751,6 +2917,9 @@ class MediaBrowser(Panel):
     gallery_axis: Optional[Literal["step", "index", "run"]] = None
     grid_x_axis: Optional[Literal["step", "index", "run"]] = None
     grid_y_axis: Optional[Literal["step", "index", "run"]] = None
+    _config_internal: Optional[internal.MediaBrowserConfig] = Field(
+        default=None, init=False, repr=False
+    )
 
     def _to_model(self):
         gallery_settings = None
@@ -2780,15 +2949,20 @@ class MediaBrowser(Panel):
             if mode is None:
                 mode = "grid"
 
+        config = (
+            self._config_internal.model_copy(deep=True)
+            if self._config_internal is not None
+            else internal.MediaBrowserConfig()
+        )
+        config.chart_title = self.title
+        config.column_count = self.num_columns
+        config.media_keys = self.media_keys
+        config.mode = mode
+        config.gallery_settings = gallery_settings
+        config.grid_settings = grid_settings
+
         return internal.MediaBrowser(
-            config=internal.MediaBrowserConfig(
-                chart_title=self.title,
-                column_count=self.num_columns,
-                media_keys=self.media_keys,
-                mode=mode,
-                gallery_settings=gallery_settings,
-                grid_settings=grid_settings,
-            ),
+            config=config,
             layout=self.layout._to_model(),
             id=self._id,
         )
@@ -2817,6 +2991,7 @@ class MediaBrowser(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._config_internal = model.config
 
         return obj
 

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -996,11 +996,20 @@ def _selection_disabled_map(
 def _current_selection_disabled_map(
     run_settings: Dict[str, "RunSettings"],
     original_disabled: Dict[str, bool],
+    selections_root: int,
 ) -> Dict[str, bool]:
     return {
         run_id: settings.disabled
         for run_id, settings in run_settings.items()
-        if settings.disabled or run_id in original_disabled
+        if
+        (
+            # root=1: tree contains hidden runs
+            (selections_root != 0 and settings.disabled)
+            # root=0: tree contains visible runs
+            or (selections_root == 0 and not settings.disabled)
+            # keep originally represented runs so removals/toggles are detected
+            or run_id in original_disabled
+        )
     }
 
 
@@ -1332,7 +1341,7 @@ class Runset(Base):
             else {}
         )
         current_disabled = _current_selection_disabled_map(
-            self.run_settings, original_disabled
+            self.run_settings, original_disabled, self._selections_root
         )
         if self._runset_internal is None or current_disabled != original_disabled:
             selections.root = self._selections_root

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -127,6 +127,7 @@ class ReportAPIBaseModel(BaseModel):
         validate_assignment=True,
         populate_by_name=True,
         arbitrary_types_allowed=True,
+        extra="allow",
     )
 
 
@@ -259,12 +260,19 @@ class PanelBankConfig(ReportAPIBaseModel):
     sections: LList[PanelBankConfigSectionsItem] = Field(
         default_factory=lambda: [PanelBankConfigSectionsItem()]
     )
+    panel_placement_overrides: Optional[Dict[str, dict]] = None
+    panel_config_overrides: Optional[Dict[str, dict]] = None
 
     # Run keys are arbitrarily added here, so add some type checking for safety
     # All run keys have the shape (key:str, value:colour)
     @root_validator(pre=True)
     def check_arbitrary_keys(cls, values):  # noqa: N805
-        fixed_keys = cls.__annotations__.keys()
+        fixed_keys = set(cls.__annotations__.keys())
+        fixed_keys.update(
+            field.alias
+            for field in cls.model_fields.values()
+            if field.alias is not None
+        )
         ignored_keys = {"ref"}
         for k, v in values.items():
             if k not in fixed_keys and k not in ignored_keys and not isinstance(v, str):

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -128,6 +128,7 @@ class ReportAPIBaseModel(BaseModel):
         validate_assignment=True,
         populate_by_name=True,
         arbitrary_types_allowed=True,
+        extra="allow",
     )
 
 
@@ -260,12 +261,19 @@ class PanelBankConfig(ReportAPIBaseModel):
     sections: LList[PanelBankConfigSectionsItem] = Field(
         default_factory=lambda: [PanelBankConfigSectionsItem()]
     )
+    panel_placement_overrides: Optional[Dict[str, dict]] = None
+    panel_config_overrides: Optional[Dict[str, dict]] = None
 
     # Run keys are arbitrarily added here, so add some type checking for safety
     # All run keys have the shape (key:str, value:colour)
     @root_validator(pre=True)
     def check_arbitrary_keys(cls, values):  # noqa: N805
-        fixed_keys = cls.__annotations__.keys()
+        fixed_keys = set(cls.__annotations__.keys())
+        fixed_keys.update(
+            field.alias
+            for field in cls.model_fields.values()
+            if field.alias is not None
+        )
         ignored_keys = {"ref"}
         for k, v in values.items():
             if k not in fixed_keys and k not in ignored_keys and not isinstance(v, str):

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -69,6 +69,29 @@ def _should_show(v):
     return False
 
 
+def _selection_disabled_map(selections: internal.RunsetSelections) -> Dict[str, bool]:
+    is_disabled = selections.root != 0
+    disabled = {}
+    for item in selections.tree:
+        if isinstance(item, str):
+            disabled[item] = is_disabled
+        else:
+            for child_id in item.children:
+                disabled[child_id] = is_disabled
+    return disabled
+
+
+def _current_selection_disabled_map(
+    run_settings: Dict[str, "RunSettings"],
+    original_disabled: Dict[str, bool],
+) -> Dict[str, bool]:
+    return {
+        run_id: settings.disabled
+        for run_id, settings in run_settings.items()
+        if settings.disabled or run_id in original_disabled
+    }
+
+
 @dataclass(config=dataclass_config, repr=False)
 class Base:
     def __repr__(self):
@@ -106,20 +129,30 @@ class SectionLayoutSettings(Base):
 
     columns: int = 3
     rows: int = 2
+    _flow_config_internal: Optional[internal.FlowConfig] = Field(
+        default=None, init=False, repr=False
+    )
 
     @classmethod
     def _from_model(cls, model: internal.FlowConfig):
-        return cls(
+        obj = cls(
             columns=model.columns_per_page,
             rows=model.rows_per_page,
         )
+        obj._flow_config_internal = model
+        return obj
 
     def _to_model(self):
-        return internal.FlowConfig(
-            snap_to_columns=True,
-            columns_per_page=self.columns,
-            rows_per_page=self.rows,
+        flow_config = (
+            self._flow_config_internal.model_copy(deep=True)
+            if self._flow_config_internal is not None
+            else internal.FlowConfig()
         )
+        flow_config.columns_per_page = self.columns
+        flow_config.rows_per_page = self.rows
+        if self._flow_config_internal is None:
+            flow_config.snap_to_columns = True
+        return flow_config
 
 
 @dataclass
@@ -147,29 +180,38 @@ class SectionPanelSettings(Base):
     # Smoothing settings
     smoothing_type: internal.SmoothingType = "none"
     smoothing_weight: Annotated[int, Ge(0)] = 0
+    _local_panel_settings_internal: Optional[internal.LocalPanelSettings] = Field(
+        default=None, init=False, repr=False
+    )
 
     @classmethod
     def _from_model(cls, model: internal.LocalPanelSettings):
         x_axis = expr._convert_be_to_fe_metric_name(model.x_axis)
 
-        return cls(
+        obj = cls(
             x_axis=x_axis,
             x_min=model.x_axis_min,
             x_max=model.x_axis_max,
             smoothing_type=model.smoothing_type,
             smoothing_weight=model.smoothing_weight,
         )
+        obj._local_panel_settings_internal = model
+        return obj
 
     def _to_model(self):
         x_axis = expr._convert_fe_to_be_metric_name(self.x_axis)
 
-        return internal.LocalPanelSettings(
-            x_axis=x_axis,
-            x_axis_min=self.x_min,
-            x_axis_max=self.x_max,
-            smoothing_type=self.smoothing_type,
-            smoothing_weight=self.smoothing_weight,
+        local_panel_settings = (
+            self._local_panel_settings_internal.model_copy(deep=True)
+            if self._local_panel_settings_internal is not None
+            else internal.LocalPanelSettings()
         )
+        local_panel_settings.x_axis = x_axis
+        local_panel_settings.x_axis_min = self.x_min
+        local_panel_settings.x_axis_max = self.x_max
+        local_panel_settings.smoothing_type = self.smoothing_type
+        local_panel_settings.smoothing_weight = self.smoothing_weight
+        return local_panel_settings
 
 
 @dataclass(config=dataclass_config, repr=False)
@@ -194,10 +236,13 @@ class Section(Base):
         default_factory=SectionLayoutSettings
     )
     panel_settings: SectionPanelSettings = Field(default_factory=SectionPanelSettings)
+    _section_internal: Optional[internal.PanelBankConfigSectionsItem] = Field(
+        default=None, init=False, repr=False
+    )
 
     @classmethod
     def _from_model(cls, model: internal.PanelBankConfigSectionsItem):
-        return cls(
+        obj = cls(
             name=model.name,
             panels=[_lookup_panel(p) for p in model.panels],
             is_open=model.is_open,
@@ -205,6 +250,8 @@ class Section(Base):
             layout_settings=SectionLayoutSettings._from_model(model.flow_config),
             panel_settings=SectionPanelSettings._from_model(model.local_panel_settings),
         )
+        obj._section_internal = model
+        return obj
 
     def _to_model(self):
         panel_models = [p._to_model() for p in self.panels]
@@ -213,14 +260,18 @@ class Section(Base):
 
         # Add warning that panel layout only works if they set section settings layout = "custom"
 
-        return internal.PanelBankConfigSectionsItem(
-            name=self.name,
-            panels=panel_models,
-            is_open=self.is_open,
-            pinned=self.pinned,
-            flow_config=flow_config,
-            local_panel_settings=local_panel_settings,
+        section = (
+            self._section_internal.model_copy(deep=True)
+            if self._section_internal is not None
+            else internal.PanelBankConfigSectionsItem()
         )
+        section.name = self.name
+        section.panels = panel_models
+        section.is_open = self.is_open
+        section.pinned = self.pinned
+        section.flow_config = flow_config
+        section.local_panel_settings = local_panel_settings
+        return section
 
 
 @dataclass(config=dataclass_config, repr=False)
@@ -459,6 +510,9 @@ class Workspace(Base):
     _internal_runset_id: str = Field("", init=False, repr=False)
     "The runset ID of the workspace."
 
+    _internal_view: Optional[internal.View] = Field(None, init=False, repr=False)
+    "The original loaded view, used to preserve frontend-owned viewspec fields."
+
     @property
     def auto_generate_panels(self) -> bool:
         return self._auto_generate_panels
@@ -487,13 +541,15 @@ class Workspace(Base):
         # construct configs from disjoint parts of settings
         run_settings = {}
 
-        disabled_runs = model.spec.section.run_sets[0].selections.tree
+        selections = model.spec.section.run_sets[0].selections
+        disabled_runs = selections.tree
+        is_disabled = selections.root != 0
         for item in disabled_runs:
             if isinstance(item, str):
-                run_settings[item] = RunSettings(disabled=True)
+                run_settings[item] = RunSettings(disabled=is_disabled)
             else:
                 for child_id in item.children:
-                    run_settings[child_id] = RunSettings(disabled=True)
+                    run_settings[child_id] = RunSettings(disabled=is_disabled)
 
         custom_run_colors = model.spec.section.custom_run_colors
         for k, v in custom_run_colors.items():
@@ -552,7 +608,12 @@ class Workspace(Base):
             point_visualization_method=point_viz_method,
             sort_panels_alphabetically=panel_bank_settings.sort_alphabetically,
             group_by_prefix=group_by_prefix,
+            panel_search_query=panel_bank_settings.search_query or "",
+            auto_expand_panel_search_results=(
+                panel_bank_settings.auto_expand_search_results or False
+            ),
         )
+        workspace_settings._panel_search_history = panel_bank_settings.search_history
 
         # Extract column settings from run_feed
         run_feed = model.spec.section.run_sets[0].run_feed
@@ -562,6 +623,9 @@ class Workspace(Base):
         ]
 
         # then construct the Workspace object
+        should_auto_generate_panels = (
+            model.spec.section.settings.should_auto_generate_panels is True
+        )
         obj = cls(
             entity=model.entity,
             project=model.project,
@@ -586,10 +650,16 @@ class Workspace(Base):
                 run_settings=run_settings,
                 pinned_columns=pinned_columns,
             ),
+            auto_generate_panels=should_auto_generate_panels,
         )
         obj._internal_name = model.name
         obj._internal_id = model.id
         obj._internal_runset_id = model.spec.section.run_sets[0].id
+        obj.runset_settings._visible_columns = [
+            col for col, is_visible in run_feed.column_visible.items() if is_visible
+        ]
+        obj.runset_settings._column_order = list(run_feed.column_order)
+        obj._internal_view = model
         return obj
 
     def _to_model(self) -> internal.View:
@@ -604,7 +674,7 @@ class Workspace(Base):
             )
 
         x_axis = expr._convert_fe_to_be_metric_name(self.settings.x_axis)
-        point_viz_method = (
+        point_viz_method: Literal["bucketing-gorilla", "sampling"] = (
             "bucketing-gorilla"
             if self.settings.point_visualization_method == "bucketing"
             else "sampling"
@@ -613,20 +683,6 @@ class Workspace(Base):
             None if not self.settings.remove_legends_from_panels else True
         )
         color_run_names = None if self.settings.tooltip_color_run_names else False
-        internal_settings = internal.ViewspecSectionSettings(
-            x_axis=x_axis,
-            x_axis_min=self.settings.x_min,
-            x_axis_max=self.settings.x_max,
-            smoothing_type=self.settings.smoothing_type,
-            smoothing_weight=self.settings.smoothing_weight,
-            ignore_outliers=self.settings.ignore_outliers,
-            suppress_legends=suppress_legends,
-            tooltip_number_of_runs=self.settings.tooltip_number_of_runs,
-            color_run_names=color_run_names,
-            max_runs=self.settings.max_runs,
-            point_visualization_method=point_viz_method,
-            should_auto_generate_panels=self.auto_generate_panels,
-        )
 
         # Convert list format (SDK) to dict format (backend) for columns
         # column_visible and column_pinned are the same (pinned columns are the only visible ones. We pass this for consistency but other columns will be visibile in the FE)
@@ -640,62 +696,147 @@ class Workspace(Base):
             else list(self.runset_settings.pinned_columns)
         )
 
-        return internal.View(
-            entity=self.entity,
-            project=self.project,
-            display_name=self.name,
-            name=self._internal_name,
-            id=self._internal_id,
-            spec=internal.WorkspaceViewspec(
-                section=internal.ViewspecSection(
-                    panel_bank_config=internal.PanelBankConfig(
-                        state=1,  # TODO: What is this?
-                        settings=internal.PanelBankConfigSettings(
-                            sort_alphabetically=self.settings.sort_panels_alphabetically,
-                            auto_organize_prefix=auto_organize_prefix,
+        if self._internal_view is not None:
+            view = self._internal_view.model_copy(deep=True)
+            view.entity = self.entity
+            view.project = self.project
+            view.display_name = self.name
+            view.name = self._internal_name
+            view.id = self._internal_id
+            section = view.spec.section
+        else:
+            view = internal.View(
+                entity=self.entity,
+                project=self.project,
+                display_name=self.name,
+                name=self._internal_name,
+                id=self._internal_id,
+                spec=internal.WorkspaceViewspec(
+                    section=internal.ViewspecSection(
+                        panel_bank_config=internal.PanelBankConfig(state=1),
+                        panel_bank_section_config=internal.PanelBankSectionConfig(
+                            pinned=False
                         ),
-                        sections=sections,
+                        custom_run_colors={},
                     ),
-                    panel_bank_section_config=internal.PanelBankSectionConfig(
-                        pinned=False
-                    ),
-                    settings=internal_settings,
-                    run_sets=[
-                        internal.Runset(
-                            id=self._internal_runset_id,
-                            run_feed=internal.RunFeed(
-                                column_pinned=column_pinned_dict,
-                                column_visible=column_visible_dict,
-                                column_order=column_order,
-                                column_widths={},  # No column widths support
-                            ),
-                            search=internal.RunsetSearch(
-                                query=self.runset_settings.query,
-                                is_regex=is_regex,
-                            ),
-                            filters=expr.expr_to_filters(
-                                self.runset_settings.filters  # type: ignore[arg-type]  # validator ensures this is always str
-                            ),
-                            grouping=[g.to_key() for g in self.runset_settings.groupby],
-                            sort=internal.Sort(
-                                keys=[o.to_key() for o in self.runset_settings.order]
-                            ),
-                            selections=internal.RunsetSelections(
-                                tree=[
-                                    id
-                                    for id, config in self.runset_settings.run_settings.items()
-                                    if config.disabled
-                                ],
-                            ),
-                        ),
-                    ],
-                    custom_run_colors={
-                        id: config.color
-                        for id, config in self.runset_settings.run_settings.items()
-                    },
                 ),
-            ),
+            )
+            section = view.spec.section
+
+        panel_bank_config = section.panel_bank_config.model_copy(deep=True)
+        panel_bank_settings = panel_bank_config.settings.model_copy(deep=True)
+        panel_bank_settings.sort_alphabetically = (
+            self.settings.sort_panels_alphabetically
         )
+        panel_bank_settings.auto_organize_prefix = auto_organize_prefix
+        if (
+            self.settings.panel_search_query
+            or panel_bank_settings.search_query is not None
+        ):
+            panel_bank_settings.search_query = self.settings.panel_search_query
+        if (
+            self.settings.auto_expand_panel_search_results
+            or panel_bank_settings.auto_expand_search_results is not None
+        ):
+            panel_bank_settings.auto_expand_search_results = (
+                self.settings.auto_expand_panel_search_results
+            )
+        if self.settings._panel_search_history is not None:
+            panel_bank_settings.search_history = self.settings._panel_search_history
+        panel_bank_config.settings = panel_bank_settings
+        panel_bank_config.sections = sections
+        section.panel_bank_config = panel_bank_config
+
+        internal_settings = section.settings.model_copy(deep=True)
+        internal_settings.x_axis = x_axis
+        internal_settings.x_axis_min = self.settings.x_min
+        internal_settings.x_axis_max = self.settings.x_max
+        internal_settings.smoothing_type = self.settings.smoothing_type
+        internal_settings.smoothing_weight = self.settings.smoothing_weight
+        internal_settings.ignore_outliers = self.settings.ignore_outliers
+        internal_settings.suppress_legends = suppress_legends
+        internal_settings.tooltip_number_of_runs = self.settings.tooltip_number_of_runs
+        internal_settings.color_run_names = color_run_names
+        internal_settings.max_runs = self.settings.max_runs
+        internal_settings.point_visualization_method = point_viz_method
+        if (
+            self._internal_view is None
+            or self.auto_generate_panels
+            or internal_settings.should_auto_generate_panels in (False, None)
+        ):
+            internal_settings.should_auto_generate_panels = self.auto_generate_panels
+        section.settings = internal_settings
+
+        run_sets = list(section.run_sets)
+        runset = run_sets[0].model_copy(deep=True) if run_sets else internal.Runset()
+        runset.id = self._internal_runset_id
+
+        run_feed = runset.run_feed.model_copy(deep=True)
+        original_pinned_columns = [
+            col for col, is_pinned in run_feed.column_pinned.items() if is_pinned
+        ]
+        pinned_columns_changed = (
+            self._internal_view is None
+            or self.runset_settings.pinned_columns != original_pinned_columns
+        )
+        if pinned_columns_changed:
+            run_feed.column_pinned = column_pinned_dict
+            run_feed.column_visible = column_visible_dict
+            run_feed.column_order = column_order
+            if self._internal_view is None:
+                run_feed.column_widths = {}
+        runset.run_feed = run_feed
+
+        search = runset.search.model_copy(deep=True)
+        search.query = self.runset_settings.query
+        search.is_regex = is_regex
+        runset.search = search
+        runset.filters = expr.expr_to_filters(
+            self.runset_settings.filters  # type: ignore[arg-type]  # validator ensures this is always str
+        )
+        runset.grouping = [g.to_key() for g in self.runset_settings.groupby]
+        runset.sort = internal.Sort(
+            keys=[o.to_key() for o in self.runset_settings.order]
+        )
+
+        selections = runset.selections.model_copy(deep=True)
+        original_disabled = _selection_disabled_map(runset.selections)
+        current_disabled = _current_selection_disabled_map(
+            self.runset_settings.run_settings, original_disabled
+        )
+        if self._internal_view is None or current_disabled != original_disabled:
+            if selections.root == 0:
+                selections.tree = [
+                    id
+                    for id, config in self.runset_settings.run_settings.items()
+                    if not config.disabled
+                ]
+            else:
+                selections.tree = [
+                    id
+                    for id, config in self.runset_settings.run_settings.items()
+                    if config.disabled
+                ]
+        runset.selections = selections
+
+        if run_sets:
+            run_sets[0] = runset
+        else:
+            run_sets = [runset]
+        section.run_sets = run_sets
+
+        custom_run_colors = dict(section.custom_run_colors)
+        custom_run_colors.update(
+            {
+                id: config.color
+                for id, config in self.runset_settings.run_settings.items()
+                if config.color
+            }
+        )
+        section.custom_run_colors = custom_run_colors
+
+        view.spec.section = section
+        return view
 
     @classmethod
     def from_url(cls, url: str):

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -29,7 +29,7 @@ workspace.save()
 import copy
 import base64
 import os
-from typing import Dict, Iterable, Literal, Optional, Union
+from typing import Dict, Iterable, Literal, Optional, Union, cast
 from typing import List as LList
 from urllib.parse import parse_qs, urlparse, urlunparse
 
@@ -123,11 +123,20 @@ def _selection_disabled_map(selections: internal.RunsetSelections) -> Dict[str, 
 def _current_selection_disabled_map(
     run_settings: Dict[str, "RunSettings"],
     original_disabled: Dict[str, bool],
+    selections_root: int,
 ) -> Dict[str, bool]:
     return {
         run_id: settings.disabled
         for run_id, settings in run_settings.items()
-        if settings.disabled or run_id in original_disabled
+        if
+        (
+            # root=1: tree contains hidden runs
+            (selections_root != 0 and settings.disabled)
+            # root=0: tree contains visible runs
+            or (selections_root == 0 and not settings.disabled)
+            # keep originally represented runs so removals/toggles are detected
+            or run_id in original_disabled
+        )
     }
 
 
@@ -713,7 +722,9 @@ class Workspace(Base):
             # Legacy filters: the workspace was saved before v2 and hasn't been
             # opened in the UI yet (which does lazy conversion).  Convert the
             # legacy Filters tree to v2.
-            stashed_v2 = expr.filters_tree_to_v2(runset_model.filters)
+            stashed_v2 = expr.filters_tree_to_v2(
+                cast(expr.Filters, runset_model.filters)
+            )
             filter_string = expr.filters_v2_to_string(stashed_v2)
 
         # then construct the Workspace object
@@ -785,13 +796,6 @@ class Workspace(Base):
         # column_visible and column_pinned are the same (pinned columns are the only visible ones. We pass this for consistency but other columns will be visibile in the FE)
         column_pinned_dict = {col: True for col in self.runset_settings.pinned_columns}
         column_visible_dict = column_pinned_dict  # Same as pinned
-
-        # Use internal _column_order if set, otherwise use pinned_columns as order
-        column_order = (
-            self.runset_settings._column_order
-            if self.runset_settings._column_order
-            else list(self.runset_settings.pinned_columns)
-        )
 
         if (
             self._stashed_filters_v2 is not None
@@ -889,7 +893,7 @@ class Workspace(Base):
         if pinned_columns_changed:
             run_feed.column_pinned = column_pinned_dict
             run_feed.column_visible = column_visible_dict
-            run_feed.column_order = column_order
+            run_feed.column_order = list(self.runset_settings.pinned_columns)
             if self._internal_view is None:
                 run_feed.column_widths = {}
         runset.run_feed = run_feed
@@ -924,7 +928,7 @@ class Workspace(Base):
         selections = runset.selections.model_copy(deep=True)
         original_disabled = _selection_disabled_map(runset.selections)
         current_disabled = _current_selection_disabled_map(
-            self.runset_settings.run_settings, original_disabled
+            self.runset_settings.run_settings, original_disabled, selections.root
         )
         if self._internal_view is None or current_disabled != original_disabled:
             if selections.root == 0:
@@ -948,13 +952,11 @@ class Workspace(Base):
         section.run_sets = run_sets
 
         custom_run_colors = dict(section.custom_run_colors)
-        custom_run_colors.update(
-            {
-                id: config.color
-                for id, config in self.runset_settings.run_settings.items()
-                if config.color
-            }
-        )
+        for run_id, config in self.runset_settings.run_settings.items():
+            if config.color:
+                custom_run_colors[run_id] = config.color
+            else:
+                custom_run_colors.pop(run_id, None)
         section.custom_run_colors = custom_run_colors
 
         view.spec.section = section

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -108,6 +108,29 @@ def _should_show(v):
     return False
 
 
+def _selection_disabled_map(selections: internal.RunsetSelections) -> Dict[str, bool]:
+    is_disabled = selections.root != 0
+    disabled = {}
+    for item in selections.tree:
+        if isinstance(item, str):
+            disabled[item] = is_disabled
+        else:
+            for child_id in item.children:
+                disabled[child_id] = is_disabled
+    return disabled
+
+
+def _current_selection_disabled_map(
+    run_settings: Dict[str, "RunSettings"],
+    original_disabled: Dict[str, bool],
+) -> Dict[str, bool]:
+    return {
+        run_id: settings.disabled
+        for run_id, settings in run_settings.items()
+        if settings.disabled or run_id in original_disabled
+    }
+
+
 @dataclass(config=dataclass_config, repr=False)
 class Base:
     def __repr__(self):
@@ -145,20 +168,30 @@ class SectionLayoutSettings(Base):
 
     columns: int = 3
     rows: int = 2
+    _flow_config_internal: Optional[internal.FlowConfig] = Field(
+        default=None, init=False, repr=False
+    )
 
     @classmethod
     def _from_model(cls, model: internal.FlowConfig):
-        return cls(
+        obj = cls(
             columns=model.columns_per_page,
             rows=model.rows_per_page,
         )
+        obj._flow_config_internal = model
+        return obj
 
     def _to_model(self):
-        return internal.FlowConfig(
-            snap_to_columns=True,
-            columns_per_page=self.columns,
-            rows_per_page=self.rows,
+        flow_config = (
+            self._flow_config_internal.model_copy(deep=True)
+            if self._flow_config_internal is not None
+            else internal.FlowConfig()
         )
+        flow_config.columns_per_page = self.columns
+        flow_config.rows_per_page = self.rows
+        if self._flow_config_internal is None:
+            flow_config.snap_to_columns = True
+        return flow_config
 
 
 @dataclass
@@ -186,29 +219,38 @@ class SectionPanelSettings(Base):
     # Smoothing settings
     smoothing_type: internal.SmoothingType = "none"
     smoothing_weight: Annotated[int, Ge(0)] = 0
+    _local_panel_settings_internal: Optional[internal.LocalPanelSettings] = Field(
+        default=None, init=False, repr=False
+    )
 
     @classmethod
     def _from_model(cls, model: internal.LocalPanelSettings):
         x_axis = expr._convert_be_to_fe_metric_name(model.x_axis)
 
-        return cls(
+        obj = cls(
             x_axis=x_axis,
             x_min=model.x_axis_min,
             x_max=model.x_axis_max,
             smoothing_type=model.smoothing_type,
             smoothing_weight=model.smoothing_weight,
         )
+        obj._local_panel_settings_internal = model
+        return obj
 
     def _to_model(self):
         x_axis = expr._convert_fe_to_be_metric_name(self.x_axis)
 
-        return internal.LocalPanelSettings(
-            x_axis=x_axis,
-            x_axis_min=self.x_min,
-            x_axis_max=self.x_max,
-            smoothing_type=self.smoothing_type,
-            smoothing_weight=self.smoothing_weight,
+        local_panel_settings = (
+            self._local_panel_settings_internal.model_copy(deep=True)
+            if self._local_panel_settings_internal is not None
+            else internal.LocalPanelSettings()
         )
+        local_panel_settings.x_axis = x_axis
+        local_panel_settings.x_axis_min = self.x_min
+        local_panel_settings.x_axis_max = self.x_max
+        local_panel_settings.smoothing_type = self.smoothing_type
+        local_panel_settings.smoothing_weight = self.smoothing_weight
+        return local_panel_settings
 
 
 @dataclass(config=dataclass_config, repr=False)
@@ -233,10 +275,13 @@ class Section(Base):
         default_factory=SectionLayoutSettings
     )
     panel_settings: SectionPanelSettings = Field(default_factory=SectionPanelSettings)
+    _section_internal: Optional[internal.PanelBankConfigSectionsItem] = Field(
+        default=None, init=False, repr=False
+    )
 
     @classmethod
     def _from_model(cls, model: internal.PanelBankConfigSectionsItem):
-        return cls(
+        obj = cls(
             name=model.name,
             panels=[_lookup_panel(p) for p in model.panels],
             is_open=model.is_open,
@@ -244,6 +289,8 @@ class Section(Base):
             layout_settings=SectionLayoutSettings._from_model(model.flow_config),
             panel_settings=SectionPanelSettings._from_model(model.local_panel_settings),
         )
+        obj._section_internal = model
+        return obj
 
     def _to_model(self):
         panel_models = [p._to_model() for p in self.panels]
@@ -252,14 +299,18 @@ class Section(Base):
 
         # Add warning that panel layout only works if they set section settings layout = "custom"
 
-        return internal.PanelBankConfigSectionsItem(
-            name=self.name,
-            panels=panel_models,
-            is_open=self.is_open,
-            pinned=self.pinned,
-            flow_config=flow_config,
-            local_panel_settings=local_panel_settings,
+        section = (
+            self._section_internal.model_copy(deep=True)
+            if self._section_internal is not None
+            else internal.PanelBankConfigSectionsItem()
         )
+        section.name = self.name
+        section.panels = panel_models
+        section.is_open = self.is_open
+        section.pinned = self.pinned
+        section.flow_config = flow_config
+        section.local_panel_settings = local_panel_settings
+        return section
 
 
 @dataclass(config=dataclass_config, repr=False)
@@ -540,6 +591,9 @@ class Workspace(Base):
     _stashed_filters_v2: Optional[dict] = Field(default=None, init=False, repr=False)
     _stashed_filter_string: Optional[str] = Field(default=None, init=False, repr=False)
 
+    _internal_view: Optional[internal.View] = Field(None, init=False, repr=False)
+    "The original loaded view, used to preserve frontend-owned viewspec fields."
+
     @property
     def auto_generate_panels(self) -> bool:
         return self._auto_generate_panels
@@ -568,13 +622,15 @@ class Workspace(Base):
         # construct configs from disjoint parts of settings
         run_settings = {}
 
-        disabled_runs = model.spec.section.run_sets[0].selections.tree
+        selections = model.spec.section.run_sets[0].selections
+        disabled_runs = selections.tree
+        is_disabled = selections.root != 0
         for item in disabled_runs:
             if isinstance(item, str):
-                run_settings[item] = RunSettings(disabled=True)
+                run_settings[item] = RunSettings(disabled=is_disabled)
             else:
                 for child_id in item.children:
-                    run_settings[child_id] = RunSettings(disabled=True)
+                    run_settings[child_id] = RunSettings(disabled=is_disabled)
 
         custom_run_colors = model.spec.section.custom_run_colors
         for k, v in custom_run_colors.items():
@@ -633,7 +689,12 @@ class Workspace(Base):
             point_visualization_method=point_viz_method,
             sort_panels_alphabetically=panel_bank_settings.sort_alphabetically,
             group_by_prefix=group_by_prefix,
+            panel_search_query=panel_bank_settings.search_query or "",
+            auto_expand_panel_search_results=(
+                panel_bank_settings.auto_expand_search_results or False
+            ),
         )
+        workspace_settings._panel_search_history = panel_bank_settings.search_history
 
         # Extract column settings from run_feed
         run_feed = model.spec.section.run_sets[0].run_feed
@@ -656,6 +717,9 @@ class Workspace(Base):
             filter_string = expr.filters_v2_to_string(stashed_v2)
 
         # then construct the Workspace object
+        should_auto_generate_panels = (
+            model.spec.section.settings.should_auto_generate_panels is True
+        )
         obj = cls(
             entity=model.entity,
             project=model.project,
@@ -681,12 +745,18 @@ class Workspace(Base):
                     for rid in (model.spec.section.run_sets[0].pinned_run_ids or [])
                 ],
             ),
+            auto_generate_panels=should_auto_generate_panels,
         )
         obj._internal_name = model.name
         obj._internal_id = model.id
         obj._internal_runset_id = runset_model.id
         obj._stashed_filters_v2 = stashed_v2
         obj._stashed_filter_string = filter_string
+        obj.runset_settings._visible_columns = [
+            col for col, is_visible in run_feed.column_visible.items() if is_visible
+        ]
+        obj.runset_settings._column_order = list(run_feed.column_order)
+        obj._internal_view = model
         return obj
 
     def _to_model(self) -> internal.View:
@@ -701,7 +771,7 @@ class Workspace(Base):
             )
 
         x_axis = expr._convert_fe_to_be_metric_name(self.settings.x_axis)
-        point_viz_method = (
+        point_viz_method: Literal["bucketing-gorilla", "sampling"] = (
             "bucketing-gorilla"
             if self.settings.point_visualization_method == "bucketing"
             else "sampling"
@@ -710,20 +780,6 @@ class Workspace(Base):
             None if not self.settings.remove_legends_from_panels else True
         )
         color_run_names = None if self.settings.tooltip_color_run_names else False
-        internal_settings = internal.ViewspecSectionSettings(
-            x_axis=x_axis,
-            x_axis_min=self.settings.x_min,
-            x_axis_max=self.settings.x_max,
-            smoothing_type=self.settings.smoothing_type,
-            smoothing_weight=self.settings.smoothing_weight,
-            ignore_outliers=self.settings.ignore_outliers,
-            suppress_legends=suppress_legends,
-            tooltip_number_of_runs=self.settings.tooltip_number_of_runs,
-            color_run_names=color_run_names,
-            max_runs=self.settings.max_runs,
-            point_visualization_method=point_viz_method,
-            should_auto_generate_panels=self.auto_generate_panels,
-        )
 
         # Convert list format (SDK) to dict format (backend) for columns
         # column_visible and column_pinned are the same (pinned columns are the only visible ones. We pass this for consistency but other columns will be visibile in the FE)
@@ -747,77 +803,162 @@ class Workspace(Base):
                 expr.expr_to_filters(self.runset_settings.filters)  # type: ignore[arg-type] # validator ensures this is always str
             )
 
-        return internal.View(
-            entity=self.entity,
-            project=self.project,
-            display_name=self.name,
-            name=self._internal_name,
-            id=self._internal_id,
-            spec=internal.WorkspaceViewspec(
-                section=internal.ViewspecSection(
-                    panel_bank_config=internal.PanelBankConfig(
-                        state=1,  # TODO: What is this?
-                        settings=internal.PanelBankConfigSettings(
-                            sort_alphabetically=self.settings.sort_panels_alphabetically,
-                            auto_organize_prefix=auto_organize_prefix,
+        if self._internal_view is not None:
+            view = self._internal_view.model_copy(deep=True)
+            view.entity = self.entity
+            view.project = self.project
+            view.display_name = self.name
+            view.name = self._internal_name
+            view.id = self._internal_id
+            section = view.spec.section
+        else:
+            view = internal.View(
+                entity=self.entity,
+                project=self.project,
+                display_name=self.name,
+                name=self._internal_name,
+                id=self._internal_id,
+                spec=internal.WorkspaceViewspec(
+                    section=internal.ViewspecSection(
+                        panel_bank_config=internal.PanelBankConfig(state=1),
+                        panel_bank_section_config=internal.PanelBankSectionConfig(
+                            pinned=False
                         ),
-                        sections=sections,
+                        custom_run_colors={},
                     ),
-                    panel_bank_section_config=internal.PanelBankSectionConfig(
-                        pinned=False
-                    ),
-                    settings=internal_settings,
-                    run_sets=[
-                        internal.Runset(
-                            id=self._internal_runset_id,
-                            run_feed=internal.RunFeed(
-                                column_pinned=column_pinned_dict,
-                                column_visible=column_visible_dict,
-                                column_order=column_order,
-                                column_widths={},  # No column widths support
-                            ),
-                            search=internal.RunsetSearch(
-                                query=self.runset_settings.query,
-                                is_regex=is_regex,
-                            ),
-                            filters=filters_value,
-                            grouping=[g.to_key() for g in self.runset_settings.groupby],
-                            sort=internal.Sort(
-                                keys=[o.to_key() for o in self.runset_settings.order]
-                            ),
-                            selections=internal.RunsetSelections(
-                                tree=[
-                                    id
-                                    for id, config in self.runset_settings.run_settings.items()
-                                    if config.disabled
-                                ],
-                            ),
-                            baseline_run_id=(
-                                _encode_run_gid(
-                                    self.runset_settings.baseline_run,
-                                    self.project,
-                                    self.entity,
-                                )
-                                if self.runset_settings.baseline_run
-                                else None
-                            ),
-                            pinned_run_ids=(
-                                [
-                                    _encode_run_gid(s, self.project, self.entity)
-                                    for s in self.runset_settings.pinned_runs
-                                ]
-                                if self.runset_settings.pinned_runs
-                                else None
-                            ),
-                        ),
-                    ],
-                    custom_run_colors={
-                        id: config.color
-                        for id, config in self.runset_settings.run_settings.items()
-                    },
                 ),
-            ),
+            )
+            section = view.spec.section
+
+        panel_bank_config = section.panel_bank_config.model_copy(deep=True)
+        panel_bank_settings = panel_bank_config.settings.model_copy(deep=True)
+        panel_bank_settings.sort_alphabetically = (
+            self.settings.sort_panels_alphabetically
         )
+        panel_bank_settings.auto_organize_prefix = auto_organize_prefix
+        if (
+            self.settings.panel_search_query
+            or panel_bank_settings.search_query is not None
+        ):
+            panel_bank_settings.search_query = self.settings.panel_search_query
+        if (
+            self.settings.auto_expand_panel_search_results
+            or panel_bank_settings.auto_expand_search_results is not None
+        ):
+            panel_bank_settings.auto_expand_search_results = (
+                self.settings.auto_expand_panel_search_results
+            )
+        if self.settings._panel_search_history is not None:
+            panel_bank_settings.search_history = self.settings._panel_search_history
+        panel_bank_config.settings = panel_bank_settings
+        panel_bank_config.sections = sections
+        section.panel_bank_config = panel_bank_config
+
+        internal_settings = section.settings.model_copy(deep=True)
+        internal_settings.x_axis = x_axis
+        internal_settings.x_axis_min = self.settings.x_min
+        internal_settings.x_axis_max = self.settings.x_max
+        internal_settings.smoothing_type = self.settings.smoothing_type
+        internal_settings.smoothing_weight = self.settings.smoothing_weight
+        internal_settings.ignore_outliers = self.settings.ignore_outliers
+        internal_settings.suppress_legends = suppress_legends
+        internal_settings.tooltip_number_of_runs = self.settings.tooltip_number_of_runs
+        internal_settings.color_run_names = color_run_names
+        internal_settings.max_runs = self.settings.max_runs
+        internal_settings.point_visualization_method = point_viz_method
+        if (
+            self._internal_view is None
+            or self.auto_generate_panels
+            or internal_settings.should_auto_generate_panels in (False, None)
+        ):
+            internal_settings.should_auto_generate_panels = self.auto_generate_panels
+        section.settings = internal_settings
+
+        run_sets = list(section.run_sets)
+        runset = run_sets[0].model_copy(deep=True) if run_sets else internal.Runset()
+        runset.id = self._internal_runset_id
+
+        run_feed = runset.run_feed.model_copy(deep=True)
+        original_pinned_columns = [
+            col for col, is_pinned in run_feed.column_pinned.items() if is_pinned
+        ]
+        pinned_columns_changed = (
+            self._internal_view is None
+            or self.runset_settings.pinned_columns != original_pinned_columns
+        )
+        if pinned_columns_changed:
+            run_feed.column_pinned = column_pinned_dict
+            run_feed.column_visible = column_visible_dict
+            run_feed.column_order = column_order
+            if self._internal_view is None:
+                run_feed.column_widths = {}
+        runset.run_feed = run_feed
+
+        search = runset.search.model_copy(deep=True)
+        search.query = self.runset_settings.query
+        search.is_regex = is_regex
+        runset.search = search
+        runset.filters = filters_value
+        runset.grouping = [g.to_key() for g in self.runset_settings.groupby]
+        runset.sort = internal.Sort(
+            keys=[o.to_key() for o in self.runset_settings.order]
+        )
+        runset.baseline_run_id = (
+            _encode_run_gid(
+                self.runset_settings.baseline_run,
+                self.project,
+                self.entity,
+            )
+            if self.runset_settings.baseline_run
+            else None
+        )
+        runset.pinned_run_ids = (
+            [
+                _encode_run_gid(s, self.project, self.entity)
+                for s in self.runset_settings.pinned_runs
+            ]
+            if self.runset_settings.pinned_runs
+            else None
+        )
+
+        selections = runset.selections.model_copy(deep=True)
+        original_disabled = _selection_disabled_map(runset.selections)
+        current_disabled = _current_selection_disabled_map(
+            self.runset_settings.run_settings, original_disabled
+        )
+        if self._internal_view is None or current_disabled != original_disabled:
+            if selections.root == 0:
+                selections.tree = [
+                    id
+                    for id, config in self.runset_settings.run_settings.items()
+                    if not config.disabled
+                ]
+            else:
+                selections.tree = [
+                    id
+                    for id, config in self.runset_settings.run_settings.items()
+                    if config.disabled
+                ]
+        runset.selections = selections
+
+        if run_sets:
+            run_sets[0] = runset
+        else:
+            run_sets = [runset]
+        section.run_sets = run_sets
+
+        custom_run_colors = dict(section.custom_run_colors)
+        custom_run_colors.update(
+            {
+                id: config.color
+                for id, config in self.runset_settings.run_settings.items()
+                if config.color
+            }
+        )
+        section.custom_run_colors = custom_run_colors
+
+        view.spec.section = section
+        return view
 
     @classmethod
     def from_url(cls, url: str):

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -29,7 +29,7 @@ workspace.save()
 import copy
 import base64
 import os
-from typing import Dict, Iterable, Literal, Optional, Union, cast
+from typing import Dict, Iterable, Literal, Optional, Set, Union, cast
 from typing import List as LList
 from urllib.parse import parse_qs, urlparse, urlunparse
 
@@ -124,6 +124,7 @@ def _current_selection_disabled_map(
     run_settings: Dict[str, "RunSettings"],
     original_disabled: Dict[str, bool],
     selections_root: int,
+    color_only_run_ids: Set[str],
 ) -> Dict[str, bool]:
     return {
         run_id: settings.disabled
@@ -133,7 +134,11 @@ def _current_selection_disabled_map(
             # root=1: tree contains hidden runs
             (selections_root != 0 and settings.disabled)
             # root=0: tree contains visible runs
-            or (selections_root == 0 and not settings.disabled)
+            or (
+                selections_root == 0
+                and not settings.disabled
+                and run_id not in color_only_run_ids
+            )
             # keep originally represented runs so removals/toggles are detected
             or run_id in original_disabled
         )
@@ -603,6 +608,9 @@ class Workspace(Base):
     _internal_view: Optional[internal.View] = Field(None, init=False, repr=False)
     "The original loaded view, used to preserve frontend-owned viewspec fields."
 
+    _color_only_run_ids: Set[str] = Field(default_factory=set, init=False, repr=False)
+    "Run IDs represented only by customRunColors, not runset selections."
+
     @property
     def auto_generate_panels(self) -> bool:
         return self._auto_generate_panels
@@ -642,6 +650,7 @@ class Workspace(Base):
                     run_settings[child_id] = RunSettings(disabled=is_disabled)
 
         custom_run_colors = model.spec.section.custom_run_colors
+        color_only_run_ids = set()
         for k, v in custom_run_colors.items():
             if k != "ref":
                 id = k
@@ -649,6 +658,7 @@ class Workspace(Base):
 
                 if id not in run_settings:
                     run_settings[id] = RunSettings(color=color)
+                    color_only_run_ids.add(id)
                 else:
                     run_settings[id].color = color
 
@@ -763,6 +773,7 @@ class Workspace(Base):
         obj._internal_runset_id = runset_model.id
         obj._stashed_filters_v2 = stashed_v2
         obj._stashed_filter_string = filter_string
+        obj._color_only_run_ids = color_only_run_ids
         obj.runset_settings._visible_columns = [
             col for col, is_visible in run_feed.column_visible.items() if is_visible
         ]
@@ -928,7 +939,10 @@ class Workspace(Base):
         selections = runset.selections.model_copy(deep=True)
         original_disabled = _selection_disabled_map(runset.selections)
         current_disabled = _current_selection_disabled_map(
-            self.runset_settings.run_settings, original_disabled, selections.root
+            self.runset_settings.run_settings,
+            original_disabled,
+            selections.root,
+            self._color_only_run_ids,
         )
         if self._internal_view is None or current_disabled != original_disabled:
             if selections.root == 0:

--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional, Union
 from typing import List as LList
 
 import wandb
@@ -32,6 +32,7 @@ class WorkspaceAPIBaseModel(BaseModel):
         validate_assignment=True,
         populate_by_name=True,
         arbitrary_types_allowed=True,
+        extra="allow",
     )
 
 
@@ -48,7 +49,7 @@ class ViewspecSectionSettings(WorkspaceAPIBaseModel):
     point_visualization_method: Optional[PointVizMethod] = None
     suppress_legends: Optional[bool] = None
     tooltip_number_of_runs: Optional[TooltipNumberOfRuns] = None
-    should_auto_generate_panels: bool = False
+    should_auto_generate_panels: Union[bool, Literal["pending"]] = False
 
     @computed_field  # type: ignore[misc]
     @property

--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional, Union
 from typing import List as LList
 
 import wandb
@@ -33,6 +33,7 @@ class WorkspaceAPIBaseModel(BaseModel):
         validate_assignment=True,
         populate_by_name=True,
         arbitrary_types_allowed=True,
+        extra="allow",
     )
 
 
@@ -49,7 +50,7 @@ class ViewspecSectionSettings(WorkspaceAPIBaseModel):
     point_visualization_method: Optional[PointVizMethod] = None
     suppress_legends: Optional[bool] = None
     tooltip_number_of_runs: Optional[TooltipNumberOfRuns] = None
-    should_auto_generate_panels: bool = False
+    should_auto_generate_panels: Union[bool, Literal["pending"]] = False
 
     @computed_field  # type: ignore[misc]
     @property


### PR DESCRIPTION
<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
Please use conventional commits in your PR title. If you are unsure what conventional commits are or how to use them, please check out [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits).

JIRA/GH Issues(s)
-----------
https://coreweave.atlassian.net/browse/WB-32724

There's some other ones as well that could have been attributed to this genre of errors/fixes.

Description
-----------
Fix workspace/report round-trip serialization so SDK saves preserve frontend-owned viewspec state instead of dropping or resetting unmodeled fields.

## Changes

- Preserve unknown viewspec fields with `extra="allow"` on internal models.
- Preserve loaded internal models and overlay only SDK-owned fields during `_to_model()`.
- Preserve frontend-owned workspace state including workspace settings, semantic legend settings, custom run names, open/expanded state, run feed metadata, sparse panel overrides, and section metadata.
- Preserve unmodeled panel config fields for LinePlot, BarPlot, ScatterPlot, and MediaBrowser.
- Preserve `Runset` metadata including run feed settings, regex search, enabled state, expanded rows, selection bounds, and additive/grouped selection trees.
- Preserve exact backend config key paths for unchanged groupby and sort keys, including `.value` placement.
- Fix audit coverage for `MediaBrowser` and config sort key round-trips.
- Add regression tests for frontend-owned fields, sparse overrides, panel config extras, runset metadata, additive selections, and config sort key preservation.


Testing
-------
How was this PR tested?

- [x] _Added unit tests_
- [ ] _Manual testing (include description)_
- [ ] _N/A (include explanation)_

