### PR TITLE
feat(sdk): support cross-project pinned and baseline runs in workspaces SDK

### DIFF
--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -621,3 +621,202 @@ def test_pinned_runs_over_cap_warns():
     warn.assert_called_once()
     assert "21" in warn.call_args.args[0]
     assert runset_settings.pinned_runs == too_many
+
+
+# Cross-project Pinned / Baseline Runs Tests
+
+
+def test_cross_project_pinned_run_slash_form_roundtrip():
+    """A cross-project pin given as 'entity/project/slug' encodes against the
+    foreign (entity, project) and decodes back to a RunRef on read."""
+    workspace = ws.Workspace(
+        entity="my-entity",
+        project="my-project",
+        runset_settings=ws.RunsetSettings(
+            pinned_runs=["other-team/other-project/abc1234"],
+        ),
+    )
+
+    model = workspace._to_model()
+    gid = model.spec.section.run_sets[0].pinned_run_ids[0]
+    assert (
+        base64.b64decode(gid).decode()
+        == "Run:v1:abc1234:other-project:other-team"
+    )
+
+    workspace2 = ws.Workspace._from_model(model)
+    assert workspace2.runset_settings.pinned_runs == [
+        ws.RunRef(slug="abc1234", entity="other-team", project="other-project"),
+    ]
+
+
+def test_cross_project_pinned_run_runref_roundtrip():
+    """A cross-project pin given as a RunRef encodes against its explicit
+    (entity, project) and decodes back to an equal RunRef."""
+    pin = ws.RunRef("abc1234", entity="other-team", project="other-project")
+    workspace = ws.Workspace(
+        entity="my-entity",
+        project="my-project",
+        runset_settings=ws.RunsetSettings(pinned_runs=[pin]),
+    )
+
+    model = workspace._to_model()
+    gid = model.spec.section.run_sets[0].pinned_run_ids[0]
+    assert (
+        base64.b64decode(gid).decode()
+        == "Run:v1:abc1234:other-project:other-team"
+    )
+
+    workspace2 = ws.Workspace._from_model(model)
+    assert workspace2.runset_settings.pinned_runs == [pin]
+
+
+def test_pinned_runs_mixed_same_and_cross_project():
+    """A mixed list of bare-slug, slash-form, and RunRef entries each encode
+    against the right (entity, project); decoded list keeps bare slugs as
+    str and cross-project entries as RunRef."""
+    workspace = ws.Workspace(
+        entity="my-entity",
+        project="my-project",
+        runset_settings=ws.RunsetSettings(
+            pinned_runs=[
+                "same-proj-slug",
+                "other-team/other-project/slash-slug",
+                ws.RunRef("ref-slug", entity="t", project="p"),
+            ],
+        ),
+    )
+
+    model = workspace._to_model()
+    gids = model.spec.section.run_sets[0].pinned_run_ids
+    decoded = [base64.b64decode(g).decode() for g in gids]
+    assert decoded == [
+        "Run:v1:same-proj-slug:my-project:my-entity",
+        "Run:v1:slash-slug:other-project:other-team",
+        "Run:v1:ref-slug:p:t",
+    ]
+
+    workspace2 = ws.Workspace._from_model(model)
+    assert workspace2.runset_settings.pinned_runs == [
+        "same-proj-slug",
+        ws.RunRef(slug="slash-slug", entity="other-team", project="other-project"),
+        ws.RunRef(slug="ref-slug", entity="t", project="p"),
+    ]
+
+
+def test_runref_defaults_to_workspace_entity_project():
+    """A RunRef with `entity=None, project=None` is treated as same-project:
+    encodes against the workspace's own (entity, project) and decodes back
+    to a bare slug string (not a RunRef)."""
+    workspace = ws.Workspace(
+        entity="my-entity",
+        project="my-project",
+        runset_settings=ws.RunsetSettings(pinned_runs=[ws.RunRef("abc1234")]),
+    )
+
+    model = workspace._to_model()
+    gid = model.spec.section.run_sets[0].pinned_run_ids[0]
+    assert (
+        base64.b64decode(gid).decode() == "Run:v1:abc1234:my-project:my-entity"
+    )
+
+    workspace2 = ws.Workspace._from_model(model)
+    assert workspace2.runset_settings.pinned_runs == ["abc1234"]
+
+
+def test_baseline_run_cross_project_auto_added_to_pinned():
+    """A cross-project baseline (slash-form or RunRef) is auto-added to
+    pinned_runs and survives the round-trip with its cross-project (entity,
+    project) intact."""
+    rs_slash = ws.RunsetSettings(
+        baseline_run="other-team/other-project/abc1234",
+    )
+    assert rs_slash.pinned_runs == ["other-team/other-project/abc1234"]
+
+    rs_ref = ws.RunsetSettings(
+        baseline_run=ws.RunRef("abc1234", entity="other-team", project="other-project"),
+    )
+    assert rs_ref.pinned_runs == [
+        ws.RunRef("abc1234", entity="other-team", project="other-project"),
+    ]
+
+    workspace = ws.Workspace(
+        entity="my-entity",
+        project="my-project",
+        runset_settings=rs_slash,
+    )
+    model = workspace._to_model()
+    runset = model.spec.section.run_sets[0]
+    expected_gid = base64.b64encode(
+        b"Run:v1:abc1234:other-project:other-team"
+    ).decode()
+    assert runset.baseline_run_id == expected_gid
+    assert runset.pinned_run_ids == [expected_gid]
+
+    workspace2 = ws.Workspace._from_model(model)
+    expected_ref = ws.RunRef(
+        slug="abc1234", entity="other-team", project="other-project"
+    )
+    assert workspace2.runset_settings.baseline_run == expected_ref
+    assert workspace2.runset_settings.pinned_runs == [expected_ref]
+
+
+def test_baseline_dedupe_across_input_forms():
+    """Baseline given as RunRef and pinned given as slash-form for the same
+    logical run is recognized as already pinned (no duplicate appended)."""
+    runset_settings = ws.RunsetSettings(
+        baseline_run=ws.RunRef("abc", entity="e", project="p"),
+        pinned_runs=["e/p/abc"],
+    )
+    assert runset_settings.pinned_runs == ["e/p/abc"]
+
+
+def test_invalid_slash_form_raises():
+    """Slash-form strings with the wrong number of parts or with empty parts
+    raise ValueError at serialization time with a clear message."""
+    too_few = ws.Workspace(
+        entity="e",
+        project="p",
+        runset_settings=ws.RunsetSettings(pinned_runs=["a/b"]),
+    )
+    with pytest.raises(ValueError, match="entity/project/slug"):
+        too_few._to_model()
+
+    too_many = ws.Workspace(
+        entity="e",
+        project="p",
+        runset_settings=ws.RunsetSettings(pinned_runs=["a/b/c/d"]),
+    )
+    with pytest.raises(ValueError, match="entity/project/slug"):
+        too_many._to_model()
+
+    empty_part = ws.Workspace(
+        entity="e",
+        project="p",
+        runset_settings=ws.RunsetSettings(pinned_runs=["a//c"]),
+    )
+    with pytest.raises(ValueError, match="non-empty"):
+        empty_part._to_model()
+
+
+def test_decoded_same_project_pin_is_bare_slug():
+    """Regression guard: a same-project pin must round-trip back as a bare
+    slug string, not as a slash-form string or a RunRef. This is what keeps
+    pre-cross-project user code (and the existing test suite) working."""
+    workspace = ws.Workspace(
+        entity="my-entity",
+        project="my-project",
+        runset_settings=ws.RunsetSettings(
+            baseline_run="abc1234",
+            pinned_runs=["abc1234", "def5678"],
+        ),
+    )
+    model = workspace._to_model()
+    workspace2 = ws.Workspace._from_model(model)
+
+    assert workspace2.runset_settings.baseline_run == "abc1234"
+    assert workspace2.runset_settings.pinned_runs == ["abc1234", "def5678"]
+    for entry in workspace2.runset_settings.pinned_runs:
+        assert isinstance(entry, str)
+        assert "/" not in entry
+    assert isinstance(workspace2.runset_settings.baseline_run, str)

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -28,6 +28,7 @@ workspace.save()
 
 import copy
 import base64
+import dataclasses
 import os
 from typing import Dict, Iterable, Literal, Optional, Union
 from typing import List as LList
@@ -82,6 +83,29 @@ def _decode_run_gid(value: Optional[str]) -> Optional[str]:
     return value
 
 
+def _decode_run_gid_parts(value: Optional[str]):
+    """Inverse of `_encode_run_gid` returning the `(slug, project, entity)`
+    triple, or `None` if `value` isn't a v1 Run GID.
+
+    Mirrors `_decode_run_gid` but exposes all three parts so the read path
+    in `_from_model` can decide whether a pin is same-project (decode back
+    to a bare slug, for back-compat) or cross-project (decode to a `RunRef`).
+    """
+    if not value:
+        return None
+    try:
+        decoded = base64.b64decode(value, validate=True).decode("utf-8")
+    except Exception:
+        return None
+    parts = decoded.split(":")
+    if len(parts) >= 5 and parts[0] in ("Run", "BucketType") and parts[1] == "v1":
+        slug = ":".join(parts[2:-2])
+        project = parts[-2]
+        entity = parts[-1]
+        return (slug, project, entity)
+    return None
+
+
 __all__ = [
     "SectionLayoutSettings",
     "SectionPanelSettings",
@@ -89,10 +113,149 @@ __all__ = [
     "WorkspaceSettings",
     "RunSettings",
     "RunsetSettings",
+    "RunRef",
     "Workspace",
 ]
 
 dataclass_config = ConfigDict(validate_assignment=True, extra="forbid")
+
+
+# RunRef is a pure data container with no validation requirements, so we use
+# the stdlib `dataclasses.dataclass` (frozen) rather than `pydantic.dataclasses`.
+# Pydantic v2 supports stdlib dataclasses transparently as field types, and
+# this avoids a benign-but-noisy pydantic warning that fires when a frozen
+# pydantic dataclass appears inside a Union[...] field annotation.
+@dataclasses.dataclass(frozen=True)
+class RunRef:
+    """Typed reference to a W&B run, optionally in another (entity, project).
+
+    Use for cross-project pinned and baseline runs, where a bare slug can't
+    disambiguate which project the run lives in. When `entity` or `project`
+    are `None`, they fall back to the enclosing workspace's own values at
+    serialization time.
+
+    Attributes:
+        slug (str): The run's slug (the value of `wandb.Run.id`, also the
+            last path segment of a run URL). For example, `"abc1234"`.
+        entity (Optional[str]): The owning entity of the referenced run.
+            `None` means "same as the workspace's entity".
+        project (Optional[str]): The project the referenced run lives in.
+            `None` means "same as the workspace's project".
+
+    Example:
+        ```python
+        # Cross-project, fully specified
+        ws.RunRef("abc1234", entity="other-team", project="other-project")
+
+        # Same project (entity / project default to the workspace's own)
+        ws.RunRef("abc1234")
+        ```
+    """
+
+    slug: str
+    entity: Optional[str] = None
+    project: Optional[str] = None
+
+
+def _resolve_run_ref(
+    value: Union[str, RunRef],
+    workspace_entity: str,
+    workspace_project: str,
+):
+    """Normalize a user-supplied run reference to `(slug, entity, project)`.
+
+    Accepted input forms:
+    - `RunRef(slug, entity=None, project=None)` — `None` fields fall back
+      to the workspace's own `(entity, project)`.
+    - `"entity/project/slug"` slash-form string — split into 3 non-empty
+      parts; anything else raises `ValueError`.
+    - bare slug `"abc1234"` — paired with the workspace's own
+      `(entity, project)`.
+
+    Pre-encoded `Run:v1:` GID strings pass through unchanged; the wire
+    encoder detects them and short-circuits to avoid double-encoding.
+    """
+    if isinstance(value, RunRef):
+        return (
+            value.slug,
+            value.entity if value.entity is not None else workspace_entity,
+            value.project if value.project is not None else workspace_project,
+        )
+    if not isinstance(value, str):
+        raise TypeError(
+            f"Run reference must be str or RunRef, got {type(value).__name__}"
+        )
+    # Pre-encoded GID: `_encode_run_gid` will detect and passthrough,
+    # so we don't need to parse the embedded entity/project here.
+    if _decode_run_gid(value) != value:
+        return (value, workspace_entity, workspace_project)
+    if "/" in value:
+        parts = value.split("/")
+        if len(parts) != 3 or not all(parts):
+            raise ValueError(
+                f"Cross-project run reference {value!r} must be of the form "
+                "'entity/project/slug' with three non-empty parts."
+            )
+        entity, project, slug = parts
+        return (slug, entity, project)
+    return (value, workspace_entity, workspace_project)
+
+
+def _encode_pin(
+    value: Union[str, RunRef], workspace_entity: str, workspace_project: str
+) -> str:
+    """Encode a single user-supplied pin into the wire-format GID."""
+    slug, entity, project = _resolve_run_ref(value, workspace_entity, workspace_project)
+    return _encode_run_gid(slug, project, entity)
+
+
+def _format_decoded_pin(
+    value: Optional[str],
+    workspace_entity: str,
+    workspace_project: str,
+):
+    """Convert a wire-format GID into the user-facing pin shape.
+
+    Returns:
+    - The bare slug string when the decoded `(entity, project)` matches
+      the workspace's own — preserving zero back-compat break for the
+      same-project case.
+    - A `RunRef(slug, entity, project)` when the pin lives in a different
+      `(entity, project)`.
+    - `value` unchanged if it isn't a v1 Run GID (forgiving for legacy or
+      non-encoded values that may exist in older specs).
+    """
+    parts = _decode_run_gid_parts(value)
+    if parts is None:
+        return value
+    slug, project, entity = parts
+    if entity == workspace_entity and project == workspace_project:
+        return slug
+    return RunRef(slug=slug, entity=entity, project=project)
+
+
+def _canonicalize_pin(value):
+    """Canonical `(slug, entity_or_None, project_or_None)` for the
+    baseline-dedupe check in `RunsetSettings.ensure_baseline_pinned`.
+
+    Bare-slug strings canonicalize with `None` for entity/project because
+    the workspace's defaults aren't visible at validator time. That's fine
+    because two bare-slug entries are still equal iff their slugs are
+    equal, which is the only thing the dedupe needs to detect.
+    """
+    if isinstance(value, RunRef):
+        return (value.slug, value.entity, value.project)
+    if isinstance(value, str):
+        parts = _decode_run_gid_parts(value)
+        if parts is not None:
+            slug, project, entity = parts
+            return (slug, entity, project)
+        if "/" in value:
+            split = value.split("/")
+            if len(split) == 3 and all(split):
+                entity, project, slug = split
+                return (slug, entity, project)
+    return (value, None, None)
 
 
 def _is_internal(k):
@@ -378,27 +541,44 @@ class RunsetSettings(Base):
             Column names use format: "run:displayName", "summary:metric", "config:param".
             run:displayName is automatically added if not present.
             Example: ["summary:accuracy", "summary:loss"]
-        baseline_run (Optional[str]): W&B run slug of the baseline run (the
-            value of `wandb.Run.id`, e.g. `"1mbku38n"` — also the last path
-            segment of a run URL). Used for delta columns and comparison
-            styling. When set, the baseline run is automatically added to
-            `pinned_runs` to match the W&B app's behavior. Must refer to a
-            run in the workspace's own project — cross-project pins are not
-            supported by this SDK yet (see the W&B app's "Add cross-project
-            runs" drawer for the UI equivalent).
-        pinned_runs (LList[str]): Ordered list of W&B run slugs to keep
-            visible in the run selector and always fetched for plots. Pass
-            slug strings (`wandb.Run.id`), not GraphQL IDs. The W&B app
-            caps this at 20 entries.
+        baseline_run (Optional[Union[str, RunRef]]): The baseline run used
+            for delta columns and comparison styling. Accepts any of:
+
+            - a bare slug `"1mbku38n"` (the value of `wandb.Run.id`, also
+              the last path segment of a run URL), interpreted as a run in
+              the workspace's own project.
+            - a slash-form string `"entity/project/abc1234"` for a run in
+              a different entity/project (cross-project).
+            - a `RunRef(slug, entity=None, project=None)`; `None`
+              entity/project default to the workspace's own.
+
+            When set, the baseline run is automatically added to
+            `pinned_runs` to match the W&B app's behavior.
+        pinned_runs (LList[Union[str, RunRef]]): Ordered list of runs to
+            keep visible in the run selector and always fetched for plots.
+            Each entry accepts the same three forms as `baseline_run`. The
+            W&B app caps this list at 20 entries.
 
     Example:
         ```python
-        # Using string filters (new)
+        # Using string filters
         RunsetSettings(
             filters="Config('learning_rate') = 0.001 and State = 'finished'",
             pinned_columns=["summary:accuracy", "summary:loss"],
             baseline_run="1mbku38n",  # wandb.Run.id (the slug from the URL)
             pinned_runs=["1mbku38n", "2u1g3j1c"],
+        )
+
+        # Cross-project pins / baseline
+        RunsetSettings(
+            baseline_run=RunRef(
+                "abc1234", entity="other-team", project="other-project"
+            ),
+            pinned_runs=[
+                "1mbku38n",                                  # same project
+                "other-team/other-project/abc1234",          # slash shorthand
+                RunRef("xyz9876", entity="t", project="p"),  # typed RunRef
+            ],
         )
 
         # Using FilterExpr list (original way)
@@ -437,8 +617,8 @@ class RunsetSettings(Base):
     pinned_columns: LList[str] = Field(default_factory=list)
 
     # Baseline / pinned runs
-    baseline_run: Optional[str] = None
-    pinned_runs: LList[str] = Field(default_factory=list)
+    baseline_run: Optional[Union[str, RunRef]] = None
+    pinned_runs: LList[Union[str, RunRef]] = Field(default_factory=list)
 
     # Internal fields for backend serialization (not user-facing)
     _visible_columns: LList[str] = Field(default_factory=list, init=False, repr=False)
@@ -472,11 +652,19 @@ class RunsetSettings(Base):
         `setRunPinnedAndBaseline`, so any spec produced by the UI has the
         baseline ID present in `pinnedRunIds`. We enforce the same here so
         SDK-produced specs match.
+
+        The dedupe check compares canonical `(slug, entity, project)`
+        tuples (see `_canonicalize_pin`), so a baseline given as
+        `RunRef("abc", "e", "p")` is correctly recognized as already
+        present when `pinned_runs` contains the slash-form `"e/p/abc"`.
         """
-        if self.baseline_run and self.baseline_run not in self.pinned_runs:
-            new_pinned = list(self.pinned_runs)
-            new_pinned.append(self.baseline_run)
-            object.__setattr__(self, "pinned_runs", new_pinned)
+        if self.baseline_run is not None:
+            baseline_canon = _canonicalize_pin(self.baseline_run)
+            pinned_canons = {_canonicalize_pin(p) for p in self.pinned_runs}
+            if baseline_canon not in pinned_canons:
+                new_pinned = list(self.pinned_runs)
+                new_pinned.append(self.baseline_run)
+                object.__setattr__(self, "pinned_runs", new_pinned)
         if len(self.pinned_runs) > 20:
             wandb.termwarn(
                 f"pinned_runs has {len(self.pinned_runs)} entries; "
@@ -673,11 +861,13 @@ class Workspace(Base):
                 order=[expr.Ordering.from_key(s) for s in runset_model.sort.keys],
                 run_settings=run_settings,
                 pinned_columns=pinned_columns,
-                baseline_run=_decode_run_gid(
-                    model.spec.section.run_sets[0].baseline_run_id
+                baseline_run=_format_decoded_pin(
+                    model.spec.section.run_sets[0].baseline_run_id,
+                    model.entity,
+                    model.project,
                 ),
                 pinned_runs=[
-                    _decode_run_gid(rid) or rid
+                    _format_decoded_pin(rid, model.entity, model.project)
                     for rid in (model.spec.section.run_sets[0].pinned_run_ids or [])
                 ],
             ),
@@ -793,17 +983,17 @@ class Workspace(Base):
                                 ],
                             ),
                             baseline_run_id=(
-                                _encode_run_gid(
+                                _encode_pin(
                                     self.runset_settings.baseline_run,
-                                    self.project,
                                     self.entity,
+                                    self.project,
                                 )
                                 if self.runset_settings.baseline_run
                                 else None
                             ),
                             pinned_run_ids=(
                                 [
-                                    _encode_run_gid(s, self.project, self.entity)
+                                    _encode_pin(s, self.entity, self.project)
                                     for s in self.runset_settings.pinned_runs
                                 ]
                                 if self.runset_settings.pinned_runs


### PR DESCRIPTION
JIRA/GH Issues(s)
-----------
https://coreweave.atlassian.net/browse/WB-34821

Description
-----------
Adding cross-project run support for pinned and baseline runs. Inputs accepted:
- bare slug "abc1234" (same project, unchanged)
- slash-form "entity/project/abc1234" (cross-project shorthand)
- typed `RunRef(slug, entity=None, project=None)`; `None` entity/project fall back to the workspace's own at serialization time

The wire format is unchanged (base64 `Run:v1:<slug>:<project>:<entity>`); we simply thread the per-run `(entity, project)` through encoding/decoding instead of always using the workspace's own.

Decode preserves bare-slug strings for same-project pins (zero back-compat break for existing user code and tests) and returns `RunRef` only for cross-project pins, so existing iteration / equality patterns over `pinned_runs` keep working unchanged.

The `ensure_baseline_pinned` validator now dedupes against a canonical `(slug, entity, project)` tuple, so a baseline given as `RunRef("abc","e","p")` is correctly recognized as already pinned when `pinned_runs` contains the slash-form `"e/p/abc"`.

Testing
-------

https://github.com/user-attachments/assets/28a2376c-65e1-4e5d-af98-45f5d8fff3b3

Test Script
```
"""Demo: cross-project pinned and baseline runs.

Builds and saves a workspace that exercises the new SDK shapes for
cross-project pinned / baseline runs:

  1. Bare slug          "abc1234"                             (same project)
  2. Slash-form string  "entity/other-project/abc1234"        (cross-project)
  3. Typed RunRef       ws.RunRef(slug, entity=..., project=...)

Prereqs:
  - You have already run `wandb login --host=<BASE_URL>` for the instance
    you're targeting (credentials live in ~/.netrc).
  - You know the slugs of the runs you want to pin / use as baseline.
    The "slug" is the value of `wandb.Run.id` — also the last path segment
    of a run URL, e.g. `https://.../runs/abc1234`.

Edit the EDIT ME block below, then:
  python scripts/demo_cross_project_pinned_runs.py
"""

import netrc
import os
from typing import Optional
from urllib.parse import urlparse

# ---------------------------------------------------------------------------
# EDIT ME
# ---------------------------------------------------------------------------
BASE_URL = "https://api.wandb.ai"
ENTITY = "wandb"
PRIMARY_PROJECT = "filter-list-repro-3"
OTHER_PROJECT = "nested-config-demo"

# Run slugs to pin / baseline. Fill these in with real `wandb.Run.id` values
# from your instance. Each pin / baseline can use any of the three shapes
# below — the script demonstrates all three plus a cross-project baseline.
SAME_PROJECT_PIN_SLUG = "m4p1c3yl"  # dutiful-sweep-3
CROSS_PROJECT_PIN_SLASH_SLUG = "afpudoar"  # charmed-frost-1  (just the slug; script prepends entity/project)
CROSS_PROJECT_PIN_RUNREF_SLUG = "afpudoar"  # charmed-frost-1  (same run as above — swap to a different slug if you want two distinct cross-project pins)
CROSS_PROJECT_BASELINE_SLUG = "ryu66t2t"  # visionary-smoke-3
# ---------------------------------------------------------------------------


def _api_key_for(base_url: str) -> Optional[str]:
    """Pull the wandb API key for `base_url` straight out of ~/.netrc.

    Avoids calling `wandb.login()`, which on older wandb versions trips a
    40-char API-key length check while trying to re-save the key — that
    path explodes for newer-format (longer) keys stored alongside in the
    same netrc.
    """
    parsed = urlparse(base_url)
    machine = parsed.netloc or parsed.path
    try:
        nrc = netrc.netrc()
    except (FileNotFoundError, netrc.NetrcParseError):
        return None
    creds = nrc.authenticators(machine)
    if creds is None:
        return None
    _login_unused, _account_unused, password = creds
    return password


os.environ["WANDB_BASE_URL"] = BASE_URL
if "WANDB_API_KEY" not in os.environ:
    _key = _api_key_for(BASE_URL)
    if _key is not None:
        os.environ["WANDB_API_KEY"] = _key

import wandb_workspaces.workspaces as ws  # noqa: E402


def main() -> None:
    placeholders = {
        "ENTITY": ENTITY,
        "SAME_PROJECT_PIN_SLUG": SAME_PROJECT_PIN_SLUG,
        "CROSS_PROJECT_PIN_SLASH_SLUG": CROSS_PROJECT_PIN_SLASH_SLUG,
        "CROSS_PROJECT_PIN_RUNREF_SLUG": CROSS_PROJECT_PIN_RUNREF_SLUG,
        "CROSS_PROJECT_BASELINE_SLUG": CROSS_PROJECT_BASELINE_SLUG,
    }
    unset = [
        k for k, v in placeholders.items()
        if v == "your-entity" or v.startswith("REPLACE_ME_")
    ]
    if unset:
        raise SystemExit(
            "Edit the EDIT ME block at the top of this script; the following "
            f"placeholders are still unset: {', '.join(unset)}"
        )

    print(f"Targeting W&B at {BASE_URL}")
    if "WANDB_API_KEY" not in os.environ:
        raise SystemExit(
            f"No netrc credentials found for {urlparse(BASE_URL).netloc!r}. "
            f"Run `wandb login --host={BASE_URL}` once, or export "
            "WANDB_API_KEY before running."
        )
    print(f"Workspace: {ENTITY}/{PRIMARY_PROJECT}")
    print()
    print("Pins:")
    print(f"  bare slug                     -> {SAME_PROJECT_PIN_SLUG}")
    print(
        f"  slash form                    -> "
        f"{ENTITY}/{OTHER_PROJECT}/{CROSS_PROJECT_PIN_SLASH_SLUG}"
    )
    print(
        f"  RunRef                        -> RunRef("
        f"{CROSS_PROJECT_PIN_RUNREF_SLUG!r}, entity={ENTITY!r}, "
        f"project={OTHER_PROJECT!r})"
    )
    print(
        f"Baseline (RunRef):              -> RunRef("
        f"{CROSS_PROJECT_BASELINE_SLUG!r}, entity={ENTITY!r}, "
        f"project={OTHER_PROJECT!r})"
    )
    print()

    workspace = ws.Workspace(
        entity=ENTITY,
        project=PRIMARY_PROJECT,
        name="Cross-project pins demo",
        runset_settings=ws.RunsetSettings(
            pinned_columns=["summary:accuracy", "summary:loss"],
            pinned_runs=[
                # Form 1: bare slug → same-project pin.
                SAME_PROJECT_PIN_SLUG,
                # Form 2: slash-form string → cross-project shorthand.
                f"{ENTITY}/{OTHER_PROJECT}/{CROSS_PROJECT_PIN_SLASH_SLUG}",
                # Form 3: typed RunRef → cross-project, explicit.
                ws.RunRef(
                    CROSS_PROJECT_PIN_RUNREF_SLUG,
                    entity=ENTITY,
                    project=OTHER_PROJECT,
                ),
            ],
            baseline_run=ws.RunRef(
                CROSS_PROJECT_BASELINE_SLUG,
                entity=ENTITY,
                project=OTHER_PROJECT,
            ),
        ),
    )

    workspace.save()
    print(f"Workspace saved: {workspace.url}")
    print()

    print("Round-trip sanity check:")
    loaded = ws.Workspace.from_url(workspace.url)
    print(f"  baseline_run on read = {loaded.runset_settings.baseline_run!r}")
    print(f"  pinned_runs on read  = {loaded.runset_settings.pinned_runs!r}")
    print(
        "  (same-project pin stays a bare slug str; cross-project pins come "
        "back as RunRef.)"
    )


if __name__ == "__main__":
    main()

```

Server compatibility
--------------------
<!--
If this PR relies on backend or UI behavior that only exists in some
W&B Server releases, apply the matching label from the Labels sidebar:

  - `requires-server/X.Y+`     — minimum tagged server release needed
  - `requires-server/unreleased` — works on SaaS today but not yet in any
                                   tagged server release; on-prem users
                                   should wait for a future server.

Leave unchecked if the change is pure SDK / works on all supported servers.
-->

- [ ] _Requires a minimum W&B Server version (label `requires-server/X.Y+` applied)_
- [ ] _SaaS only — not yet in any tagged W&B Server release (label `requires-server/unreleased` applied)_
- [ ] _N/A — works on all currently supported servers_

