### PR TITLE
fix: avoid import-time wandb_gql dependency

### DIFF
--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,0 +1,93 @@
+import subprocess
+import sys
+import textwrap
+import types
+
+from wandb_workspaces._graphql import execute_graphql
+
+
+def test_report_and_workspace_imports_do_not_require_wandb_gql():
+    script = textwrap.dedent(
+        """
+        import builtins
+        import importlib
+        import sys
+
+        import wandb
+
+        for module_name in list(sys.modules):
+            if module_name == "wandb_gql" or module_name.startswith("wandb_gql."):
+                del sys.modules[module_name]
+
+        real_import = builtins.__import__
+
+        def guarded_import(name, *args, **kwargs):
+            if name == "wandb_gql" or name.startswith("wandb_gql."):
+                raise ModuleNotFoundError("No module named 'wandb_gql'")
+            return real_import(name, *args, **kwargs)
+
+        builtins.__import__ = guarded_import
+
+        for module_name in [
+            "wandb_workspaces.reports.v1.mutations",
+            "wandb_workspaces.reports.v2",
+            "wandb_workspaces.workspaces.internal",
+        ]:
+            importlib.import_module(module_name)
+
+        print("ok")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_execute_graphql_prefers_service_api():
+    class ServiceApi:
+        def __init__(self):
+            self.calls = []
+
+        def execute_graphql(self, query, variables=None):
+            self.calls.append((query, variables))
+            return {"ok": True}
+
+    class Api:
+        def __init__(self):
+            self._service_api = ServiceApi()
+
+    api = Api()
+    result = execute_graphql(api, "query Test { viewer { id } }", {"x": 1})
+
+    assert result == {"ok": True}
+    assert api._service_api.calls == [("query Test { viewer { id } }", {"x": 1})]
+
+
+def test_execute_graphql_lazily_uses_wandb_gql_for_legacy_clients(monkeypatch):
+    class Client:
+        def __init__(self):
+            self.calls = []
+
+        def execute(self, query, *, variable_values):
+            self.calls.append((query, variable_values))
+            return {"ok": True}
+
+    class Api:
+        def __init__(self):
+            self.client = Client()
+
+    fake_wandb_gql = types.SimpleNamespace(gql=lambda query: f"parsed:{query}")
+    monkeypatch.setitem(sys.modules, "wandb_gql", fake_wandb_gql)
+
+    api = Api()
+    result = execute_graphql(api, "query Test { viewer { id } }", {"x": 1})
+
+    assert result == {"ok": True}
+    assert api.client.calls == [("parsed:query Test { viewer { id } }", {"x": 1})]

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -3,7 +3,7 @@ import sys
 import textwrap
 import types
 
-from wandb_workspaces._graphql import execute_graphql
+from wandb_workspaces._graphql import execute_graphql, get_app_url
 
 
 def test_report_and_workspace_imports_do_not_require_wandb_gql():
@@ -91,3 +91,24 @@ def test_execute_graphql_lazily_uses_wandb_gql_for_legacy_clients(monkeypatch):
 
     assert result == {"ok": True}
     assert api.client.calls == [("parsed:query Test { viewer { id } }", {"x": 1})]
+
+
+def test_get_app_url_prefers_service_api_without_client():
+    class ServiceApi:
+        app_url = "https://service.wandb.test/"
+
+    class Api:
+        def __init__(self):
+            self._service_api = ServiceApi()
+
+    assert get_app_url(Api()) == "https://service.wandb.test/"
+
+
+def test_get_app_url_falls_back_to_legacy_client():
+    class Client:
+        app_url = "https://legacy.wandb.test/"
+
+    class Api:
+        client = Client()
+
+    assert get_app_url(Api()) == "https://legacy.wandb.test/"

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -316,9 +316,9 @@ def test_idempotency(request, factory_name) -> None:
 
     # Panels must preserve their id through the round-trip
     if factory_name in panel_factory_names:
-        assert (
-            model.id
-        ), f"{cls.__name__}: panel id should not be empty after _to_model()"
+        assert model.id, (
+            f"{cls.__name__}: panel id should not be empty after _to_model()"
+        )
 
 
 def test_fix_panel_collisions():
@@ -638,9 +638,9 @@ def test_metric_to_backend_groupby():
 
     for input_val, expected in test_cases:
         result = wr.interface._metric_to_backend_groupby(input_val)
-        assert (
-            result == expected
-        ), f"Input: {input_val!r}, Expected: {expected!r}, Got: {result!r}"
+        assert result == expected, (
+            f"Input: {input_val!r}, Expected: {expected!r}, Got: {result!r}"
+        )
 
 
 def test_metric_to_frontend_groupby():
@@ -660,9 +660,9 @@ def test_metric_to_frontend_groupby():
 
     for input_val, expected in test_cases:
         result = wr.interface._metric_to_frontend_groupby(input_val)
-        assert (
-            result == expected
-        ), f"Input: {input_val!r}, Expected: {expected!r}, Got: {result!r}"
+        assert result == expected, (
+            f"Input: {input_val!r}, Expected: {expected!r}, Got: {result!r}"
+        )
 
 
 def test_orderby_round_trip_preserves_section():
@@ -1033,9 +1033,9 @@ def test_block_validation_no_unknown_blocks():
 
     # Ensure no blocks are UnknownBlock
     for block in model.spec.blocks:
-        assert not isinstance(
-            block, internal.UnknownBlock
-        ), f"Block should not be UnknownBlock, got {type(block).__name__}"
+        assert not isinstance(block, internal.UnknownBlock), (
+            f"Block should not be UnknownBlock, got {type(block).__name__}"
+        )
 
     # Verify specific block types
     assert isinstance(model.spec.blocks[0], internal.Heading)
@@ -2046,9 +2046,7 @@ class TestRunsetColumnConfig:
             MAX_RUNSET_VISIBLE_COLUMNS,
         )
 
-        cols = [
-            f"summary:m{i}" for i in range(MAX_RUNSET_VISIBLE_COLUMNS - 1)
-        ]
+        cols = [f"summary:m{i}" for i in range(MAX_RUNSET_VISIBLE_COLUMNS - 1)]
         runset = wr.Runset(entity="e", project="p", visible_columns=cols)
 
         with warnings.catch_warnings():
@@ -2118,9 +2116,7 @@ class TestRunsetColumnConfig:
             MAX_RUNSET_VISIBLE_COLUMNS,
         )
 
-        visible = [
-            f"summary:v{i}" for i in range(MAX_RUNSET_VISIBLE_COLUMNS - 1)
-        ]
+        visible = [f"summary:v{i}" for i in range(MAX_RUNSET_VISIBLE_COLUMNS - 1)]
         hidden = [f"summary:h{i}" for i in range(100)]
         runset = wr.Runset(
             entity="e",
@@ -2138,6 +2134,10 @@ class TestRunsetColumnConfig:
 
 class TestReportSharing:
     """Tests for Report magic link sharing methods."""
+
+    @staticmethod
+    def _query_name(query):
+        return query.definitions[0].name.value
 
     def _make_report(self, monkeypatch):
         """Create a report with a mocked API."""
@@ -2159,17 +2159,15 @@ class TestReportSharing:
 
     def test_enable_share_link(self, monkeypatch):
         """enable_share_link creates a PUBLIC access token and returns the URL."""
-        from wandb_workspaces.reports.v2 import gql as report_gql
-
         captured = {}
 
         class _Client:
             app_url = "https://wandb.ai/"
 
             def execute(self, query, *, variable_values):
-                if query is report_gql.view_access_tokens:
+                if TestReportSharing._query_name(query) == "ViewAccessTokens":
                     return {"view": {"accessTokens": []}}
-                if query is report_gql.create_access_token:
+                if TestReportSharing._query_name(query) == "createAccessToken":
                     captured["variables"] = variable_values
                     return {
                         "createAccessToken": {
@@ -2228,13 +2226,11 @@ class TestReportSharing:
 
     def test_disable_share_link(self, monkeypatch):
         """disable_share_link revokes the active PUBLIC token."""
-        from wandb_workspaces.reports.v2 import gql as report_gql
-
         captured = {}
 
         class _Client:
             def execute(self, query, *, variable_values):
-                if query is report_gql.view_access_tokens:
+                if TestReportSharing._query_name(query) == "ViewAccessTokens":
                     return {
                         "view": {
                             "accessTokens": [
@@ -2246,7 +2242,7 @@ class TestReportSharing:
                             ]
                         }
                     }
-                if query is report_gql.revoke_access_token:
+                if TestReportSharing._query_name(query) == "revokeAccessToken":
                     captured["variables"] = variable_values
                     return {"revokeAccessToken": {"success": True}}
                 raise AssertionError(f"Unexpected query: {query}")
@@ -2263,13 +2259,11 @@ class TestReportSharing:
 
     def test_disable_share_link_revokes_all_tokens(self, monkeypatch):
         """disable_share_link revokes all active PUBLIC tokens."""
-        from wandb_workspaces.reports.v2 import gql as report_gql
-
         revoked = []
 
         class _Client:
             def execute(self, query, *, variable_values):
-                if query is report_gql.view_access_tokens:
+                if TestReportSharing._query_name(query) == "ViewAccessTokens":
                     return {
                         "view": {
                             "accessTokens": [
@@ -2278,7 +2272,7 @@ class TestReportSharing:
                             ]
                         }
                     }
-                if query is report_gql.revoke_access_token:
+                if TestReportSharing._query_name(query) == "revokeAccessToken":
                     revoked.append(variable_values["token"])
                     return {"revokeAccessToken": {"success": True}}
                 raise AssertionError(f"Unexpected query: {query}")

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -8,6 +8,7 @@ from polyfactory.factories import DataclassFactory
 from polyfactory.pytest_plugin import register_fixture
 
 import wandb_workspaces.reports.v2 as wr
+import wandb_workspaces.reports.v1 as wr_v1
 from wandb_workspaces.expr import expr_to_filters, Filters, Key
 
 T = TypeVar("T")
@@ -429,6 +430,40 @@ def test_report_delete(monkeypatch):
 
     # Ensure the GraphQL mutation received the correct variables (deleteDrafts always True)
     assert captured["variables"] == {"id": "dummy-id", "deleteDrafts": True}
+
+
+def test_v1_report_url_uses_service_api_app_url_without_client():
+    class _ServiceApi:
+        app_url = "https://service.wandb.test/"
+
+    class _Api:
+        default_entity = "ent"
+
+        def __init__(self):
+            self._service_api = _ServiceApi()
+
+    report = wr_v1.Report(project="proj", entity="ent", title="My Report", _api=_Api())
+    report._viewspec["id"] = "abc123=="
+
+    assert report.url == "https://service.wandb.test/ent/proj/reports/My-Report--abc123"
+
+
+def test_v2_report_url_uses_service_api_app_url_without_client(monkeypatch):
+    class _ServiceApi:
+        app_url = "https://service.wandb.test/"
+
+    class _Api:
+        default_entity = "ent"
+
+        def __init__(self):
+            self._service_api = _ServiceApi()
+
+    monkeypatch.setattr(wr.interface, "_get_api", lambda: _Api())
+
+    report = wr.Report(project="proj", entity="ent", title="My Report")
+    report.id = "abc123"
+
+    assert report.url == "https://service.wandb.test/ent/proj/reports/My-Report--abc123"
 
 
 def test_runset_project_lookup(monkeypatch):

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -204,10 +204,11 @@ def test_load_workspace_from_url():
         # Verify the mock was called
         assert mock_client.execute.call_count == 1
         cargs = mock_client.execute.call_args[0]
+        ckwargs = mock_client.execute.call_args.kwargs
         gql_definition = cargs[0].definitions[0]
         assert gql_definition.name.value == "View"
         assert gql_definition.operation == "query"
-        assert cargs[1] == {
+        assert ckwargs["variable_values"] == {
             "viewType": "project-view",
             "entityName": "test_entity",
             "projectName": "test_project",
@@ -236,13 +237,13 @@ def test_save_workspace():
         cargs_list = mock_client.execute.call_args_list
 
         # Important: id SHOULD not be in the first call as view hasn't been created
-        assert "id" not in cargs_list[0][0][1]
+        assert "id" not in cargs_list[0].kwargs["variable_values"]
 
         # Important: id SHOULD be in the second call as the view has been created
-        assert "id" in cargs_list[1][0][1]
+        assert "id" in cargs_list[1].kwargs["variable_values"]
 
         # Important: id SHOULD not be in the third call as we want to make a new view
-        assert "id" not in cargs_list[2][0][1]
+        assert "id" not in cargs_list[2].kwargs["variable_values"]
 
         # all the gql should be the same
         assert cargs_list[0][0][0] == cargs_list[1][0][0]

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -253,6 +253,21 @@ def test_save_workspace():
         assert gql_definition.operation == "mutation"
 
 
+def test_workspace_url_uses_service_api_app_url_without_client():
+    class _ServiceApi:
+        app_url = "https://service.wandb.test/"
+
+    class _Api:
+        def __init__(self):
+            self._service_api = _ServiceApi()
+
+    with patch("wandb.Api", return_value=_Api()):
+        workspace = ws.Workspace(entity="ent", project="proj")
+        workspace._internal_name = "nw-abc123-v"
+
+        assert workspace.url == "https://service.wandb.test/ent/proj?nw=abc123"
+
+
 @pytest.mark.parametrize(
     "example, should_pass",
     [

--- a/wandb_workspaces/_graphql.py
+++ b/wandb_workspaces/_graphql.py
@@ -1,0 +1,20 @@
+"""GraphQL helpers compatible across W&B SDK GraphQL transports."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Mapping
+
+
+def execute_graphql(
+    api: Any,
+    query: str,
+    variables: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Execute a GraphQL document with the current or legacy W&B SDK transport."""
+    service_api = getattr(api, "__dict__", {}).get("_service_api")
+    if service_api is not None and hasattr(service_api, "execute_graphql"):
+        return service_api.execute_graphql(query, variables=dict(variables or {}))
+
+    gql = importlib.import_module("wandb_gql").gql
+    return api.client.execute(gql(query), variable_values=dict(variables or {}))

--- a/wandb_workspaces/_graphql.py
+++ b/wandb_workspaces/_graphql.py
@@ -18,3 +18,12 @@ def execute_graphql(
 
     gql = importlib.import_module("wandb_gql").gql
     return api.client.execute(gql(query), variable_values=dict(variables or {}))
+
+
+def get_app_url(api: Any) -> str:
+    """Return the W&B app URL from the current or legacy SDK API object."""
+    service_api = getattr(api, "__dict__", {}).get("_service_api")
+    if service_api is not None and hasattr(service_api, "app_url"):
+        return service_api.app_url
+
+    return api.client.app_url

--- a/wandb_workspaces/reports/v1/mutations.py
+++ b/wandb_workspaces/reports/v1/mutations.py
@@ -1,7 +1,4 @@
-from wandb_gql import gql
-
-VIEW_REPORT = gql(
-    """
+VIEW_REPORT = """
     query SpecificReport($reportId: ID!) {
         view(id: $reportId) {
             id
@@ -18,10 +15,8 @@ VIEW_REPORT = gql(
             spec
         }
     }
-    """
-)
-UPSERT_VIEW = gql(
-    """
+"""
+UPSERT_VIEW = """
     mutation upsertView(
         $id: ID
         $entityName: String
@@ -63,4 +58,3 @@ UPSERT_VIEW = gql(
         }
     }
 """
-)

--- a/wandb_workspaces/reports/v1/report.py
+++ b/wandb_workspaces/reports/v1/report.py
@@ -12,6 +12,8 @@ from wandb.apis.public import Api as PublicApi
 from wandb.apis.public import RetryingClient
 from wandb.sdk.lib import ipython
 
+from wandb_workspaces._graphql import execute_graphql
+
 from ._blocks import P, PanelGrid, UnknownBlock, WeaveBlock, block_mapping, weave_blocks
 from .mutations import UPSERT_VIEW, VIEW_REPORT
 from .runset import Runset
@@ -62,7 +64,7 @@ class Report(Base):
         if api is None:
             api = PublicApi()
         report_id = cls._url_to_report_id(url)
-        r = api.client.execute(VIEW_REPORT, variable_values={"reportId": report_id})
+        r = execute_graphql(api, VIEW_REPORT, {"reportId": report_id})
         viewspec = r["view"]
         viewspec["spec"] = json.loads(viewspec["spec"])
         return cls.from_json(viewspec)
@@ -229,9 +231,10 @@ class Report(Base):
             rs.entity = coalesce(rs.entity, self._api.default_entity)
             rs.project = coalesce(rs.project, self.project)
 
-        r = self._api.client.execute(
+        r = execute_graphql(
+            self._api,
             UPSERT_VIEW,
-            variable_values={
+            {
                 "id": None if clone or not self.id else self.id,
                 "name": generate_name() if clone or not self.name else self.name,
                 "entityName": self.entity,

--- a/wandb_workspaces/reports/v1/report.py
+++ b/wandb_workspaces/reports/v1/report.py
@@ -9,7 +9,6 @@ from typing import List as LList
 from wandb import __version__ as wandb_ver
 from wandb import termlog, termwarn
 from wandb.apis.public import Api as PublicApi
-from wandb.apis.public import RetryingClient
 from wandb.sdk.lib import ipython
 
 from wandb_workspaces._graphql import execute_graphql, get_app_url
@@ -175,7 +174,7 @@ class Report(Base):
         return self._viewspec["spec"]
 
     @property
-    def client(self) -> "RetryingClient":
+    def client(self):
         return self._api.client
 
     @property

--- a/wandb_workspaces/reports/v1/report.py
+++ b/wandb_workspaces/reports/v1/report.py
@@ -12,7 +12,7 @@ from wandb.apis.public import Api as PublicApi
 from wandb.apis.public import RetryingClient
 from wandb.sdk.lib import ipython
 
-from wandb_workspaces._graphql import execute_graphql
+from wandb_workspaces._graphql import execute_graphql, get_app_url
 
 from ._blocks import P, PanelGrid, UnknownBlock, WeaveBlock, block_mapping, weave_blocks
 from .mutations import UPSERT_VIEW, VIEW_REPORT
@@ -200,7 +200,7 @@ class Report(Base):
         title = re.sub(r"-+", "-", title)
         title = urllib.parse.quote(title)
         id = self.id.replace("=", "")
-        app_url = self._api.client.app_url
+        app_url = get_app_url(self._api)
         if not app_url.endswith("/"):
             app_url = app_url + "/"
         return f"{app_url}{self.entity}/{self.project}/reports/{title}--{id}"

--- a/wandb_workspaces/reports/v2/gql.py
+++ b/wandb_workspaces/reports/v2/gql.py
@@ -1,9 +1,6 @@
 """GraphQL queries and mutations."""
 
-from wandb_gql import gql
-
-view_report = gql(
-    """
+view_report = """
     query SpecificReport($reportId: ID!) {
         view(id: $reportId) {
             id
@@ -20,10 +17,8 @@ view_report = gql(
             spec
         }
     }
-    """
-)
-upsert_view = gql(
-    """
+"""
+upsert_view = """
     mutation upsertView(
         $id: ID
         $entityName: String
@@ -65,13 +60,11 @@ upsert_view = gql(
         }
     }
 """
-)
 
 # Mutation to delete a report (view) given its ID.
 # Accepts a flag to also delete any associated draft views.
 # Mirrors the save/upsert structure above.
-delete_view = gql(
-    """
+delete_view = """
     mutation deleteView($id: ID!, $deleteDrafts: Boolean) {
         deleteView(input: { id: $id, deleteDrafts: $deleteDrafts }) {
             success
@@ -79,22 +72,18 @@ delete_view = gql(
             __typename
         }
     }
-    """
-)
+"""
 
-projectInternalId = gql(
-    """
+projectInternalId = """
     query ProjectInternalId($projectName: String!, $entityName: String!) {
         project(name: $projectName, entityName: $entityName) {
             id
             internalId
         }
     }
-    """
-)
+"""
 
-view_access_tokens = gql(
-    """
+view_access_tokens = """
     query ViewAccessTokens($reportId: ID!) {
         view(id: $reportId) {
             accessTokens {
@@ -104,11 +93,9 @@ view_access_tokens = gql(
             }
         }
     }
-    """
-)
+"""
 
-create_access_token = gql(
-    """
+create_access_token = """
     mutation createAccessToken(
         $viewId: ID!
         $entityName: String!
@@ -126,15 +113,12 @@ create_access_token = gql(
             }
         }
     }
-    """
-)
+"""
 
-revoke_access_token = gql(
-    """
+revoke_access_token = """
     mutation revokeAccessToken($token: String!) {
         revokeAccessToken(input: { token: $token }) {
             success
         }
     }
-    """
-)
+"""

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -47,6 +47,8 @@ import wandb
 from pydantic import ConfigDict, Field, model_validator, validator
 from pydantic.dataclasses import dataclass
 
+from wandb_workspaces._graphql import execute_graphql
+
 from . import gql, internal
 from ... import expr
 from .internal import (
@@ -1075,7 +1077,9 @@ class Runset(Base):
     def convert_filterexpr_list_to_string(self):
         """Convert FilterExpr list to string expression."""
         if isinstance(self.filters, list):
-            object.__setattr__(self, "filters", expr.filterexpr_list_to_string(self.filters))
+            object.__setattr__(
+                self, "filters", expr.filterexpr_list_to_string(self.filters)
+            )
         elif isinstance(self.filters, (expr.Or, expr.And)):
             tree = expr._filter_items_to_filters_tree([self.filters])
             v2 = expr.filters_tree_to_v2(tree)
@@ -1087,9 +1091,10 @@ class Runset(Base):
 
         if self.entity and self.project:
             # Look up project internal ID
-            r = _get_api().client.execute(
+            r = execute_graphql(
+                _get_api(),
                 gql.projectInternalId,
-                variable_values={
+                {
                     "entityName": self.entity,
                     "projectName": self.project,
                 },
@@ -1125,8 +1130,10 @@ class Runset(Base):
         # Use stashed v2 dict when the filter string hasn't changed since load.
         # This preserves per-filter metadata (e.g. disabled state) that the
         # lossy string representation cannot express.
-        if (self._stashed_filters_v2 is not None
-                and self.filters == self._stashed_filter_string):
+        if (
+            self._stashed_filters_v2 is not None
+            and self.filters == self._stashed_filter_string
+        ):
             filters_value = self._stashed_filters_v2
         else:
             filters_value = expr.filters_tree_to_v2(
@@ -3634,9 +3641,10 @@ class Report(Base):
         if is_new_project:
             _get_api().create_project(self.project, self.entity)
 
-        r = _get_api().client.execute(
+        r = execute_graphql(
+            _get_api(),
             gql.upsert_view,
-            variable_values={
+            {
                 "id": None if clone or not model.id else model.id,
                 "name": internal._generate_name()
                 if clone or not model.name
@@ -3696,9 +3704,10 @@ class Report(Base):
             wandb.termlog("Share link already active.")
             return url
 
-        r = _get_api().client.execute(
+        r = execute_graphql(
+            _get_api(),
             gql.create_access_token,
-            variable_values={
+            {
                 "viewId": self.id,
                 "entityName": self.entity,
                 "projectName": self.project,
@@ -3726,9 +3735,10 @@ class Report(Base):
 
         all_success = True
         for token in tokens:
-            r = _get_api().client.execute(
+            r = execute_graphql(
+                _get_api(),
                 gql.revoke_access_token,
-                variable_values={"token": token},
+                {"token": token},
             )
             if not r["revokeAccessToken"]["success"]:
                 all_success = False
@@ -3746,9 +3756,10 @@ class Report(Base):
 
     def _get_active_share_tokens(self) -> LList[str]:
         """Return all active PUBLIC access token strings."""
-        r = _get_api().client.execute(
+        r = execute_graphql(
+            _get_api(),
             gql.view_access_tokens,
-            variable_values={"reportId": self.id},
+            {"reportId": self.id},
         )
         view = r.get("view")
         if not view:
@@ -3773,9 +3784,10 @@ class Report(Base):
                 "Cannot delete a report that has not been saved or does not have an id."
             )
 
-        response = _get_api().client.execute(
+        response = execute_graphql(
+            _get_api(),
             gql.delete_view,
-            variable_values={
+            {
                 "id": self.id,
                 "deleteDrafts": True,
             },
@@ -3842,9 +3854,7 @@ def _get_api():
 
 def _url_to_viewspec(url):
     report_id = _url_to_report_id(url)
-    r = _get_api().client.execute(
-        gql.view_report, variable_values={"reportId": report_id}
-    )
+    r = execute_graphql(_get_api(), gql.view_report, {"reportId": report_id})
     viewspec = r["view"]
 
     # The spec field is a JSON string, we need to parse it, strip refs, and re-serialize

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -47,7 +47,7 @@ import wandb
 from pydantic import ConfigDict, Field, model_validator, validator
 from pydantic.dataclasses import dataclass
 
-from wandb_workspaces._graphql import execute_graphql
+from wandb_workspaces._graphql import execute_graphql, get_app_url
 
 from . import gql, internal
 from ... import expr
@@ -3613,7 +3613,7 @@ class Report(Base):
         if self.id == "":
             raise AttributeError("save report or explicitly pass `id` to get a url")
 
-        base = urlparse(_get_api().client.app_url)
+        base = urlparse(get_app_url(_get_api()))
 
         title = self.title.replace(" ", "-")
 

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -38,6 +38,7 @@ from annotated_types import Annotated, Ge
 from pydantic import AfterValidator, ConfigDict, Field, PositiveInt, model_validator
 from pydantic.dataclasses import dataclass
 
+from wandb_workspaces._graphql import get_app_url
 from wandb_workspaces.reports.v2.interface import PanelTypes, _lookup_panel
 from wandb_workspaces.reports.v2.internal import TooltipNumberOfRuns
 from wandb_workspaces.utils.validators import validate_no_emoji, validate_url
@@ -79,6 +80,7 @@ def _decode_run_gid(value: Optional[str]) -> Optional[str]:
     if len(parts) >= 5 and parts[0] in ("Run", "BucketType") and parts[1] == "v1":
         return ":".join(parts[2:-2])
     return value
+
 
 __all__ = [
     "SectionLayoutSettings",
@@ -486,7 +488,9 @@ class RunsetSettings(Base):
     def convert_filterexpr_list_to_string(self):
         """Convert FilterExpr list or Or/And to string expression."""
         if isinstance(self.filters, list):
-            object.__setattr__(self, "filters", expr.filterexpr_list_to_string(self.filters))
+            object.__setattr__(
+                self, "filters", expr.filterexpr_list_to_string(self.filters)
+            )
         elif isinstance(self.filters, (expr.Or, expr.And)):
             tree = expr._filter_items_to_filters_tree([self.filters])
             v2 = expr.filters_tree_to_v2(tree)
@@ -548,7 +552,7 @@ class Workspace(Base):
                 "save workspace or explicitly pass `_internal_name` to get a url"
             )
 
-        base = urlparse(wandb.Api().client.app_url)
+        base = urlparse(get_app_url(wandb.Api()))
 
         scheme = base.scheme
         netloc = base.netloc
@@ -639,7 +643,9 @@ class Workspace(Base):
         ]
 
         runset_model = model.spec.section.run_sets[0]
-        if isinstance(runset_model.filters, dict) and expr.is_filter_v2(runset_model.filters):
+        if isinstance(runset_model.filters, dict) and expr.is_filter_v2(
+            runset_model.filters
+        ):
             stashed_v2 = copy.deepcopy(runset_model.filters)
             filter_string = expr.filters_v2_to_string(runset_model.filters)
         else:
@@ -663,12 +669,8 @@ class Workspace(Base):
                 query=runset_model.search.query,
                 regex_query=regex_query,
                 filters=filter_string,
-                groupby=[
-                    expr.BaseMetric.from_key(v) for v in runset_model.grouping
-                ],
-                order=[
-                    expr.Ordering.from_key(s) for s in runset_model.sort.keys
-                ],
+                groupby=[expr.BaseMetric.from_key(v) for v in runset_model.grouping],
+                order=[expr.Ordering.from_key(s) for s in runset_model.sort.keys],
                 run_settings=run_settings,
                 pinned_columns=pinned_columns,
                 baseline_run=_decode_run_gid(
@@ -676,9 +678,7 @@ class Workspace(Base):
                 ),
                 pinned_runs=[
                     _decode_run_gid(rid) or rid
-                    for rid in (
-                        model.spec.section.run_sets[0].pinned_run_ids or []
-                    )
+                    for rid in (model.spec.section.run_sets[0].pinned_run_ids or [])
                 ],
             ),
         )
@@ -737,8 +737,10 @@ class Workspace(Base):
             else list(self.runset_settings.pinned_columns)
         )
 
-        if (self._stashed_filters_v2 is not None
-                and self.runset_settings.filters == self._stashed_filter_string):
+        if (
+            self._stashed_filters_v2 is not None
+            and self.runset_settings.filters == self._stashed_filter_string
+        ):
             filters_value = self._stashed_filters_v2
         else:
             filters_value = expr.filters_tree_to_v2(

--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -6,7 +6,8 @@ import wandb
 from annotated_types import Annotated, Ge
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 from pydantic.alias_generators import to_camel
-from wandb_gql import gql
+
+from wandb_workspaces._graphql import execute_graphql
 
 # these internal objects should be factored out into a separate module as a
 # shared dependency between Workspaces and Reports API
@@ -119,8 +120,7 @@ class View(WorkspaceAPIBaseModel):
 
 
 def upsert_view2(view: View) -> Dict[str, Any]:
-    query = gql(
-        """
+    query = """
         mutation UpsertView2($id: ID, $entityName: String, $projectName: String, $type: String, $name: String, $displayName: String, $description: String, $spec: String) {
         upsertView(
             input: {id: $id, entityName: $entityName, projectName: $projectName, name: $name, displayName: $displayName, description: $description, type: $type, spec: $spec, createdUsing: WANDB_SDK}
@@ -133,7 +133,6 @@ def upsert_view2(view: View) -> Dict[str, Any]:
         }
         }
         """
-    )
 
     api = wandb.Api()
     spec_str = view.spec.model_dump_json(by_alias=True, exclude_none=True)
@@ -154,15 +153,14 @@ def upsert_view2(view: View) -> Dict[str, Any]:
     if view.id:
         variables["id"] = view.id
 
-    response = api.client.execute(query, variables)
+    response = execute_graphql(api, query, variables)
 
     return response
 
 
 def get_view_dict(entity: str, project: str, view_name: str) -> Dict[str, Any]:
     # Use this query because it let you use view_name instead of id
-    query = gql(
-        """
+    query = """
         query View($entityName: String, $name: String, $viewType: String = "runs", $userName: String, $viewName: String) {
             project(name: $name, entityName: $entityName) {
                 allViews(viewType: $viewType, viewName: $viewName, userName: $userName) {
@@ -177,11 +175,11 @@ def get_view_dict(entity: str, project: str, view_name: str) -> Dict[str, Any]:
             }
         }
         """
-    )
 
     api = wandb.Api()
 
-    response = api.client.execute(
+    response = execute_graphql(
+        api,
         query,
         {
             "viewType": "project-view",


### PR DESCRIPTION
## Summary
- Removes import-time dependency on private `wandb_gql` modules.
- Stores workspace/report GraphQL documents as raw strings.
- Routes execution through the current W&B SDK `_service_api.execute_graphql` path when available.
- Lazily falls back to `wandb_gql.gql` only for older SDK clients.
- Routes app URL lookup through a compatibility helper so report/workspace URL construction works when `Api.client` is not available.

## Why
- `wandb==0.27.1` removed vendored `wandb_gql` as part of routing Public API GraphQL through wandb-core.
- `wandb-workspaces==0.4.1` still imports `wandb_gql` at module import time.
- `wandb==0.27.1` also exposes app URL through `_service_api.app_url`, so `api.client.app_url` is not a safe internal assumption.
- As a result, `import wandb_workspaces.reports.v2` and runtime URL helpers can fail with `wandb==0.27.1`.

Fixes #173.

## Test plan
- `uv run --python 3.12 pytest tests/test_graphql.py tests/test_reports.py::test_v1_report_url_uses_service_api_app_url_without_client tests/test_reports.py::test_v2_report_url_uses_service_api_app_url_without_client tests/test_workspaces.py::test_workspace_url_uses_service_api_app_url_without_client tests/test_reports.py::TestReportSharing tests/test_workspaces.py::test_load_workspace_from_url -q`
- `uv run --python 3.12 pytest -q`
- `uv run --python 3.12 ruff check <changed files>`
- `uv run --python 3.12 ruff format --check <changed files>`
- `uv build`
- Fresh wheel smoke with `wandb==0.27.1`:
  - `uv venv /tmp/wandb-workspaces-0271-smoke --python 3.12`
  - `uv pip install --python /tmp/wandb-workspaces-0271-smoke/bin/python dist/*.whl "wandb==0.27.1"`
  - `/tmp/wandb-workspaces-0271-smoke/bin/python -c "import wandb_workspaces.reports.v2; import wandb_workspaces.workspaces as ws; print('ok')"`

## Notes
- Repo-wide ruff currently reports pre-existing unrelated errors in examples and `tests/test_filters.py`; changed files pass ruff check/format.