### PR TITLE
chore(release): auto-detect server-compat labels in release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,3 +24,21 @@ How was this PR tested?
 - [ ] _Manual testing (include description)_
 - [ ] _N/A (include explanation)_
 
+Server compatibility
+--------------------
+<!--
+If this PR relies on backend or UI behavior that only exists in some
+W&B Server releases, apply the matching label from the Labels sidebar:
+
+  - `requires-server/X.Y+`     — minimum tagged server release needed
+  - `requires-server/unreleased` — works on SaaS today but not yet in any
+                                   tagged server release; on-prem users
+                                   should wait for a future server.
+
+Leave unchecked if the change is pure SDK / works on all supported servers.
+-->
+
+- [ ] _Requires a minimum W&B Server version (label `requires-server/X.Y+` applied)_
+- [ ] _SaaS only — not yet in any tagged W&B Server release (label `requires-server/unreleased` applied)_
+- [ ] _N/A — works on all currently supported servers_
+

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -93,7 +93,81 @@ jobs:
               dist/*.whl \
               dist/*.tar.gz
           fi
-          
+
+      - name: Inject server-compatibility section into release notes
+        if: steps.version-check.outputs.version_changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          TAG="v${{ steps.version-check.outputs.version }}"
+
+          # Previous tag = highest semver tag other than the current one.
+          PREV_TAG=$(gh api "repos/${REPO}/tags" --jq '.[].name' \
+            | grep -vx "${TAG}" | sort -V | tail -1)
+          if [ -z "${PREV_TAG}" ]; then
+            echo "No previous tag found; skipping compatibility section."
+            exit 0
+          fi
+          echo "Scanning PRs between ${PREV_TAG} and HEAD..."
+
+          # Enumerate every commit truly in the range PREV_TAG..HEAD via the
+          # compare API (commit-accurate, unlike a date filter which can mix
+          # overlapping releases or hotfix branches).
+          SHAS=$(gh api --paginate "repos/${REPO}/compare/${PREV_TAG}...HEAD" \
+            --jq '.commits[].sha')
+
+          # Look up the PR each commit came from, dedupe by PR number, and
+          # shape the JSON to match what `gh pr list --json` returns so the
+          # downstream jq stays simple.
+          PRS_JSON=$(
+            for sha in ${SHAS}; do
+              gh api "repos/${REPO}/commits/${sha}/pulls" 2>/dev/null \
+                | jq -c '.[] | select(.merged_at != null) | {
+                    number,
+                    title,
+                    url: .html_url,
+                    author: { login: .user.login },
+                    labels: [.labels[] | {name}]
+                  }'
+            done | jq -s 'unique_by(.number)'
+          )
+
+          # Group PRs by their `requires-server/*` label. If a PR carries
+          # multiple such labels, only the highest tier is kept — a PR
+          # requiring server >= 0.78 trivially also runs on 0.76+, so it
+          # should appear once under the most-restrictive tier.
+          BLOCK=$(printf '%s' "${PRS_JSON}" | jq -r '
+              # vparts sorts "unreleased" above any numeric tier so SaaS-only
+              # features (not yet in any server release) lead the section.
+              def vparts: if . == "unreleased" then [9999] else split(".") | map(tonumber) end;
+              def heading: if . == "unreleased"
+                then "Not yet in any W&B Server release (SaaS only)"
+                else "Requires W&B Server >= " + . end;
+              [ .[] | . as $pr
+                | .labels[] | select(.name | startswith("requires-server/"))
+                | { version: (.name | sub("requires-server/"; "") | rtrimstr("+")), pr: $pr } ]
+              | group_by(.pr.number)
+              | map(max_by(.version | vparts))
+              | group_by(.version)
+              | sort_by(.[0].version | vparts) | reverse
+              | map(
+                  "### " + (.[0].version | heading) + "\n" +
+                  (map("* " + .pr.title + " by @" + .pr.author.login + " in " + .pr.url) | join("\n"))
+                )
+              | join("\n\n")
+            ')
+
+          if [ -z "${BLOCK}" ] || [ "${BLOCK}" = "null" ]; then
+            echo "No requires-server/* labels on PRs in this release; leaving notes unchanged."
+            exit 0
+          fi
+
+          CURRENT=$(gh release view "${TAG}" --json body --jq '.body')
+          printf "%s\n\n%s\n" "${BLOCK}" "${CURRENT}" \
+            | gh release edit "${TAG}" --notes-file -
+          echo "Prepended server-compatibility section to ${TAG} notes."
+
       - name: Publish to PyPI
         if: steps.version-check.outputs.version_changed == 'true'
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1


### PR DESCRIPTION
Adds a post-release step to auto-release.yml that scans every PR merged since the previous tag for `requires-server/X.Y+` labels, groups them by version, and prepends a "Requires W&B Server >= X.Y" section to the release notes. If the feature is in saas but not server, you can add a server-release/unreleased tag

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
Please use conventional commits in your PR title. If you are unsure what conventional commits are or how to use them, please check out [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits).

JIRA/GH Issues(s)
-----------
https://coreweave.atlassian.net/browse/WB-34893
https://coreweave.atlassian.net/browse/WB-34406?search_id=010a1f6a-a5e0-4a1e-ae0b-c8e6ce2d8ae8

Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
_What does this PR do? Write a short paragraph to contextualize and explain your change._

Testing
-------
Ran test script on current release with some sample labels:
```
#!/usr/bin/env bash
#
# Preview the release notes that auto-release.yml would generate for an
# upcoming release, including the server-compatibility section produced by
# scanning `requires-server/*` labels on merged PRs.
#
# Usage:
#   scripts/preview-release-notes.sh [TAG] [TARGET_COMMITISH] [PREVIOUS_TAG]
#
# Examples:
#   # Preview v0.3.10 generated from the release PR branch
#   scripts/preview-release-notes.sh v0.3.10 release/v0.3.10
#
#   # Preview v0.4.0 generated from main, with explicit prev tag
#   scripts/preview-release-notes.sh v0.4.0 main v0.3.10
#
# Requirements: gh CLI authenticated, jq.

set -euo pipefail

REPO="${REPO:-wandb/wandb-workspaces}"
TAG="${1:-v0.3.10}"
TARGET="${2:-main}"
PREV_TAG="${3:-}"

if [ -z "${PREV_TAG}" ]; then
  PREV_TAG=$(gh api "repos/${REPO}/tags" --jq '.[].name' \
    | grep -vx "${TAG}" | sort -V | tail -1)
fi

PREV_DATE=$(gh release view "${PREV_TAG}" --repo "${REPO}" --json publishedAt --jq '.publishedAt')

cat <<EOF
Repo:           ${REPO}
Upcoming tag:   ${TAG}
Target branch:  ${TARGET}
Previous tag:   ${PREV_TAG}  (published ${PREV_DATE})

EOF

# Step 1: base notes from GitHub's --generate-notes equivalent
BASE=$(gh api "repos/${REPO}/releases/generate-notes" \
  -X POST \
  -f tag_name="${TAG}" \
  -f previous_tag_name="${PREV_TAG}" \
  -f target_commitish="${TARGET}" \
  --jq '.body')

# Step 2: server-compatibility block from scraping requires-server/* labels
BLOCK=$(gh pr list \
    --repo "${REPO}" --state merged --base main --limit 200 \
    --search "merged:>${PREV_DATE}" \
    --json number,title,url,author,labels \
  | jq -r '
      def vparts: split(".") | map(tonumber);
      [ .[] | . as $pr
        | .labels[] | select(.name | startswith("requires-server/"))
        | { version: (.name | sub("requires-server/"; "") | rtrimstr("+")), pr: $pr } ]
      | group_by(.pr.number)
      | map(max_by(.version | vparts))
      | group_by(.version)
      | sort_by(.[0].version | vparts) | reverse
      | map(
          "### Requires W&B Server >= " + .[0].version + "\n" +
          (map("* " + .pr.title + " by @" + .pr.author.login + " in " + .pr.url) | join("\n"))
        )
      | join("\n\n")
    ')

echo "============================================================"
echo "  STAGE 1: base notes (from gh release create --generate-notes)"
echo "============================================================"
echo "${BASE}"
echo

echo "============================================================"
echo "  STAGE 2: server-compat block (from scraping requires-server/* labels)"
echo "============================================================"
if [ -z "${BLOCK}" ] || [ "${BLOCK}" = "null" ]; then
  echo "(none — no PRs in this range carry a requires-server/* label)"
else
  echo "${BLOCK}"
fi
echo

echo "============================================================"
echo "  STAGE 3: FINAL notes (what users will see on the release page)"
echo "============================================================"
if [ -z "${BLOCK}" ] || [ "${BLOCK}" = "null" ]; then
  echo "${BASE}"
else
  printf "%s\n\n%s\n" "${BLOCK}" "${BASE}"
fi
```
and got:
```
$ timeout 30 /Users/mbarrramsey/core/wandb-workspaces-contrib/scripts/preview-release-notes.sh v0.3.10 release/v0.3.10 2>&1 | sed -n '/STAGE 2/,$p'
STAGE 2: server-compat block (from scraping requires-server/* labels)
============================================================
### Requires W&B Server >= 0.78
* fix(sdk): legacy filters adding nesting by @mbarrramsey in https://github.com/wandb/wandb-workspaces/pull/157
* fix: normalize filter value key by @acasey-wandb in https://github.com/wandb/wandb-workspaces/pull/161
* feat(sdk): support baseline_run and pinned_runs in RunsetSettings by @mbarrramsey in https://github.com/wandb/wandb-workspaces/pull/165

============================================================
  STAGE 3: FINAL notes (what users will see on the release page)
============================================================
### Requires W&B Server >= 0.78
* fix(sdk): legacy filters adding nesting by @mbarrramsey in https://github.com/wandb/wandb-workspaces/pull/157
* fix: normalize filter value key by @acasey-wandb in https://github.com/wandb/wandb-workspaces/pull/161
* feat(sdk): support baseline_run and pinned_runs in RunsetSettings by @mbarrramsey in https://github.com/wandb/wandb-workspaces/pull/165

## What's Changed
* fix: preserve sort key section in OrderBy round-trip by @willtryagain in https://github.com/wandb/wandb-workspaces/pull/148
* fix(sdk): legacy filters adding nesting by @mbarrramsey in https://github.com/wandb/wandb-workspaces/pull/157
* chore(security): enable Renovate for GitHub Actions SHA pinning by @shivawandb in https://github.com/wandb/wandb-workspaces/pull/164
* fix: normalize filter value key by @acasey-wandb in https://github.com/wandb/wandb-workspaces/pull/161
* feat(sdk): support baseline_run and pinned_runs in RunsetSettings by @mbarrramsey in https://github.com/wandb/wandb-workspaces/pull/165

## New Contributors
* @shivawandb made their first contribution in https://github.com/wandb/wandb-workspaces/pull/164

**Full Changelog**: https://github.com/wandb/wandb-workspaces/compare/v0.3.9...v0.3.10
```

with labels added for testing:
<img width="1418" height="453" alt="Screenshot 2026-05-27 at 11 54 48 AM" src="https://github.com/user-attachments/assets/6a1fc5f0-9955-4f75-8e7a-0a49f4f291a3" />

<img width="1479" height="449" alt="Screenshot 2026-05-27 at 11 55 04 AM" src="https://github.com/user-attachments/assets/8367e81e-88ea-4ecb-b833-0e9b391ac2ca" />

<img width="1403" height="444" alt="Screenshot 2026-05-27 at 11 55 15 AM" src="https://github.com/user-attachments/assets/fbec7a44-ccc1-4737-bead-a80615ebc5fc" />

- [ ] _Added unit tests_
- [ ] _Manual testing (include description)_
- [ ] _N/A (include explanation)_

