### PR TITLE
fix(sdk): legacy filters adding nesting

### DIFF
--- a/wandb_workspaces/expr.py
+++ b/wandb_workspaces/expr.py
@@ -615,12 +615,11 @@ def _handle_logical_op(node) -> Filters:
     return Filters(op=op, filters=filters)
 
 
-def filters_to_expr(filter_obj: Any, is_root=True) -> str:
+def filters_to_expr(filter_obj: Any) -> str:
     """Convert an internal Filters tree back to a string expression.
 
     Args:
         filter_obj: An internal Filters tree structure
-        is_root: Whether this is the root of the tree (used internally)
 
     Returns:
         A Python-like filter expression string
@@ -639,10 +638,10 @@ def filters_to_expr(filter_obj: Any, is_root=True) -> str:
         "OR": "or",
     }
 
-    def _convert_filter(filter: Any, is_root: bool) -> str:
+    def _convert_filter(filter: Any) -> str:
         if hasattr(filter, "filters") and filter.filters is not None:
             sub_expressions = [
-                _convert_filter(f, False)
+                _convert_filter(f)
                 for f in filter.filters
                 if f.filters is not None or (f.key and f.key.name)
             ]
@@ -650,8 +649,7 @@ def filters_to_expr(filter_obj: Any, is_root=True) -> str:
                 return ""
 
             joint = " and " if filter.op == "AND" else " or "
-            expr = joint.join(sub_expressions)
-            return f"({expr})" if not is_root and sub_expressions else expr
+            return joint.join(sub_expressions)
         else:
             if not filter.key or not filter.key.name:
                 # Skip filters with empty key names
@@ -711,7 +709,7 @@ def filters_to_expr(filter_obj: Any, is_root=True) -> str:
 
             return f"{key_name} {op_map[filter.op]} {value}"
 
-    return _convert_filter(filter_obj, is_root)
+    return _convert_filter(filter_obj)
 
 
 def _key_to_server_path(key: Key):


### PR DESCRIPTION
<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
Please use conventional commits in your PR title. If you are unsure what conventional commits are or how to use them, please check out [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits).

JIRA/GH Issues(s)
-----------
https://coreweave.atlassian.net/browse/WB-33841

Description
-----------

Before

When reading filters, the SDK wrapped them in unnecessary parentheses — e.g., `(Metric("Name") == 'love-story' and Metric("Name") == 'we-are-never-getting-back-together')`.

If a user appended to the filter string like:

`workspace.runset_settings.filters = workspace.runset_settings.filters + " and Config('lr') == 0.01"`

The resulting string would be:
`(Metric("Name") == 'love-story' and Metric("Name") == 'we-are-never-getting-back-together') and Config("lr") == 0.01)`

Python's parser treats the parenthesized portion as a nested sub-group, creating a nested AND that legacy filters can't handle. Each save cycle added another layer of nesting, progressively corrupting the filters.

https://github.com/user-attachments/assets/478a2642-e994-4d44-bc79-149643de991b

After

The SDK no longer wraps legacy filters in parentheses, so appending produces a flat expression:

`Metric("Name") == 'right-where-you-left-me' and Metric("Name") == 'love-story' and Config("lr") == 0.01`

https://github.com/user-attachments/assets/f404c06f-3492-4b55-a968-0db5a4375066



- [ ] _Added unit tests_
- [ ] _Manual testing (include description)_
- [ ] _N/A (include explanation)_

