### PR TITLE
feat: Runset column config + column locking

### DIFF
--- a/examples/reports/06_column_management.py
+++ b/examples/reports/06_column_management.py
@@ -1,0 +1,170 @@
+"""
+Example: Managing Columns in a Report's Runs Table
+
+Demonstrates how to control which columns appear in the runs table inside
+a Report's PanelGrid. The Runset API exposes three list fields for
+visibility — `pinned_columns`, `visible_columns`, `hidden_columns` — plus
+the `lock_columns` toggle.
+
+Locked-columns mode:
+    By default, runs tables show every column the underlying runs logged;
+    `hidden_columns` drops specific cols, `visible_columns` is a no-op.
+    Set `lock_columns=True` to show ONLY cols listed in `pinned_columns`
+    or `visible_columns`. The FE exposes the same toggle as the lock icon
+    in the runs-table toolbar (Reports edit mode).
+
+Column format: "section:name"
+    run     - Built-in run properties (e.g. "run:displayName", "run:state")
+    config  - Config parameters (e.g. "config:learning_rate.value")
+    summary - Summary metrics (e.g. "summary:accuracy")
+    tags    - Run tags (only "tags:__ALL__" is valid)
+
+Nested config uses dot notation:
+    {"model": {"lr": 0.001}} → "config:model.lr"
+"""
+
+import os
+
+import wandb_workspaces.reports.v2 as wr
+
+entity = os.getenv("WANDB_ENTITY")
+project = os.getenv("WANDB_PROJECT")
+
+
+# ============================================================================
+# Example 1: Pin a column without hiding others (default permissive mode)
+# ============================================================================
+# Pinning sticks the column to the left. All other columns the runs logged
+# remain visible — lock_columns is left at its default (None / permissive).
+
+report = wr.Report(
+    entity=entity,
+    project=project,
+    title="Pin one column",
+    blocks=[
+        wr.PanelGrid(
+            runsets=[
+                wr.Runset(
+                    entity=entity,
+                    project=project,
+                    pinned_columns=["summary:loss"],
+                ),
+            ],
+            panels=[wr.LinePlot(x="Step", y=["val_loss"])],
+        ),
+    ],
+).save()
+print(f"Saved: {report.url}")
+
+
+# ============================================================================
+# Example 2: Locked columns — show ONLY a curated set of columns
+# ============================================================================
+# Set lock_columns=True to switch to allowlist mode. Only columns listed
+# in pinned_columns or visible_columns will appear; all auto-discovered
+# config:* and summary:* keys are hidden.
+
+report = wr.Report(
+    entity=entity,
+    project=project,
+    title="Curated column set",
+    blocks=[
+        wr.PanelGrid(
+            runsets=[
+                wr.Runset(
+                    entity=entity,
+                    project=project,
+                    pinned_columns=["summary:accuracy"],
+                    visible_columns=[
+                        "summary:loss",
+                        "config:learning_rate.value",
+                        "run:state",
+                    ],
+                    lock_columns=True,
+                ),
+            ],
+            panels=[wr.LinePlot(x="Step", y=["val_loss", "val_accuracy"])],
+        ),
+    ],
+).save()
+print(f"Saved: {report.url}")
+
+
+# ============================================================================
+# Example 3: Hide specific columns without locked mode
+# ============================================================================
+# Use hidden_columns to drop a few noisy cols while keeping everything else
+# visible (default permissive mode).
+
+report = wr.Report(
+    entity=entity,
+    project=project,
+    title="Hide noisy columns",
+    blocks=[
+        wr.PanelGrid(
+            runsets=[
+                wr.Runset(
+                    entity=entity,
+                    project=project,
+                    hidden_columns=[
+                        "config:internal_debug_flag.value",
+                        "summary:scratch_value",
+                    ],
+                ),
+            ],
+            panels=[wr.LinePlot(x="Step", y=["val_loss"])],
+        ),
+    ],
+).save()
+print(f"Saved: {report.url}")
+
+
+# ============================================================================
+# Example 4: Custom column order and widths
+# ============================================================================
+
+report = wr.Report(
+    entity=entity,
+    project=project,
+    title="Ordered and sized columns",
+    blocks=[
+        wr.PanelGrid(
+            runsets=[
+                wr.Runset(
+                    entity=entity,
+                    project=project,
+                    pinned_columns=["summary:accuracy", "summary:loss"],
+                    column_order=[
+                        "summary:accuracy",
+                        "summary:loss",
+                        "config:learning_rate.value",
+                    ],
+                    column_widths={
+                        "summary:accuracy": 200,
+                        "summary:loss": 200,
+                        "config:learning_rate.value": 150,
+                    },
+                ),
+            ],
+            panels=[wr.LinePlot(x="Step", y=["val_loss"])],
+        ),
+    ],
+).save()
+print(f"Saved: {report.url}")
+
+
+# ============================================================================
+# Example 5: Round-trip — load, modify, save
+# ============================================================================
+# Column config (including lock_columns) survives load/save.
+
+loaded = wr.Report.from_url(report.url)
+runset = loaded.blocks[0].runsets[0]
+print(f"Loaded pinned:         {runset.pinned_columns}")
+print(f"Loaded visible:        {runset.visible_columns}")
+print(f"Loaded hidden:         {runset.hidden_columns}")
+print(f"Loaded lock_columns: {runset.lock_columns}")
+
+runset.pinned_columns.append("run:state")
+loaded.save()
+print(f"Re-saved with extra column: {loaded.url}")

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 from typing import Any, Dict, Generic, Type, TypeVar
 from unittest.mock import Mock
 
@@ -2038,6 +2039,101 @@ class TestRunsetColumnConfig:
         re_model = runset._to_model()
 
         assert re_model.run_feed.column_pinned == {"summary:accuracy": True}
+
+    def test_under_limit_no_warning(self):
+        """Below 500 rendered cols emits no warning."""
+        from wandb_workspaces.reports.v2.interface import (
+            MAX_RUNSET_VISIBLE_COLUMNS,
+        )
+
+        cols = [
+            f"summary:m{i}" for i in range(MAX_RUNSET_VISIBLE_COLUMNS - 1)
+        ]
+        runset = wr.Runset(entity="e", project="p", visible_columns=cols)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            model = runset._to_model()
+
+        assert len(model.run_feed.column_order) == MAX_RUNSET_VISIBLE_COLUMNS - 1
+
+    def test_at_limit_warns_but_does_not_truncate(self):
+        """Exactly 500 cols warns (heads-up) but nothing is truncated."""
+        from wandb_workspaces.reports.v2.interface import (
+            MAX_RUNSET_VISIBLE_COLUMNS,
+        )
+
+        cols = [f"summary:m{i}" for i in range(MAX_RUNSET_VISIBLE_COLUMNS)]
+        runset = wr.Runset(entity="e", project="p", visible_columns=cols)
+
+        with pytest.warns(UserWarning, match="at the FE display limit"):
+            model = runset._to_model()
+
+        assert len(model.run_feed.column_order) == MAX_RUNSET_VISIBLE_COLUMNS
+        # All cols intact — at-limit is a warning, not a truncation.
+        assert model.run_feed.column_order == cols
+
+    def test_over_limit_warns_but_does_not_truncate(self):
+        """Combined visible set above 500 warns but keeps the full set on the
+        wire — the FE enforces the display limit, not the SDK."""
+        from wandb_workspaces.reports.v2.interface import (
+            MAX_RUNSET_VISIBLE_COLUMNS,
+        )
+
+        over = MAX_RUNSET_VISIBLE_COLUMNS + 50
+        cols = [f"summary:m{i}" for i in range(over)]
+        runset = wr.Runset(entity="e", project="p", visible_columns=cols)
+
+        with pytest.warns(UserWarning, match=f"{over} visible columns"):
+            model = runset._to_model()
+
+        # All cols stay on the wire — nothing dropped by the SDK.
+        assert len(model.run_feed.column_order) == over
+        assert model.run_feed.column_order == cols
+
+    def test_over_limit_keeps_all_pinned(self):
+        """Over the cap, pinned cols are all preserved (no SDK truncation)."""
+        from wandb_workspaces.reports.v2.interface import (
+            MAX_RUNSET_VISIBLE_COLUMNS,
+        )
+
+        pinned = [f"summary:p{i}" for i in range(10)]
+        visible = [f"summary:v{i}" for i in range(MAX_RUNSET_VISIBLE_COLUMNS)]
+        runset = wr.Runset(
+            entity="e", project="p", pinned_columns=pinned, visible_columns=visible
+        )
+
+        with pytest.warns(UserWarning):
+            model = runset._to_model()
+
+        # 10 pinned + 500 visible = 510, all retained on the wire.
+        assert len(model.run_feed.column_order) == 510
+        assert set(model.run_feed.column_pinned.keys()) == set(pinned)
+        assert "summary:v499" in model.run_feed.column_order
+
+    def test_hidden_cols_do_not_count_toward_limit(self):
+        """Hidden cols are not rendered, so they don't count against the cap.
+        499 visible + many hidden should not warn (well under the limit)."""
+        from wandb_workspaces.reports.v2.interface import (
+            MAX_RUNSET_VISIBLE_COLUMNS,
+        )
+
+        visible = [
+            f"summary:v{i}" for i in range(MAX_RUNSET_VISIBLE_COLUMNS - 1)
+        ]
+        hidden = [f"summary:h{i}" for i in range(100)]
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            visible_columns=visible,
+            hidden_columns=hidden,
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            model = runset._to_model()
+
+        assert len(model.run_feed.column_order) == MAX_RUNSET_VISIBLE_COLUMNS - 1
 
 
 class TestReportSharing:

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1565,6 +1565,481 @@ class TestRunsetRunSettings:
         assert result.selections.tree == ["hidden-run"]
 
 
+class TestRunsetColumnConfig:
+    """Round-trip and behavior tests for Runset column configuration."""
+
+    @pytest.fixture(autouse=True)
+    def mock_api(self, monkeypatch):
+        mock_client = Mock()
+        mock_client.execute.return_value = {
+            "project": {"internalId": "test-project-id"}
+        }
+        monkeypatch.setattr(
+            "wandb_workspaces.reports.v2.interface._get_api",
+            lambda: type("MockApi", (), {"client": mock_client})(),
+        )
+
+    def test_pinned_columns_serialize(self):
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            pinned_columns=["summary:accuracy", "summary:loss"],
+        )
+        model = runset._to_model()
+
+        assert model.run_feed.column_pinned == {
+            "summary:accuracy": True,
+            "summary:loss": True,
+        }
+        # Pinned cols MUST be in column_visible with True — Reports render
+        # with hideNewKey=true, which strips missing cols when the modified
+        # flag is set.
+        assert model.run_feed.column_visible == {
+            "summary:accuracy": True,
+            "summary:loss": True,
+        }
+        assert model.run_feed.column_order == ["summary:accuracy", "summary:loss"]
+
+    def test_visible_and_hidden_lists_consolidate_to_column_visible(self):
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            visible_columns=["summary:accuracy"],
+            hidden_columns=["config:internal_flag"],
+        )
+        model = runset._to_model()
+
+        assert model.run_feed.column_visible == {
+            "summary:accuracy": True,
+            "config:internal_flag": False,
+        }
+
+    def test_visible_columns_appear_in_default_column_order(self):
+        """The FE renders from column_order, not column_visible. visible_columns
+        entries MUST appear in the default column_order so they actually render
+        (especially under lock_columns=True). Hidden cols stay out of the
+        order entirely."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            pinned_columns=["summary:accuracy"],
+            visible_columns=["summary:loss", "summary:f1_score"],
+            hidden_columns=["config:noise_param"],
+            lock_columns=True,
+        )
+        model = runset._to_model()
+
+        # Pinned first, then visible (in declared order). Hidden col absent.
+        assert model.run_feed.column_order == [
+            "summary:accuracy",
+            "summary:loss",
+            "summary:f1_score",
+        ]
+        # column_visible carries the full picture (including the hidden col).
+        assert model.run_feed.column_visible == {
+            "config:noise_param": False,
+            "summary:loss": True,
+            "summary:f1_score": True,
+            "summary:accuracy": True,
+        }
+
+    def test_explicit_column_order_with_curated_cols_appends_missing(self):
+        """Explicit column_order preserves the user's layout preference but
+        curated cols (pinned + visible) missing from it are appended to the
+        end — otherwise they'd ghost out, since column_order is the FE's
+        render gate."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            pinned_columns=["summary:accuracy"],
+            visible_columns=["summary:loss", "summary:f1_score"],
+            column_order=["summary:loss", "summary:accuracy"],  # f1_score omitted
+        )
+        model = runset._to_model()
+        # f1_score gets appended; user's order for loss/accuracy is preserved.
+        assert model.run_feed.column_order == [
+            "summary:loss",
+            "summary:accuracy",
+            "summary:f1_score",
+        ]
+
+    def test_explicit_column_order_alone_used_verbatim(self):
+        """When no curated cols are specified, explicit column_order is
+        written verbatim."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            column_order=["summary:a", "summary:b", "summary:c"],
+        )
+        model = runset._to_model()
+        assert model.run_feed.column_order == [
+            "summary:a",
+            "summary:b",
+            "summary:c",
+        ]
+
+    def test_hidden_col_excluded_from_column_order(self):
+        """A col in both column_order and hidden_columns should not render
+        (hidden wins over column_order alone, since column_order isn't an
+        explicit 'keep visible' directive)."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            column_order=["summary:a", "summary:b", "summary:c"],
+            hidden_columns=["summary:b"],
+        )
+        model = runset._to_model()
+        # b excluded from column_order; column_visible carries the False.
+        assert model.run_feed.column_order == ["summary:a", "summary:c"]
+        assert model.run_feed.column_visible == {
+            "summary:b": False,
+            "summary:a": True,
+            "summary:c": True,
+        }
+
+    def test_hidden_wins_over_pinned_columns(self):
+        """Hide is absolute: a col in both pinned_columns and hidden_columns
+        is stripped from column_pinned and not rendered. We don't silently
+        keep something the user said to hide."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            pinned_columns=["summary:accuracy"],
+            hidden_columns=["summary:accuracy"],
+        )
+        model = runset._to_model()
+        assert model.run_feed.column_visible == {"summary:accuracy": False}
+        assert model.run_feed.column_pinned == {}
+        assert model.run_feed.column_order == []
+
+    def test_hidden_wins_over_visible_columns(self):
+        """Hide is absolute: a col in both visible_columns and hidden_columns
+        is stripped from column_visible's True entries and from column_order."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            visible_columns=["summary:loss", "summary:f1_score"],
+            hidden_columns=["summary:loss"],
+        )
+        model = runset._to_model()
+        assert model.run_feed.column_visible == {
+            "summary:loss": False,
+            "summary:f1_score": True,
+        }
+        assert model.run_feed.column_order == ["summary:f1_score"]
+
+    def test_locked_mode_drops_column_order_only_cols(self):
+        """Under lock_columns=True, cols in column_order but not in
+        pinned_columns / visible_columns are dropped — locked mode requires
+        explicit declaration of what's visible. Layout preference alone is
+        not enough."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            pinned_columns=["summary:accuracy"],
+            visible_columns=["summary:loss"],
+            column_order=[
+                "summary:accuracy",
+                "summary:noise",  # not declared anywhere else
+                "summary:loss",
+            ],
+            lock_columns=True,
+        )
+        model = runset._to_model()
+        # noise is dropped from column_order under locked mode.
+        assert model.run_feed.column_order == [
+            "summary:accuracy",
+            "summary:loss",
+        ]
+        assert model.run_feed.column_visible == {
+            "summary:accuracy": True,
+            "summary:loss": True,
+        }
+
+    def test_triple_combo_locked_pin_order_hide(self):
+        """Full combo under locked mode:
+        - pinned col stays (and renders)
+        - hidden col strips from column_order entirely
+        - column_order-only col (not pinned/visible) drops under locked mode
+        Verifies hide and lock-mode precedence rules both apply in one pass."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            pinned_columns=["summary:accuracy"],
+            hidden_columns=["summary:noise"],
+            column_order=[
+                "summary:accuracy",
+                "summary:noise",  # hidden — drops
+                "summary:layout_only",  # not curated, locked → drops
+            ],
+            lock_columns=True,
+        )
+        model = runset._to_model()
+        assert model.run_feed.column_order == ["summary:accuracy"]
+        assert model.run_feed.column_visible == {
+            "summary:noise": False,
+            "summary:accuracy": True,
+        }
+        assert model.run_feed.column_pinned == {"summary:accuracy": True}
+
+    def test_triple_combo_permissive_pin_order_hide(self):
+        """Full combo under non-locked mode:
+        - pinned col stays
+        - hidden col strips from column_order
+        - column_order-only col (not pinned/visible) is kept (permissive)
+        Verifies non-locked mode is permissive about column_order entries."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            pinned_columns=["summary:accuracy"],
+            hidden_columns=["summary:noise"],
+            column_order=[
+                "summary:accuracy",
+                "summary:noise",  # hidden — drops
+                "summary:layout_only",  # not curated, permissive → kept
+            ],
+        )
+        model = runset._to_model()
+        assert model.run_feed.column_order == [
+            "summary:accuracy",
+            "summary:layout_only",
+        ]
+        assert model.run_feed.column_visible == {
+            "summary:noise": False,
+            "summary:accuracy": True,
+            "summary:layout_only": True,
+        }
+        assert model.run_feed.column_pinned == {"summary:accuracy": True}
+
+    def test_pinned_col_not_in_column_order_appends(self):
+        """A pinned col not listed in column_order gets appended to the wire's
+        column_order. The FE anchors it visually to the left via column_pinned;
+        the wire position is just metadata for if pinning changes."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            pinned_columns=["summary:b"],
+            column_order=["summary:a"],
+        )
+        model = runset._to_model()
+        # b appended after a; visual rendering anchors b left via column_pinned.
+        assert model.run_feed.column_order == ["summary:a", "summary:b"]
+        assert model.run_feed.column_pinned == {"summary:b": True}
+
+    def test_permissive_keeps_column_order_only_cols(self):
+        """Without lock_columns, cols in column_order render even if not
+        listed in pinned/visible — non-locked mode is permissive."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            column_order=["summary:a", "summary:b"],
+        )
+        model = runset._to_model()
+        assert model.run_feed.column_order == ["summary:a", "summary:b"]
+        assert model.run_feed.column_visible == {
+            "summary:a": True,
+            "summary:b": True,
+        }
+
+    def test_round_trip_preserves_three_lists(self):
+        """Round-trip reflects what the wire ends up rendering, not the
+        user's original typed inputs. visible_columns on reload includes
+        any col that's True in column_visible (i.e., in column_order and
+        not pinned). column_order on reload is the full effective render
+        list (explicit order + appended curated cols)."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            pinned_columns=["summary:accuracy"],
+            visible_columns=["summary:f1_score"],
+            hidden_columns=["config:internal_flag"],
+            column_order=["summary:accuracy", "summary:loss"],
+        )
+        model = runset._to_model()
+        reconstructed = wr.Runset._from_model(model)
+
+        assert reconstructed.pinned_columns == ["summary:accuracy"]
+        # summary:loss came from column_order (not visible_columns) but
+        # ends up True in column_visible to match the FE's invariant —
+        # so it surfaces in visible_columns on round-trip.
+        assert sorted(reconstructed.visible_columns) == sorted(
+            ["summary:f1_score", "summary:loss"]
+        )
+        assert reconstructed.hidden_columns == ["config:internal_flag"]
+        # column_order includes the appended f1_score from visible_columns.
+        assert reconstructed.column_order == [
+            "summary:accuracy",
+            "summary:loss",
+            "summary:f1_score",
+        ]
+
+    def test_duplicates_in_list_fields_are_deduped_on_serialize(self):
+        """Duplicate entries in list fields would render duplicate columns;
+        _to_model must dedupe while preserving order."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            pinned_columns=["summary:a", "summary:a", "summary:b"],
+            column_order=["summary:a", "summary:b", "summary:a"],
+        )
+        model = runset._to_model()
+
+        assert model.run_feed.column_pinned == {
+            "summary:a": True,
+            "summary:b": True,
+        }
+        assert model.run_feed.column_order == ["summary:a", "summary:b"]
+
+    def test_column_widths_round_trip(self):
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            column_widths={"summary:accuracy": 200, "summary:loss": 150},
+        )
+        model = runset._to_model()
+
+        assert model.run_feed.column_widths == {
+            "summary:accuracy": 200,
+            "summary:loss": 150,
+        }
+
+        reconstructed = wr.Runset._from_model(model)
+        assert reconstructed.column_widths == {
+            "summary:accuracy": 200,
+            "summary:loss": 150,
+        }
+
+    def test_lock_columns_default_is_none(self):
+        """Default permissive — lock_columns left unset is None on the wire."""
+        runset = wr.Runset(entity="e", project="p", pinned_columns=["summary:a"])
+        model = runset._to_model()
+        assert model.run_feed.lock_columns is None
+
+    def test_lock_columns_true_round_trip(self):
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            visible_columns=["summary:a", "summary:b"],
+            lock_columns=True,
+        )
+        model = runset._to_model()
+        assert model.run_feed.lock_columns is True
+
+        reconstructed = wr.Runset._from_model(model)
+        assert reconstructed.lock_columns is True
+        assert reconstructed.visible_columns == ["summary:a", "summary:b"]
+
+    def test_lock_columns_false_round_trip(self):
+        """Explicit False is the GM 'pin without losing the rest' case."""
+        runset = wr.Runset(
+            entity="e",
+            project="p",
+            pinned_columns=["summary:a"],
+            lock_columns=False,
+        )
+        model = runset._to_model()
+        assert model.run_feed.lock_columns is False
+
+        reconstructed = wr.Runset._from_model(model)
+        assert reconstructed.lock_columns is False
+
+    def test_from_model_extracts_default_seed_entries(self):
+        """Default RunFeed carries {'run:name': False} on the wire; _from_model
+        surfaces it as hidden_columns."""
+        from wandb_workspaces.reports.v2 import internal
+
+        model = internal.Runset(name="rs")
+        assert "run:name" in model.run_feed.column_visible
+
+        runset = wr.Runset._from_model(model)
+        assert runset.pinned_columns == []
+        assert runset.visible_columns == []
+        assert runset.hidden_columns == ["run:name"]
+
+    def test_noop_round_trip_preserves_runfeed_verbatim(self):
+        """Loading and re-saving without touching column fields writes the
+        stashed RunFeed back verbatim (preserves legacy seed entries)."""
+        from wandb_workspaces.reports.v2 import internal
+
+        model = internal.Runset(name="rs")
+        assert model.run_feed.column_visible == {"run:name": False}
+
+        runset = wr.Runset._from_model(model)
+        re_model = runset._to_model()
+
+        assert re_model.run_feed.column_visible == {"run:name": False}
+
+    def test_from_model_extracts_column_order_only_cols_as_visible(self):
+        """If a wire spec has a col in column_order but missing from
+        column_visible (e.g. hand-edited or non-canonical spec), _from_model
+        should still surface it in visible_columns — column_order is the
+        actual render gate."""
+        from wandb_workspaces.reports.v2 import internal
+
+        model = internal.Runset(
+            name="rs",
+            run_feed=internal.RunFeed(
+                column_visible={"summary:a": True},  # only a, b missing
+                column_order=["summary:a", "summary:b"],  # both render
+            ),
+        )
+        runset = wr.Runset._from_model(model)
+        assert sorted(runset.visible_columns) == ["summary:a", "summary:b"]
+
+    def test_round_trip_preserves_non_column_runfeed_fields(self):
+        """RunFeed fields the SDK doesn't expose (page_size, only_show_selected)
+        survive round-trip via the stash, even when the user changes column
+        config after loading."""
+        from wandb_workspaces.reports.v2 import internal
+
+        model = internal.Runset(
+            name="rs",
+            run_feed=internal.RunFeed(page_size=42, only_show_selected=True),
+        )
+        runset = wr.Runset._from_model(model)
+        runset.pinned_columns = ["summary:accuracy"]  # touch a column field
+        re_model = runset._to_model()
+
+        assert re_model.run_feed.page_size == 42
+        assert re_model.run_feed.only_show_selected is True
+        assert re_model.run_feed.column_pinned == {"summary:accuracy": True}
+
+    def test_modified_runfeed_round_trip(self):
+        """Loaded runset with curated columns round-trips its column config
+        verbatim."""
+        from wandb_workspaces.reports.v2 import internal
+
+        model = internal.Runset(
+            name="rs",
+            run_feed=internal.RunFeed(
+                column_visible={"summary:a": True, "summary:b": False},
+                column_pinned={"summary:a": True},
+                column_order=["summary:a"],
+            ),
+        )
+
+        runset = wr.Runset._from_model(model)
+        re_model = runset._to_model()
+
+        assert re_model.run_feed.column_visible == {
+            "summary:a": True,
+            "summary:b": False,
+        }
+        assert re_model.run_feed.column_pinned == {"summary:a": True}
+
+    def test_user_change_after_load_reflected_in_wire(self):
+        """After loading, mutating a column field flows through to the wire."""
+        from wandb_workspaces.reports.v2 import internal
+
+        model = internal.Runset(name="rs")
+        runset = wr.Runset._from_model(model)
+
+        runset.pinned_columns = ["summary:accuracy"]
+        re_model = runset._to_model()
+
+        assert re_model.run_feed.column_pinned == {"summary:accuracy": True}
+
+
 class TestReportSharing:
     """Tests for Report magic link sharing methods."""
 

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -29,6 +29,7 @@ report.save()
 import base64
 import copy
 import os
+import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Tuple, Union
 from typing import List as LList
@@ -69,6 +70,10 @@ SpecialMetricType = Union["Config", "SummaryMetric", "Metric"]
 MetricType = Union[str, SpecialMetricType]
 SummaryOrConfigOnlyMetric = Union[str, "Config", "SummaryMetric", "Metric"]
 RunId = str
+
+# Mirrors the FE runs-table COLUMN_LIMIT. The FE truncates beyond this on
+# parse/render; the SDK only warns when a Runset's visible set reaches it.
+MAX_RUNSET_VISIBLE_COLUMNS = 500
 
 
 dataclass_config = ConfigDict(validate_assignment=True, extra="forbid", slots=True)
@@ -993,6 +998,13 @@ class Runset(Base):
             - `summary:<key>`: summary metrics
             - `tags:__ALL__`: run tags
 
+    Column limit:
+        The FE runs-table displays at most 500 columns. When the visible set
+        (pinned + visible + column_order, minus hidden) reaches or exceeds
+        500, the SDK emits a warning on save; hidden columns don't count. The
+        SDK does not truncate — the full set is sent and the frontend enforces
+        the limit on render.
+
     Example:
         ```python
         # Using string filters
@@ -1143,6 +1155,30 @@ class Runset(Base):
             col_order = [c for c in combined_order if c in curated_set]
         else:
             col_order = combined_order
+
+        # The cap applies only to visible columns (col_order == the
+        # column_visible:True set). Hidden columns are column_visible:False and
+        # never enter col_order, so they don't count toward the limit. We only
+        # warn here — the FE enforces COLUMN_LIMIT on parse/render, so we leave
+        # the full set on the wire rather than truncate and risk diverging.
+        if len(col_order) >= MAX_RUNSET_VISIBLE_COLUMNS:
+            if len(col_order) == MAX_RUNSET_VISIBLE_COLUMNS:
+                warnings.warn(
+                    f"Runset '{self.name}' has {len(col_order)} visible columns, "
+                    f"at the FE display limit of {MAX_RUNSET_VISIBLE_COLUMNS} "
+                    f"(hidden columns don't count). Adding more visible columns "
+                    f"will exceed the cap and the frontend will not display them.",
+                    stacklevel=2,
+                )
+            else:
+                warnings.warn(
+                    f"Runset '{self.name}' has {len(col_order)} visible columns "
+                    f"(pinned + visible + column_order, minus hidden), exceeding "
+                    f"the FE display limit of {MAX_RUNSET_VISIBLE_COLUMNS}. The "
+                    f"frontend will only display the first "
+                    f"{MAX_RUNSET_VISIBLE_COLUMNS}.",
+                    stacklevel=2,
+                )
 
         # FE invariant: column_visible True entries must mirror column_order.
         column_visible: Dict[str, bool] = {col: False for col in hidden_cols}

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -969,37 +969,29 @@ class Runset(Base):
             Use this to set colors and/or hide individual runs. See `RunSettings`.
         pinned_columns (LList[str]): Column accessors to pin to the left of
             the runs table (e.g. `["summary:accuracy", "config:lr.value"]`).
-            A col also listed in `hidden_columns` is stripped from this list
-            on save — hide is absolute and wins over pin.
-        visible_columns (LList[str]): Column accessors to force-show without
-            pinning. Main use case: curating the visible set in locked mode
-            (combine with `lock_columns=True`). A col also listed in
-            `hidden_columns` is stripped on save.
-        hidden_columns (LList[str]): Column accessors to hide. Hide takes
-            precedence over `pinned_columns`, `visible_columns`, and entries
-            in `column_order` — a hidden col never renders, regardless of
-            where else it appears.
-        column_order (LList[str]): Left-to-right order of columns. Entries are
-            written to the wire's column_order and (under permissive mode)
-            cause the col to render. Under `lock_columns=True`, entries
-            here that are not also in `pinned_columns` / `visible_columns`
-            are dropped — locked mode requires explicit declaration of intent.
+            Cols also in `hidden_columns` are stripped on save.
+        visible_columns (LList[str]): Column accessors to force-show. Use with
+            `lock_columns=True` to curate the visible set. On reload, this
+            also includes cols set only via `column_order`.
+        hidden_columns (LList[str]): Column accessors to hide. Takes
+            precedence over `pinned_columns`, `visible_columns`, and
+            `column_order`. On reload, may include server-seeded entries
+            like `run:name`.
+        column_order (LList[str]): Left-to-right column order. Under
+            `lock_columns=True`, entries not in `pinned_columns` or
+            `visible_columns` are dropped.
         column_widths (Dict[str, int]): Per-column pixel widths.
-        lock_columns (Optional[bool]): Opt-in toggle to lock the runs-table
-            column set to whatever's listed in `pinned_columns` /
-            `visible_columns`. `True` enables locked mode (only listed cols
-            render; auto-discovered config and summary keys are hidden).
-            `False` and `None` (default) are both permissive — all known 
-            and future columns appear, `hidden_columns`/`visible_columns` 
-            act as overrides. The lock icon in the runs-table toolbar 
-            (Reports edit mode) toggles this same flag.
+        lock_columns (Optional[bool]): Opt-in lock for the runs-table column
+            set. `True` shows only `pinned_columns` and `visible_columns`;
+            `False` or `None` (default) is permissive. Matches the lock icon
+            in the runs-table toolbar.
 
     Column format:
         Columns are addressed as `"<section>:<name>"`:
-            - `run:<attr>`        — built-in run properties (e.g. `run:state`, `run:createdAt`)
-            - `config:<key>.value` — config keys (note the `.value` suffix from nested config)
-            - `summary:<key>`     — summary metrics
-            - `tags:__ALL__`      — run tags
+            - `run:<attr>`: built-in run properties (e.g. `run:state`)
+            - `config:<key>.value`: config keys (note the `.value` suffix)
+            - `summary:<key>`: summary metrics
+            - `tags:__ALL__`: run tags
 
     Example:
         ```python

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -967,6 +967,39 @@ class Runset(Base):
             grouped runs) to colors. For simple per-run colors, prefer using `run_settings`.
         run_settings (Dict[str, RunSettings]): Per-run display settings keyed by run ID.
             Use this to set colors and/or hide individual runs. See `RunSettings`.
+        pinned_columns (LList[str]): Column accessors to pin to the left of
+            the runs table (e.g. `["summary:accuracy", "config:lr.value"]`).
+            A col also listed in `hidden_columns` is stripped from this list
+            on save — hide is absolute and wins over pin.
+        visible_columns (LList[str]): Column accessors to force-show without
+            pinning. Main use case: curating the visible set in locked mode
+            (combine with `lock_columns=True`). A col also listed in
+            `hidden_columns` is stripped on save.
+        hidden_columns (LList[str]): Column accessors to hide. Hide takes
+            precedence over `pinned_columns`, `visible_columns`, and entries
+            in `column_order` — a hidden col never renders, regardless of
+            where else it appears.
+        column_order (LList[str]): Left-to-right order of columns. Entries are
+            written to the wire's column_order and (under permissive mode)
+            cause the col to render. Under `lock_columns=True`, entries
+            here that are not also in `pinned_columns` / `visible_columns`
+            are dropped — locked mode requires explicit declaration of intent.
+        column_widths (Dict[str, int]): Per-column pixel widths.
+        lock_columns (Optional[bool]): Opt-in toggle to lock the runs-table
+            column set to whatever's listed in `pinned_columns` /
+            `visible_columns`. `True` enables locked mode (only listed cols
+            render; auto-discovered config and summary keys are hidden).
+            `False` and `None` (default) are both permissive — all known 
+            and future columns appear, `hidden_columns`/`visible_columns` 
+            act as overrides. The lock icon in the runs-table toolbar 
+            (Reports edit mode) toggles this same flag.
+
+    Column format:
+        Columns are addressed as `"<section>:<name>"`:
+            - `run:<attr>`        — built-in run properties (e.g. `run:state`, `run:createdAt`)
+            - `config:<key>.value` — config keys (note the `.value` suffix from nested config)
+            - `summary:<key>`     — summary metrics
+            - `tags:__ALL__`      — run tags
 
     Example:
         ```python
@@ -1006,11 +1039,23 @@ class Runset(Base):
 
     run_settings: Dict[str, "RunSettings"] = Field(default_factory=dict)
 
+    pinned_columns: LList[str] = Field(default_factory=list)
+    visible_columns: LList[str] = Field(default_factory=list)
+    hidden_columns: LList[str] = Field(default_factory=list)
+    column_order: LList[str] = Field(default_factory=list)
+    column_widths: Dict[str, int] = Field(default_factory=dict)
+    lock_columns: Optional[bool] = None
+
     _id: str = Field(default_factory=internal._generate_name, init=False, repr=False)
     _selections_root: int = Field(default=1, init=False, repr=False)
 
     _stashed_filters_v2: Optional[dict] = Field(default=None, init=False, repr=False)
     _stashed_filter_string: Optional[str] = Field(default=None, init=False, repr=False)
+
+    # Stashed RunFeed; lets _to_model preserve non-column fields on round-trip.
+    _run_feed_loaded: Optional["internal.RunFeed"] = Field(
+        default=None, init=False, repr=False
+    )
 
     @model_validator(mode="after")
     def merge_custom_run_colors_into_run_settings(self):
@@ -1084,6 +1129,49 @@ class Runset(Base):
                 expr.expr_to_filters(self.filters)  # type: ignore[arg-type] # validator ensures this is always str
             )
 
+        pinned_raw = list(dict.fromkeys(self.pinned_columns))
+        visible_raw = list(dict.fromkeys(self.visible_columns))
+        hidden_cols = list(dict.fromkeys(self.hidden_columns))
+        hidden_set = set(hidden_cols)
+
+        # Hide wins over pin/visible/order.
+        pinned_cols = [c for c in pinned_raw if c not in hidden_set]
+        visible_cols = [c for c in visible_raw if c not in hidden_set]
+        pinned_set = set(pinned_cols)
+        curated_set = pinned_set | set(visible_cols)
+
+        curated = pinned_cols + [c for c in visible_cols if c not in pinned_set]
+        explicit_order = [
+            c for c in dict.fromkeys(self.column_order) if c not in hidden_set
+        ]
+        combined_order = explicit_order + [
+            c for c in curated if c not in set(explicit_order)
+        ]
+        if self.lock_columns:
+            col_order = [c for c in combined_order if c in curated_set]
+        else:
+            col_order = combined_order
+
+        # FE invariant: column_visible True entries must mirror column_order.
+        column_visible: Dict[str, bool] = {col: False for col in hidden_cols}
+        column_visible.update({col: True for col in col_order})
+
+        column_pinned = {col: True for col in pinned_cols}
+
+        col_fields = {
+            "column_visible": column_visible,
+            "column_pinned": column_pinned,
+            "column_order": col_order,
+            "column_widths": dict(self.column_widths),
+            "lock_columns": self.lock_columns,
+        }
+        # Start from the stashed RunFeed so non-column fields (page_size,
+        # only_show_selected, future additions) survive round-trip.
+        if self._run_feed_loaded is not None:
+            run_feed = self._run_feed_loaded.model_copy(update=col_fields)
+        else:
+            run_feed = internal.RunFeed(**col_fields)
+
         obj = internal.Runset(
             project=project,
             name=self.name,
@@ -1094,6 +1182,7 @@ class Runset(Base):
             selections=internal.RunsetSelections(
                 root=self._selections_root, tree=tree_ids
             ),
+            run_feed=run_feed,
         )
         obj.id = self._id
         return obj
@@ -1132,6 +1221,27 @@ class Runset(Base):
             stashed_v2 = expr.filters_tree_to_v2(model.filters)
             filter_string = expr.filters_v2_to_string(stashed_v2)
 
+        rf = model.run_feed
+        pinned_columns = [
+            col for col, is_pinned in rf.column_pinned.items() if is_pinned
+        ]
+        pinned_set = set(pinned_columns)
+        hidden_columns = [
+            col for col, is_visible in rf.column_visible.items() if is_visible is False
+        ]
+        hidden_set = set(hidden_columns)
+        # column_order is the FE's render list. Union it with column_visible
+        # True entries (minus pin/hide) to capture cols in either source.
+        visible_from_order = [
+            c for c in rf.column_order if c not in pinned_set and c not in hidden_set
+        ]
+        visible_from_dict = [
+            c
+            for c, v in rf.column_visible.items()
+            if v is True and c not in pinned_set and c not in set(visible_from_order)
+        ]
+        visible_columns = visible_from_order + visible_from_dict
+
         obj = cls(
             entity=entity,
             project=project,
@@ -1141,11 +1251,18 @@ class Runset(Base):
             groupby=[expr.to_frontend_name(k.name) for k in model.grouping],
             order=[OrderBy._from_model(s) for s in model.sort.keys],
             run_settings=run_settings,
+            pinned_columns=pinned_columns,
+            visible_columns=visible_columns,
+            hidden_columns=hidden_columns,
+            column_order=list(rf.column_order),
+            column_widths=dict(rf.column_widths),
+            lock_columns=rf.lock_columns,
         )
         obj._id = model.id
         obj._selections_root = model.selections.root
         obj._stashed_filters_v2 = stashed_v2
         obj._stashed_filter_string = filter_string
+        obj._run_feed_loaded = rf.model_copy(deep=True)
         return obj
 
 

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -337,6 +337,7 @@ class RunFeed(ReportAPIBaseModel):
     column_order: LList[str] = Field(default_factory=list)
     page_size: int = 10
     only_show_selected: bool = False
+    lock_columns: Optional[bool] = None
 
 
 class Sort(ReportAPIBaseModel):


### PR DESCRIPTION
JIRA/GH Issues(s)
-----------
https://coreweave.atlassian.net/browse/WB-33632

Description
-----------
**note:** requires [frontend PR](https://github.com/wandb/core/pull/43679) to view the column changes

- Adds `pinned_columns`, `visible_columns`, `hidden_columns`, `column_order`, `column_widths`, and `lock_columns` to `wr.Runset` for programmatic column config
- Adds `lockColumns` wire field for opt-in allowlist mode (only listed cols render, future-logged keys are auto-hidden at every render)
- Drops columnConfigModified from the wire (dead code in favor of `lockColumns`) 

`lock_columns=True` opts into allowlist mode. False/None is permissive (default). When locked, the runset hides everything not in pinned_columns / visible_columns at every load. Hide is absolute: a col in `hidden_columns` is stripped from pin/visible/order on save. Prevents silent "I thought I hid this" bugs.

**Overall adds functionality to configure what and how columns are displayed in runsets with the addition of lock_columns to simplify DX to not have to define all columns in either `hidden_columns` or `visible_columns` and hide future unknown columns.**

ex.
```python
runset = wr.Runset(
    entity=ENTITY,
    project=PROJECT,
    name="Runs",
    filters=f'Metric("Sweep") in ({quoted_sweep_ids})',
    groupby=["Sweep"],
    pinned_columns=["run:displayName"],
    visible_columns=[
        "summary:accuracy",
        "summary:f1_score",
        "summary:loss",
        "config:learning_rate.value",
        "config:batch_size.value",
        "run:state",
        "run:duration",
    ],
    lock_columns=True,
)
```

[ex report created to show diff in SDK usage using the column config](https://wandb.ai/wandb/wb33632-column-config-smoketest/reports/WB-33632-K-customer-sweep-style-report-post-fix-DX---VmlldzoxNjg3MjkxMQ) 

Testing
-------
[py script to generate runs and reports with different configs](https://github.com/user-attachments/files/27733633/wb33632_pr_demo.py)

