### PR TITLE
feat(sdk): support baseline_run and pinned_runs in RunsetSettings

### DIFF
--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import sys
 from typing import Any, Dict, Generic, Type, TypeVar
@@ -452,3 +453,155 @@ def test_workspace_lineplot_metric_regex():
     workspace2 = ws.Workspace._from_model(model)
     panel2 = workspace2.sections[0].panels[0]
     assert panel2.metric_regex == "train/.*"
+
+
+# Baseline / Pinned Runs Tests
+
+
+def test_baseline_and_pinned_runs_roundtrip():
+    """Both baseline_run and pinned_runs round-trip through _to_model /
+    _from_model: slugs in, base64-encoded `Run:v1:` GIDs on the wire (the
+    format the viewspec stores), slugs back out on read."""
+    workspace = ws.Workspace(
+        entity="test-entity",
+        project="test-project",
+        runset_settings=ws.RunsetSettings(
+            baseline_run="1mbku38n",
+            pinned_runs=["1mbku38n", "2u1g3j1c"],
+        ),
+    )
+
+    model = workspace._to_model()
+    runset = model.spec.section.run_sets[0]
+
+    expected_baseline_gid = base64.b64encode(
+        b"Run:v1:1mbku38n:test-project:test-entity"
+    ).decode()
+    expected_pinned_gids = [
+        base64.b64encode(b"Run:v1:1mbku38n:test-project:test-entity").decode(),
+        base64.b64encode(b"Run:v1:2u1g3j1c:test-project:test-entity").decode(),
+    ]
+    assert runset.baseline_run_id == expected_baseline_gid
+    assert runset.pinned_run_ids == expected_pinned_gids
+
+    # Verify the camelCase keys land in the dumped spec JSON
+    dumped = model.spec.model_dump(by_alias=True, exclude_none=True)
+    rs_dump = dumped["section"]["runSets"][0]
+    assert rs_dump["baselineRunId"] == expected_baseline_gid
+    assert rs_dump["pinnedRunIds"] == expected_pinned_gids
+
+    workspace2 = ws.Workspace._from_model(model)
+    assert workspace2.runset_settings.baseline_run == "1mbku38n"
+    assert workspace2.runset_settings.pinned_runs == ["1mbku38n", "2u1g3j1c"]
+
+
+def test_pinned_runs_encoded_with_workspace_project_and_entity():
+    """The encoded GID embeds the workspace's own (project, entity), so the
+    same slug used in two workspaces produces two different GIDs."""
+    ws_a = ws.Workspace(
+        entity="entity-a",
+        project="project-a",
+        runset_settings=ws.RunsetSettings(pinned_runs=["g0dpjzew"]),
+    )
+    ws_b = ws.Workspace(
+        entity="entity-b",
+        project="project-b",
+        runset_settings=ws.RunsetSettings(pinned_runs=["g0dpjzew"]),
+    )
+
+    gid_a = ws_a._to_model().spec.section.run_sets[0].pinned_run_ids[0]
+    gid_b = ws_b._to_model().spec.section.run_sets[0].pinned_run_ids[0]
+
+    assert gid_a != gid_b
+    assert base64.b64decode(gid_a).decode() == "Run:v1:g0dpjzew:project-a:entity-a"
+    assert base64.b64decode(gid_b).decode() == "Run:v1:g0dpjzew:project-b:entity-b"
+
+
+def test_from_model_decodes_legacy_gid_inputs():
+    """`_from_model` decodes GID-encoded pinned/baseline values into slugs,
+    so users always see the slug form on read regardless of what the spec
+    happens to hold today."""
+    workspace = ws.Workspace(
+        entity="test-entity",
+        project="test-project",
+        runset_settings=ws.RunsetSettings(
+            baseline_run="1mbku38n",
+            pinned_runs=["1mbku38n", "2u1g3j1c"],
+        ),
+    )
+    model = workspace._to_model()
+
+    # Round-trip through the encoded GID form back to slugs
+    decoded = ws.Workspace._from_model(model)
+    assert decoded.runset_settings.baseline_run == "1mbku38n"
+    assert decoded.runset_settings.pinned_runs == ["1mbku38n", "2u1g3j1c"]
+
+
+def test_encode_passthrough_for_already_encoded_gid():
+    """If the user happens to pass an already-encoded `Run:v1:` GID (e.g.
+    from legacy code that did the base64 encoding by hand), the encoder
+    leaves it alone instead of double-encoding it."""
+    legacy_gid = base64.b64encode(
+        b"Run:v1:g0dpjzew:legacy-project:legacy-entity"
+    ).decode()
+    workspace = ws.Workspace(
+        entity="new-entity",
+        project="new-project",
+        runset_settings=ws.RunsetSettings(pinned_runs=[legacy_gid]),
+    )
+
+    pinned = workspace._to_model().spec.section.run_sets[0].pinned_run_ids
+    assert pinned == [legacy_gid]
+
+
+def test_baseline_run_auto_added_to_pinned():
+    """Setting only baseline_run auto-adds it to pinned_runs (mirrors the W&B
+    app's setRunPinnedAndBaseline write path)."""
+    runset_settings = ws.RunsetSettings(baseline_run="1mbku38n")
+    assert runset_settings.pinned_runs == ["1mbku38n"]
+
+
+def test_baseline_already_in_pinned_not_duplicated():
+    """If the user already includes the baseline in pinned_runs, the validator
+    leaves the list untouched."""
+    runset_settings = ws.RunsetSettings(
+        baseline_run="1mbku38n",
+        pinned_runs=["1mbku38n", "2u1g3j1c"],
+    )
+    assert runset_settings.pinned_runs == ["1mbku38n", "2u1g3j1c"]
+
+
+def test_empty_baseline_and_pinned():
+    """Defaults serialize cleanly: no baselineRunId / pinnedRunIds keys in the
+    dumped spec, and round-trip yields the same defaults."""
+    workspace = ws.Workspace(
+        entity="test-entity",
+        project="test-project",
+        runset_settings=ws.RunsetSettings(),
+    )
+
+    model = workspace._to_model()
+    runset = model.spec.section.run_sets[0]
+    assert runset.baseline_run_id is None
+    assert runset.pinned_run_ids is None
+
+    dumped = model.spec.model_dump(by_alias=True, exclude_none=True)
+    rs_dump = dumped["section"]["runSets"][0]
+    assert "baselineRunId" not in rs_dump
+    assert "pinnedRunIds" not in rs_dump
+
+    workspace2 = ws.Workspace._from_model(model)
+    assert workspace2.runset_settings.baseline_run is None
+    assert workspace2.runset_settings.pinned_runs == []
+
+
+def test_pinned_runs_over_cap_warns():
+    """Exceeding the app's MAX_PINNED_RUNS (20) emits a termwarn but still
+    serializes every entry the user provided."""
+    too_many = [f"run{i}" for i in range(21)]
+    with patch("wandb_workspaces.workspaces.interface.wandb.termwarn") as warn:
+        runset_settings = ws.RunsetSettings(pinned_runs=too_many)
+
+    warn.assert_called_once()
+    assert "21" in warn.call_args.args[0]
+    assert runset_settings.pinned_runs == too_many

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -368,6 +368,8 @@ class Runset(ReportAPIBaseModel):
     sort: Sort = Field(default_factory=Sort)
     selections: RunsetSelections = Field(default_factory=RunsetSelections)
     expanded_row_addresses: list = Field(default_factory=list)
+    baseline_run_id: Optional[str] = None
+    pinned_run_ids: Optional[LList[str]] = None
 
 
 class CodeLine(ReportAPIBaseModel):

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -26,6 +26,7 @@ workspace.save()
 ```
 """
 
+import base64
 import os
 from typing import Dict, Iterable, Literal, Optional, Union
 from typing import List as LList
@@ -42,6 +43,41 @@ from wandb_workspaces.utils.validators import validate_no_emoji, validate_url
 
 from .. import expr
 from . import internal
+
+
+def _encode_run_gid(slug: str, project: str, entity: str) -> str:
+    """Encode a run slug into the GraphQL Relay GID form the viewspec stores.
+
+    The W&B app's viewspec stores pinned/baseline runs as base64-encoded
+    `Run:v1:<slug>:<project>:<entity>` GIDs (see `gorilla.RunID`). The SDK
+    accepts the user-friendly slug (the value of `wandb.Run.id`) and encodes
+    here at the serialization boundary, so users never see the GID form.
+
+    If the input already looks like a v1 Run GID, it's passed through
+    unchanged so users with pre-existing GID values aren't broken.
+    """
+    if _decode_run_gid(slug) != slug:
+        return slug
+    payload = f"Run:v1:{slug}:{project}:{entity}".encode("utf-8")
+    return base64.b64encode(payload).decode("ascii")
+
+
+def _decode_run_gid(value: Optional[str]) -> Optional[str]:
+    """Inverse of `_encode_run_gid`: extract the slug from a v1 Run GID.
+
+    Non-GID inputs (already-decoded slugs, garbage strings) are returned
+    unchanged so the read path is forgiving across spec format transitions.
+    """
+    if not value:
+        return value
+    try:
+        decoded = base64.b64decode(value, validate=True).decode("utf-8")
+    except Exception:
+        return value
+    parts = decoded.split(":")
+    if len(parts) >= 5 and parts[0] in ("Run", "BucketType") and parts[1] == "v1":
+        return ":".join(parts[2:-2])
+    return value
 
 __all__ = [
     "SectionLayoutSettings",
@@ -337,6 +373,18 @@ class RunsetSettings(Base):
             Column names use format: "run:displayName", "summary:metric", "config:param".
             run:displayName is automatically added if not present.
             Example: ["summary:accuracy", "summary:loss"]
+        baseline_run (Optional[str]): W&B run slug of the baseline run (the
+            value of `wandb.Run.id`, e.g. `"1mbku38n"` — also the last path
+            segment of a run URL). Used for delta columns and comparison
+            styling. When set, the baseline run is automatically added to
+            `pinned_runs` to match the W&B app's behavior. Must refer to a
+            run in the workspace's own project — cross-project pins are not
+            supported by this SDK yet (see the W&B app's "Add cross-project
+            runs" drawer for the UI equivalent).
+        pinned_runs (LList[str]): Ordered list of W&B run slugs to keep
+            visible in the run selector and always fetched for plots. Pass
+            slug strings (`wandb.Run.id`), not GraphQL IDs. The W&B app
+            caps this at 20 entries.
 
     Example:
         ```python
@@ -344,6 +392,8 @@ class RunsetSettings(Base):
         RunsetSettings(
             filters="Config('learning_rate') = 0.001 and State = 'finished'",
             pinned_columns=["summary:accuracy", "summary:loss"],
+            baseline_run="1mbku38n",  # wandb.Run.id (the slug from the URL)
+            pinned_runs=["1mbku38n", "2u1g3j1c"],
         )
 
         # Using FilterExpr list (original way)
@@ -381,6 +431,10 @@ class RunsetSettings(Base):
     # Column management
     pinned_columns: LList[str] = Field(default_factory=list)
 
+    # Baseline / pinned runs
+    baseline_run: Optional[str] = None
+    pinned_runs: LList[str] = Field(default_factory=list)
+
     # Internal fields for backend serialization (not user-facing)
     _visible_columns: LList[str] = Field(default_factory=list, init=False, repr=False)
     _column_order: LList[str] = Field(default_factory=list, init=False, repr=False)
@@ -403,6 +457,26 @@ class RunsetSettings(Base):
             object.__setattr__(self, "_visible_columns", list(self.pinned_columns))
             object.__setattr__(self, "_column_order", list(self.pinned_columns))
 
+        return self
+
+    @model_validator(mode="after")
+    def ensure_baseline_pinned(self):
+        """Mirror the W&B app's invariant: a baseline run is always also pinned.
+
+        The frontend's `setBaselineRun` action handler routes through
+        `setRunPinnedAndBaseline`, so any spec produced by the UI has the
+        baseline ID present in `pinnedRunIds`. We enforce the same here so
+        SDK-produced specs match.
+        """
+        if self.baseline_run and self.baseline_run not in self.pinned_runs:
+            new_pinned = list(self.pinned_runs)
+            new_pinned.append(self.baseline_run)
+            object.__setattr__(self, "pinned_runs", new_pinned)
+        if len(self.pinned_runs) > 20:
+            wandb.termwarn(
+                f"pinned_runs has {len(self.pinned_runs)} entries; "
+                "the W&B app caps pinned runs at 20."
+            )
         return self
 
     @model_validator(mode="after")
@@ -585,6 +659,15 @@ class Workspace(Base):
                 ],
                 run_settings=run_settings,
                 pinned_columns=pinned_columns,
+                baseline_run=_decode_run_gid(
+                    model.spec.section.run_sets[0].baseline_run_id
+                ),
+                pinned_runs=[
+                    _decode_run_gid(rid) or rid
+                    for rid in (
+                        model.spec.section.run_sets[0].pinned_run_ids or []
+                    )
+                ],
             ),
         )
         obj._internal_name = model.name
@@ -686,6 +769,23 @@ class Workspace(Base):
                                     for id, config in self.runset_settings.run_settings.items()
                                     if config.disabled
                                 ],
+                            ),
+                            baseline_run_id=(
+                                _encode_run_gid(
+                                    self.runset_settings.baseline_run,
+                                    self.project,
+                                    self.entity,
+                                )
+                                if self.runset_settings.baseline_run
+                                else None
+                            ),
+                            pinned_run_ids=(
+                                [
+                                    _encode_run_gid(s, self.project, self.entity)
+                                    for s in self.runset_settings.pinned_runs
+                                ]
+                                if self.runset_settings.pinned_runs
+                                else None
                             ),
                         ),
                     ],


### PR DESCRIPTION
## Jira
https://coreweave.atlassian.net/browse/WB-34105

## Summary

Adds `baseline_run` and `pinned_runs` to `RunsetSettings` so the SDK can configure the runset's baseline + pinned runs the same way the W&B app does (no more workspace UI required to pin a run).

Users pass run **slugs** -- the value of `wandb.Run.id` (e.g. `"g0dpjzew"`), which is also the last segment of a run URL

```python
import wandb_workspaces.workspaces as ws

ws.Workspace(
    entity="my-team",
    project="my-project",
    runset_settings=ws.RunsetSettings(
        baseline_run="g0dpjzew",
        pinned_runs=["g0dpjzew", "abc1234"],
    ),
).save()
```

## What it does

- New `RunsetSettings.baseline_run: Optional[str]` and `RunsetSettings.pinned_runs: list[str]` fields.
- Mirrors the W&B app's `setRunPinnedAndBaseline` invariant: setting only `baseline_run` auto-adds it to `pinned_runs`.
- Warns (but still serializes) when `pinned_runs` exceeds the app's 20-entry cap.
- At the serialization boundary the SDK encodes user-supplied slugs into the `base64("Run:v1:<slug>:<project>:<entity>")` GID form the viewspec currently stores, using the workspace's own `entity` / `project`.

## Forward compatibility

The encode/decode logic is isolated to two helpers (`_encode_run_gid` / `_decode_run_gid`) so two upcoming changes can land **without touching this public API**:

1. **Cross-project pins** — purely additive. We'll widen accepted inputs to also allow `"entity/project/slug"` strings (or a typed `RunRef`) alongside today's bare slugs. Same-project users keep writing `pinned_runs=[run.id, ...]` unchanged.
2. **Viewspec format change to rename-stable composite ID** (e.g. `(slug, projectInternalId)`) — zero impact on the SDK signature. Only the encoder/decoder swap out.

Existing `Run:v1:` GID values are also passed through unchanged in the encoder so any legacy callers don't double-encode.

## Test plan
Successfully writes baseline + pinned runs to new saved view:

https://github.com/user-attachments/assets/37d03bab-735d-4f79-8e99-c17fa121a4c0

Successfully writes baseline + pinned runs to existing saved view:


https://github.com/user-attachments/assets/5291a6a2-3c3f-4b23-a349-3e94d2d591fe



- [x] `pytest tests/test_workspaces.py` — 42 passed, including:
  - `test_baseline_and_pinned_runs_roundtrip` — slugs in, encoded GIDs on the wire, slugs back out
  - `test_pinned_runs_encoded_with_workspace_project_and_entity` — same slug in two workspaces produces two different GIDs
  - `test_from_model_decodes_legacy_gid_inputs` — read path always returns slugs
  - `test_encode_passthrough_for_already_encoded_gid` — legacy callers passing pre-encoded GIDs still work
  - `test_baseline_run_auto_added_to_pinned`
  - `test_baseline_already_in_pinned_not_duplicated`
  - `test_empty_baseline_and_pinned`
  - `test_pinned_runs_over_cap_warns`
- [x] Verified live end-to-end : the saved viewspec has the expected `baselineRunId` / `pinnedRunIds` base64 GID values and the UI shows the pinned runs.