### PR TITLE
feat(sdk): Support reading personal views

### DIFF
--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -253,6 +253,33 @@ def test_save_workspace():
         assert gql_definition.operation == "mutation"
 
 
+def test_save_personal_view_is_read_only():
+    mock_upsert_response = {
+        "upsertView": {
+            "view": {"id": "new-view-id", "name": "nw-generatedid-v"},
+            "inserted": True,
+        }
+    }
+
+    mock_api_instance, mock_client = create_mock_wandb_api(mock_upsert_response)
+
+    with patch("wandb.Api", return_value=mock_api_instance):
+        workspace = ws.Workspace(entity="test", project="test")
+        # Simulate a workspace loaded from a personal/user view URL
+        workspace._internal_name = "nw-nwuserbufo-w"
+
+        # save() must refuse *before* issuing any write
+        with pytest.raises(UnsupportedViewError):
+            workspace.save()
+        assert mock_client.execute.call_count == 0
+
+        # save_as_new_view() is the supported escape hatch and persists a new
+        # saved view (nw-{id}-v), so it should succeed
+        workspace.save_as_new_view()
+        assert mock_client.execute.call_count == 1
+        assert not workspace._internal_name.startswith("nw-nwuser")
+
+
 def test_workspace_url_uses_service_api_app_url_without_client():
     class _ServiceApi:
         app_url = "https://service.wandb.test/"
@@ -318,9 +345,9 @@ def test_validate_spec_version(example, should_pass):
             True,
         ),
         (
-            # username url
+            # personal/user view url
             "https://wandb.ai/entity/project?nw=nwusermegatruong",
-            False,
+            True,
         ),
         (
             # sweeps url
@@ -639,10 +666,7 @@ def test_cross_project_pinned_run_slash_form_roundtrip():
 
     model = workspace._to_model()
     gid = model.spec.section.run_sets[0].pinned_run_ids[0]
-    assert (
-        base64.b64decode(gid).decode()
-        == "Run:v1:abc1234:other-project:other-team"
-    )
+    assert base64.b64decode(gid).decode() == "Run:v1:abc1234:other-project:other-team"
 
     workspace2 = ws.Workspace._from_model(model)
     assert workspace2.runset_settings.pinned_runs == [
@@ -662,10 +686,7 @@ def test_cross_project_pinned_run_runref_roundtrip():
 
     model = workspace._to_model()
     gid = model.spec.section.run_sets[0].pinned_run_ids[0]
-    assert (
-        base64.b64decode(gid).decode()
-        == "Run:v1:abc1234:other-project:other-team"
-    )
+    assert base64.b64decode(gid).decode() == "Run:v1:abc1234:other-project:other-team"
 
     workspace2 = ws.Workspace._from_model(model)
     assert workspace2.runset_settings.pinned_runs == [pin]
@@ -716,9 +737,7 @@ def test_runref_defaults_to_workspace_entity_project():
 
     model = workspace._to_model()
     gid = model.spec.section.run_sets[0].pinned_run_ids[0]
-    assert (
-        base64.b64decode(gid).decode() == "Run:v1:abc1234:my-project:my-entity"
-    )
+    assert base64.b64decode(gid).decode() == "Run:v1:abc1234:my-project:my-entity"
 
     workspace2 = ws.Workspace._from_model(model)
     assert workspace2.runset_settings.pinned_runs == ["abc1234"]
@@ -747,9 +766,7 @@ def test_baseline_run_cross_project_auto_added_to_pinned():
     )
     model = workspace._to_model()
     runset = model.spec.section.run_sets[0]
-    expected_gid = base64.b64encode(
-        b"Run:v1:abc1234:other-project:other-team"
-    ).decode()
+    expected_gid = base64.b64encode(b"Run:v1:abc1234:other-project:other-team").decode()
     assert runset.baseline_run_id == expected_gid
     assert runset.pinned_run_ids == [expected_gid]
 

--- a/wandb_workspaces/utils/validators.py
+++ b/wandb_workspaces/utils/validators.py
@@ -1,6 +1,6 @@
 import unicodedata
 from typing import Any, Dict
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 from wandb_workspaces.workspaces.errors import SpecVersionError, UnsupportedViewError
 
@@ -43,14 +43,6 @@ def validate_url(url: str) -> str:
     else:
         raise UnsupportedViewError(
             r"Please use a saved view that looks like https://wandb.ai/{entity}/{project}?nw=a0b1c2d3"
-        )
-
-    # Supported NW query params
-    query_dict = parse_qs(parsed_url.query)
-    nw = query_dict.get("nw")
-    if nw and nw[0].startswith("nwuser"):
-        raise UnsupportedViewError(
-            r"Workspace API does not currently support user views.  Please use a saved view that looks like https://wandb.ai/{entity}/{project}?nw=a0b1c2d3"
         )
 
     return url

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -38,6 +38,7 @@ import wandb
 from annotated_types import Annotated, Ge
 from pydantic import AfterValidator, ConfigDict, Field, PositiveInt, model_validator
 from pydantic.dataclasses import dataclass
+from wandb.errors import UnsupportedError
 
 from wandb_workspaces._graphql import get_app_url
 from wandb_workspaces.reports.v2.interface import PanelTypes, _lookup_panel
@@ -46,6 +47,7 @@ from wandb_workspaces.utils.validators import validate_no_emoji, validate_url
 
 from .. import expr
 from . import internal
+from . import errors
 
 
 def _encode_run_gid(slug: str, project: str, entity: str) -> str:
@@ -1032,6 +1034,12 @@ class Workspace(Base):
         Returns:
             Workspace: The updated workspace with the saved internal name and ID.
         """
+        if self._internal_name.startswith("nw-nwuser"):
+            raise errors.UnsupportedViewError(
+                "Personal workspace views are read-only via the API. "
+                "Use `save_as_new_view()` to persist changes as a saved view."
+            )
+
         view = self._to_model()
 
         # If creating a new view with `ws.Workspace(...)`

--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -119,10 +119,6 @@ class View(WorkspaceAPIBaseModel):
         )
 
 
-VIEW_NAME_PREFIX = "nw-"
-VIEW_NAME_SUFFIXES = {"-v", "-w"}
-
-
 def upsert_view2(view: View) -> Dict[str, Any]:
     query = """
         mutation UpsertView2($id: ID, $entityName: String, $projectName: String, $type: String, $name: String, $displayName: String, $description: String, $spec: String) {
@@ -214,9 +210,10 @@ def get_view_dict(entity: str, project: str, view_name: str) -> Dict[str, Any]:
 
 
 def _internal_name_to_url_query_str(name: str) -> str:
-    if name.startswith(VIEW_NAME_PREFIX):
-        name = name[len(VIEW_NAME_PREFIX) :]
-    for suffix in VIEW_NAME_SUFFIXES:
+    # strip the "nw-" prefix and the "-v" (saved) / "-w" (personal) suffix
+    if name.startswith("nw-"):
+        name = name[len("nw-") :]
+    for suffix in ("-v", "-w"):
         if name.endswith(suffix):
             name = name[: -len(suffix)]
             break
@@ -227,8 +224,8 @@ def _internal_name_to_url_query_str(name: str) -> str:
 def _url_query_str_to_internal_name(name: str) -> str:
     # personal views are stored with a "-w" suffix; saved views use "-v"
     if name.startswith("nwuser"):
-        return f"{VIEW_NAME_PREFIX}{name}-w"
-    return f"{VIEW_NAME_PREFIX}{name}-v"
+        return f"nw-{name}-w"
+    return f"nw-{name}-v"
 
 
 def _generate_view_name() -> str:

--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -119,6 +119,10 @@ class View(WorkspaceAPIBaseModel):
         )
 
 
+VIEW_NAME_PREFIX = "nw-"
+VIEW_NAME_SUFFIXES = {"-v", "-w"}
+
+
 def upsert_view2(view: View) -> Dict[str, Any]:
     query = """
         mutation UpsertView2($id: ID, $entityName: String, $projectName: String, $type: String, $name: String, $displayName: String, $description: String, $spec: String) {
@@ -210,12 +214,21 @@ def get_view_dict(entity: str, project: str, view_name: str) -> Dict[str, Any]:
 
 
 def _internal_name_to_url_query_str(name: str) -> str:
-    name = name.replace("nw-", "").replace("-v", "")
+    if name.startswith(VIEW_NAME_PREFIX):
+        name = name[len(VIEW_NAME_PREFIX) :]
+    for suffix in VIEW_NAME_SUFFIXES:
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+            break
+
     return name
 
 
 def _url_query_str_to_internal_name(name: str) -> str:
-    return f"nw-{name}-v"
+    # personal views are stored with a "-w" suffix; saved views use "-v"
+    if name.startswith("nwuser"):
+        return f"{VIEW_NAME_PREFIX}{name}-w"
+    return f"{VIEW_NAME_PREFIX}{name}-v"
 
 
 def _generate_view_name() -> str:


### PR DESCRIPTION
<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
Please use conventional commits in your PR title. If you are unsure what conventional commits are or how to use them, please check out [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits).

JIRA/GH Issues(s)
-----------
Paste links to relevant JIRA/GH issues here, one per line e.g.
- https://coreweave.atlassian.net/browse/WB-35895

Description
-----------
Enables read access of personal workspace views by:
1. updating helper functions used for normalizing/rebuilding view names to account for personal views
2. getting rid of guard against user (personal) views in `validators.py`
3. adding a guard against saving personal views (because we want to allow read access only, not write)

I also applied Black formatting, so some of the asserts in the test file were re-formatted

Testing
-------
Tested out `Workspace.from_url` on a personal view. 

https://github.com/user-attachments/assets/81b3a1e6-e336-445e-a836-df3d1cbeded1

To test:
- Replace `PERSONAL_URL` in the test script below with your preferred view (ideally one with pinned/baseline views to distinguish it from other personal views of that project)
- run `uv run python <test_script.py>` 
- observe the printed statements in the terminal match what you see in the UI for your personal view.
- Also observe that if you ran this test script on master, you'd get `wandb_workspaces.workspaces.errors.UnsupportedViewError: Workspace API does not currently support user views.  Please use a saved view that looks like https://wandb.ai/{entity}/{project}?nw=a0b1c2d3`

**Test Script:** 
```
import wandb_workspaces.workspaces as ws
from wandb_workspaces.workspaces.errors import UnsupportedViewError

# A personal/user workspace URL (?nw=nwuser...)
PERSONAL_URL = "https://wandb.ai/wandb/dlin-mushrooms?nw=nwuserdlinwandb"


def check_read(url, label):
    print(f"\n=== READ {label} ===\n{url}")
    workspace = ws.Workspace.from_url(url)
    print(f"  loaded OK: name={workspace.name!r}")
    print(f"  internal_name={workspace._internal_name!r}")
    print(f"  sections={[s.name for s in workspace.sections]}")
    return workspace


# 1) Reading a personal view should now work
personal = check_read(PERSONAL_URL, "personal view")
rs = personal.runset_settings
print("\n=== pinned runs ===")
print(f"  baseline_run: {rs.baseline_run!r}")
print(f"  pinned_runs ({len(rs.pinned_runs)}):")
for r in rs.pinned_runs:
    print(f"    - {r!r}")

# 2) save() on a personal view must be blocked BEFORE any write
print("\n=== WRITE guard: save() on personal view ===")
try:
    personal.save()
    print("  ERROR: save() did NOT raise (guard failed!)")
except UnsupportedViewError as e:
    print(f"  blocked as expected: {e}")


print("\nDone.")
```

- [X] _Added unit tests_
- [ ] _Manual testing (include description)_
- [ ] _N/A (include explanation)_

Server compatibility
--------------------
<!--
If this PR relies on backend or UI behavior that only exists in some
W&B Server releases, apply the matching label from the Labels sidebar:

  - `requires-server/X.Y+`     — minimum tagged server release needed
  - `requires-server/unreleased` — works on SaaS today but not yet in any
                                   tagged server release; on-prem users
                                   should wait for a future server.

Leave unchecked if the change is pure SDK / works on all supported servers.
-->

- [ ] _Requires a minimum W&B Server version (label `requires-server/X.Y+` applied)_
- [ ] _SaaS only — not yet in any tagged W&B Server release (label `requires-server/unreleased` applied)_
- [ ] _N/A — works on all currently supported servers_

