### PR TITLE
feat: Add support for run group colors

### DIFF
--- a/examples/workspaces/05_group_colors.py
+++ b/examples/workspaces/05_group_colors.py
@@ -1,0 +1,42 @@
+import os
+
+import wandb_workspaces.reports.v2 as wr  # Panels are Reports API objects
+import wandb_workspaces.workspaces as ws
+
+# !! edit to your entity and project !!
+entity = os.getenv("WANDB_ENTITY")
+project = os.getenv("WANDB_PROJECT")
+
+# Color grouped runs by their groupby hierarchy. A bare string targets the
+# first groupby level; ws.GroupPath(...) targets a nested level. Descendants
+# inherit a parent's color unless they set their own.
+workspace = ws.Workspace(
+    entity=entity,
+    project=project,
+    name="Group colors example",
+    sections=[
+        ws.Section(
+            name="Metrics",
+            panels=[
+                wr.LinePlot(x="Step", y=["loss"]),
+                wr.LinePlot(x="Step", y=["accuracy"]),
+            ],
+            is_open=True,
+        ),
+    ],
+    runset_settings=ws.RunsetSettings(
+        groupby=[ws.Metric("group"), ws.Config("model")],
+        group_colors={
+            # Parent colors: descendants inherit unless overridden.
+            "sweep_alpha": "#4E79A7",
+            "sweep_beta": "#E15759",
+            # Nested override under sweep_alpha.
+            ws.GroupPath("sweep_alpha", "convnext"): "#59A14F",
+            # Nested-only colors under sweep_gamma.
+            ws.GroupPath("sweep_gamma", "resnet"): "#2A9D8F",
+            ws.GroupPath("sweep_gamma", "mlp"): "#F28E2B",
+        },
+    ),
+).save()
+
+print(workspace.url)

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -11,6 +11,11 @@ import wandb_workspaces.reports.v2.internal as _wr
 import wandb_workspaces.expr
 import wandb_workspaces.reports.v2 as wr
 import wandb_workspaces.workspaces as ws
+import wandb_workspaces.workspaces.interface as ws_interface
+from wandb_workspaces.workspaces._run_color_groups import (
+    RUN_COLOR_GROUP_KEY_PREFIX,
+    parse_run_color_group_key,
+)
 from tests.weave_panel_factory import WeavePanelFactory
 from wandb_workspaces.utils.validators import (
     validate_no_emoji,
@@ -423,6 +428,171 @@ def test_empty_column_settings():
     # Test round-trip - should be empty list
     workspace2 = ws.Workspace._from_model(model)
     assert workspace2.runset_settings.pinned_columns == []
+
+
+def _workspace_with_group_colors(groupby=None, group_colors=None):
+    return ws.Workspace(
+        entity="test-entity",
+        project="test-project",
+        runset_settings=ws.RunsetSettings(
+            groupby=groupby or [],
+            group_colors=group_colors or {},
+        ),
+    )
+
+
+def _only_group_color(workspace):
+    model = workspace._to_model()
+    custom_run_color = model.spec.section.custom_run_colors
+    assert len(custom_run_color) == 1
+    key, color = next(iter(custom_run_color.items()))
+    return model, parse_run_color_group_key(key), color
+
+
+def _custom_run_colors(workspace):
+    return workspace._to_model().spec.section.custom_run_colors
+
+
+def _capture_termwarns(monkeypatch):
+    warnings = []
+    monkeypatch.setattr(ws_interface.wandb, "termwarn", warnings.append)
+    return warnings
+
+
+@pytest.mark.parametrize(
+    ("groupby", "group_colors", "color", "path"),
+    [
+        (
+            [ws.Metric("group")],
+            {"sweep_alpha": "#4E79A7"},
+            "#4E79A7",
+            [{"kind": "group", "key": "run:group", "value": "sweep_alpha"}],
+        ),
+        (
+            [ws.Metric("group"), ws.Config("model")],
+            {ws.GroupPath("sweep_alpha", "model_vit"): "#59A14F"},
+            "#59A14F",
+            [
+                {"kind": "group", "key": "run:group", "value": "sweep_alpha"},
+                {"kind": "group", "key": "config:model.value", "value": "model_vit"},
+            ],
+        ),
+    ],
+)
+def test_group_colors_serialize_path(groupby, group_colors, color, path):
+    model, parsed, actual_color = _only_group_color(
+        _workspace_with_group_colors(groupby=groupby, group_colors=group_colors)
+    )
+
+    assert model.spec.section.run_sets[0].id
+    assert actual_color == color
+    assert parsed == {
+        "runset_id": model.spec.section.run_sets[0].id,
+        "path": path,
+    }
+
+
+def test_invalid_group_colors_warn_and_omit(monkeypatch):
+    workspace = _workspace_with_group_colors(
+        groupby=[ws.Metric("group")],
+        group_colors={
+            ws.GroupPath(): "#111111",
+            ws.GroupPath("sweep_alpha", "model_vit"): "#222222",
+            ws.GroupPath("sweep_alpha", 1): "#333333",
+            ws.GroupPath("sweep_beta"): 123,
+        },
+    )
+    warnings = _capture_termwarns(monkeypatch)
+
+    assert _custom_run_colors(workspace) == {}
+    assert len(warnings) == 4
+    assert any("empty GroupPath" in warning for warning in warnings)
+    assert any("exceeds groupby depth" in warning for warning in warnings)
+    assert any("segments must be strings" in warning for warning in warnings)
+    assert any("color must be a string" in warning for warning in warnings)
+
+
+def test_group_colors_without_groupby_warn_and_omit(monkeypatch):
+    workspace = _workspace_with_group_colors(
+        group_colors={"sweep_alpha": "#4E79A7"}
+    )
+    warnings = _capture_termwarns(monkeypatch)
+
+    assert _custom_run_colors(workspace) == {}
+    assert warnings == [
+        "Omitting group_colors because runset_settings.groupby is empty."
+    ]
+
+
+def test_duplicate_group_color_path_warns_and_keeps_first(monkeypatch):
+    workspace = _workspace_with_group_colors(
+        groupby=[ws.Metric("group")],
+        group_colors={
+            "sweep_alpha": "#111111",
+            ws.GroupPath("sweep_alpha"): "#222222",
+        },
+    )
+    warnings = _capture_termwarns(monkeypatch)
+
+    assert list(_custom_run_colors(workspace).values()) == ["#111111"]
+    assert len(warnings) == 1
+    assert "duplicate group color" in warnings[0]
+
+
+def test_group_colors_round_trip_from_model():
+    workspace = _workspace_with_group_colors(
+        groupby=[
+            ws.Metric("group"),
+            ws.Config("model"),
+            ws.Config("pbt.workspace.value"),
+        ],
+        group_colors={
+            "sweep_alpha": "#4E79A7",
+            ws.GroupPath("sweep_alpha", "model_vit"): "#59A14F",
+        },
+    )
+    model = workspace._to_model()
+
+    workspace2 = ws.Workspace._from_model(model)
+    model2 = workspace2._to_model()
+
+    assert [type(group) for group in workspace2.runset_settings.groupby] == [
+        ws.Metric,
+        ws.Config,
+        ws.Config,
+    ]
+    assert [group.name for group in workspace2.runset_settings.groupby] == [
+        "Group",
+        "model",
+        "pbt.workspace.value",
+    ]
+    assert [group.name for group in model2.spec.section.run_sets[0].grouping] == [
+        "group",
+        "model.value",
+        "pbt.workspace.value",
+    ]
+    assert workspace2.runset_settings.group_colors == {
+        "sweep_alpha": "#4E79A7",
+        ws.GroupPath("sweep_alpha", "model_vit"): "#59A14F",
+    }
+    assert model2.spec.section.custom_run_colors == model.spec.section.custom_run_colors
+
+
+def test_unknown_run_color_group_keys_round_trip_as_passthrough():
+    workspace = _workspace_with_group_colors(groupby=[ws.Metric("group")])
+    model = workspace._to_model()
+    unknown_key = f"{RUN_COLOR_GROUP_KEY_PREFIX}not-json:also-not-json"
+    model.spec.section.custom_run_colors[unknown_key] = "#123456"
+
+    workspace2 = ws.Workspace._from_model(model)
+    model2 = workspace2._to_model()
+
+    assert workspace2.runset_settings.group_colors == {}
+    assert (
+        workspace2.runset_settings._custom_run_colors_passthrough[unknown_key]
+        == "#123456"
+    )
+    assert model2.spec.section.custom_run_colors[unknown_key] == "#123456"
 
 
 def test_run_display_name_auto_added_to_pinned():

--- a/wandb_workspaces/workspaces/_run_color_groups.py
+++ b/wandb_workspaces/workspaces/_run_color_groups.py
@@ -1,0 +1,94 @@
+import json
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote, unquote
+
+RUN_COLOR_GROUP_KEY_PREFIX = "run-color-group:"
+URI_COMPONENT_SAFE_CHARS = "-_.!~*'()"
+
+
+class GroupPath:
+    """Hierarchical grouped-run path used as a group_colors key."""
+
+    __slots__ = ("segments",)
+
+    def __init__(self, *segments: str):
+        self.segments = tuple(segments)
+
+    def __iter__(self):
+        return iter(self.segments)
+
+    def __len__(self):
+        return len(self.segments)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, GroupPath):
+            return False
+        return self.segments == other.segments
+
+    def __hash__(self) -> int:
+        return hash(self.segments)
+
+    def __repr__(self) -> str:
+        args = ", ".join(repr(segment) for segment in self.segments)
+        return f"GroupPath({args})"
+
+
+def _encode_json_uri_component(value: Any) -> str:
+    return quote(
+        json.dumps(value, separators=(",", ":"), ensure_ascii=False),
+        safe=URI_COMPONENT_SAFE_CHARS,
+    )
+
+
+def _decode_json_uri_component(value: str) -> Any:
+    return json.loads(unquote(value))
+
+
+def build_run_color_group_key(
+    runset_id: Optional[str], path: List[Dict[str, Optional[str]]]
+) -> str:
+    return (
+        f"{RUN_COLOR_GROUP_KEY_PREFIX}"
+        f"{_encode_json_uri_component(runset_id)}:"
+        f"{_encode_json_uri_component(path)}"
+    )
+
+
+def parse_run_color_group_key(key: str) -> Optional[Dict[str, Any]]:
+    if not key.startswith(RUN_COLOR_GROUP_KEY_PREFIX):
+        return None
+
+    encoded_parts = key[len(RUN_COLOR_GROUP_KEY_PREFIX) :]
+    separator_index = encoded_parts.find(":")
+    if separator_index == -1:
+        return None
+
+    try:
+        runset_id = _decode_json_uri_component(encoded_parts[:separator_index])
+        path = _decode_json_uri_component(encoded_parts[separator_index + 1 :])
+    except Exception:
+        return None
+
+    if not (isinstance(runset_id, str) or runset_id is None):
+        return None
+    if not isinstance(path, list):
+        return None
+
+    for entry in path:
+        if not isinstance(entry, dict):
+            return None
+        if entry.get("kind") != "group":
+            return None
+        if not isinstance(entry.get("key"), str):
+            return None
+        value = entry.get("value")
+        if not (isinstance(value, str) or value is None):
+            return None
+
+    return {"runset_id": runset_id, "path": path}
+
+
+def group_path_key_from_segments(segments: Tuple[str, ...]) -> object:
+    if len(segments) == 1:
+        return segments[0]
+    return GroupPath(*segments)

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -164,7 +164,9 @@ def _serialize_group_colors(
         return {}
 
     if len(groupby) == 0:
-        wandb.termwarn("Omitting group_colors because runset_settings.groupby is empty.")
+        wandb.termwarn(
+            "Omitting group_colors because runset_settings.groupby is empty."
+        )
         return {}
 
     group_keys = [_key_to_string(_groupby_to_key(group)) for group in groupby]
@@ -1160,8 +1162,7 @@ class Workspace(Base):
                             ),
                             filters=filters_value,
                             grouping=[
-                                _groupby_to_key(g)
-                                for g in self.runset_settings.groupby
+                                _groupby_to_key(g) for g in self.runset_settings.groupby
                             ],
                             sort=internal.Sort(
                                 keys=[o.to_key() for o in self.runset_settings.order]

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -26,11 +26,11 @@ workspace.save()
 ```
 """
 
-import copy
 import base64
+import copy
 import dataclasses
 import os
-from typing import Dict, Iterable, Literal, Optional, Union
+from typing import Any, Dict, Iterable, Literal, Optional, Tuple, Union, cast
 from typing import List as LList
 from urllib.parse import parse_qs, urlparse, urlunparse
 
@@ -41,11 +41,18 @@ from pydantic.dataclasses import dataclass
 
 from wandb_workspaces._graphql import get_app_url
 from wandb_workspaces.reports.v2.interface import PanelTypes, _lookup_panel
-from wandb_workspaces.reports.v2.internal import TooltipNumberOfRuns
+from wandb_workspaces.reports.v2.internal import TooltipNumberOfRuns, _generate_name
 from wandb_workspaces.utils.validators import validate_no_emoji, validate_url
 
 from .. import expr
 from . import internal
+from ._run_color_groups import (
+    RUN_COLOR_GROUP_KEY_PREFIX,
+    GroupPath,
+    build_run_color_group_key,
+    group_path_key_from_segments,
+    parse_run_color_group_key,
+)
 
 
 def _encode_run_gid(slug: str, project: str, entity: str) -> str:
@@ -114,10 +121,132 @@ __all__ = [
     "RunSettings",
     "RunsetSettings",
     "RunRef",
+    "GroupPath",
     "Workspace",
 ]
 
 dataclass_config = ConfigDict(validate_assignment=True, extra="forbid")
+
+
+def _key_to_string(key: expr.Key) -> str:
+    return f"{key.section}:{key.name}"
+
+
+def _groupby_to_key(group: expr.MetricType) -> expr.Key:
+    key = group.to_key()
+    group_str = key.name if key.section == "run" else f"{key.section}.{key.name}"
+    return expr.groupby_str_to_key(group_str)
+
+
+def _groupby_from_key(key: expr.Key) -> expr.MetricType:
+    if key.section == "config":
+        path = ".".join(part for part in key.name.split(".") if part != "value")
+        config = expr.Config(path)
+        if _groupby_to_key(config) == key:
+            return config
+    return expr.BaseMetric.from_key(key)
+
+
+def _group_color_path_segments(path: object) -> Optional[Tuple[Any, ...]]:
+    if isinstance(path, str):
+        return (path,)
+    if isinstance(path, GroupPath):
+        return path.segments
+    return None
+
+
+def _serialize_group_colors(
+    group_colors: Dict[object, object],
+    groupby: LList[expr.MetricType],
+    runset_id: str,
+) -> Dict[str, str]:
+    if not group_colors:
+        return {}
+
+    if len(groupby) == 0:
+        wandb.termwarn("Omitting group_colors because runset_settings.groupby is empty.")
+        return {}
+
+    group_keys = [_key_to_string(_groupby_to_key(group)) for group in groupby]
+    serialized: Dict[str, str] = {}
+    seen_paths: set[Tuple[str, ...]] = set()
+
+    for raw_path, raw_color in group_colors.items():
+        segments = _group_color_path_segments(raw_path)
+        if segments is None:
+            wandb.termwarn(
+                f"Omitting group color for unsupported path key {raw_path!r}; "
+                "use a string or ws.GroupPath(...)."
+            )
+            continue
+        if len(segments) == 0:
+            wandb.termwarn("Omitting group color for empty GroupPath().")
+            continue
+        if not all(isinstance(segment, str) for segment in segments):
+            wandb.termwarn(
+                f"Omitting group color for path {raw_path!r}; "
+                "all group path segments must be strings."
+            )
+            continue
+        if len(segments) > len(group_keys):
+            wandb.termwarn(
+                f"Omitting group color for path {raw_path!r}; depth "
+                f"{len(segments)} exceeds groupby depth {len(group_keys)}."
+            )
+            continue
+        if not isinstance(raw_color, str):
+            wandb.termwarn(
+                f"Omitting group color for path {raw_path!r}; color must be a string."
+            )
+            continue
+
+        normalized_segments = tuple(segments)
+        if normalized_segments in seen_paths:
+            wandb.termwarn(
+                f"Omitting duplicate group color for path {raw_path!r}; "
+                "the first color for this path was kept."
+            )
+            continue
+
+        seen_paths.add(normalized_segments)
+        path_entries = [
+            {"kind": "group", "key": group_keys[index], "value": segment}
+            for index, segment in enumerate(normalized_segments)
+        ]
+        serialized[build_run_color_group_key(runset_id, path_entries)] = raw_color
+
+    return serialized
+
+
+def _deserialize_group_color(
+    key: str,
+    color: object,
+    runset_id: str,
+    groupby: LList[expr.Key],
+) -> Optional[Tuple[object, str]]:
+    parsed = parse_run_color_group_key(key)
+    if parsed is None:
+        return None
+    if parsed["runset_id"] != runset_id:
+        return None
+    if not isinstance(color, str):
+        return None
+
+    path = parsed["path"]
+    if len(path) == 0 or len(path) > len(groupby):
+        return None
+
+    group_keys = [_key_to_string(group) for group in groupby]
+    segments = []
+    for index, entry in enumerate(path):
+        if entry["key"] != group_keys[index]:
+            return None
+        value = entry["value"]
+        if not isinstance(value, str):
+            return None
+        segments.append(value)
+
+    return group_path_key_from_segments(tuple(segments)), color
 
 
 # RunRef is a pure data container with no validation requirements, so we use
@@ -537,6 +666,9 @@ class RunsetSettings(Base):
         order (LList[expr.Ordering]): A list of metrics and ordering to apply to the runset.
         run_settings (Dict[str, RunSettings]): A dictionary of run settings, where the key
             is the run's ID and the value is a RunSettings object.
+        group_colors (Dict[Union[str, GroupPath], str]): Colors for grouped run
+            hierarchy nodes. Keys follow `groupby` order; a string targets the
+            first group level and `GroupPath(...)` targets nested levels.
         pinned_columns (LList[str]): List of column names to pin.
             Column names use format: "run:displayName", "summary:metric", "config:param".
             run:displayName is automatically added if not present.
@@ -612,6 +744,19 @@ class RunsetSettings(Base):
     }
     ```
     """
+    group_colors: Dict[object, object] = Field(default_factory=dict)
+    """
+    A dictionary of group path colors. A string key targets the first groupby
+    level; use GroupPath(...) for nested group paths.
+
+    Example usage:
+    ```
+    group_colors = {
+        "sweep_alpha": "#4E79A7",
+        GroupPath("sweep_alpha", "model_vit"): "#59A14F",
+    }
+    ```
+    """
 
     # Column management
     pinned_columns: LList[str] = Field(default_factory=list)
@@ -623,6 +768,9 @@ class RunsetSettings(Base):
     # Internal fields for backend serialization (not user-facing)
     _visible_columns: LList[str] = Field(default_factory=list, init=False, repr=False)
     _column_order: LList[str] = Field(default_factory=list, init=False, repr=False)
+    _custom_run_colors_passthrough: Dict[str, object] = Field(
+        default_factory=dict, init=False, repr=False
+    )
 
     @model_validator(mode="after")
     def validate_and_setup_columns(self):
@@ -755,8 +903,11 @@ class Workspace(Base):
     def _from_model(cls, model: internal.View):
         # construct configs from disjoint parts of settings
         run_settings = {}
+        group_colors: Dict[object, object] = {}
+        custom_run_colors_passthrough: Dict[str, object] = {}
+        runset_model = model.spec.section.run_sets[0]
 
-        disabled_runs = model.spec.section.run_sets[0].selections.tree
+        disabled_runs = runset_model.selections.tree
         for item in disabled_runs:
             if isinstance(item, str):
                 run_settings[item] = RunSettings(disabled=True)
@@ -766,14 +917,28 @@ class Workspace(Base):
 
         custom_run_colors = model.spec.section.custom_run_colors
         for k, v in custom_run_colors.items():
-            if k != "ref":
-                id = k
-                color = v
+            if k == "ref":
+                continue
 
-                if id not in run_settings:
-                    run_settings[id] = RunSettings(color=color)
+            if isinstance(k, str) and k.startswith(RUN_COLOR_GROUP_KEY_PREFIX):
+                group_color = _deserialize_group_color(
+                    k, v, runset_model.id, runset_model.grouping
+                )
+                if group_color is None:
+                    custom_run_colors_passthrough[k] = v
                 else:
-                    run_settings[id].color = color
+                    path_key, color = group_color
+                    if path_key not in group_colors:
+                        group_colors[path_key] = color
+                continue
+
+            id = k
+            color = v
+
+            if id not in run_settings:
+                run_settings[id] = RunSettings(color=color)
+            else:
+                run_settings[id].color = color
 
         regex_query = True if model.spec.section.run_sets[0].search.is_regex else False
 
@@ -830,7 +995,6 @@ class Workspace(Base):
             col for col, is_pinned in run_feed.column_pinned.items() if is_pinned
         ]
 
-        runset_model = model.spec.section.run_sets[0]
         if isinstance(runset_model.filters, dict) and expr.is_filter_v2(
             runset_model.filters
         ):
@@ -840,7 +1004,9 @@ class Workspace(Base):
             # Legacy filters: the workspace was saved before v2 and hasn't been
             # opened in the UI yet (which does lazy conversion).  Convert the
             # legacy Filters tree to v2.
-            stashed_v2 = expr.filters_tree_to_v2(runset_model.filters)
+            stashed_v2 = expr.filters_tree_to_v2(
+                cast(expr.Filters, runset_model.filters)
+            )
             filter_string = expr.filters_v2_to_string(stashed_v2)
 
         # then construct the Workspace object
@@ -857,20 +1023,24 @@ class Workspace(Base):
                 query=runset_model.search.query,
                 regex_query=regex_query,
                 filters=filter_string,
-                groupby=[expr.BaseMetric.from_key(v) for v in runset_model.grouping],
+                groupby=[_groupby_from_key(v) for v in runset_model.grouping],
                 order=[expr.Ordering.from_key(s) for s in runset_model.sort.keys],
                 run_settings=run_settings,
+                group_colors=group_colors,
                 pinned_columns=pinned_columns,
                 baseline_run=_format_decoded_pin(
-                    model.spec.section.run_sets[0].baseline_run_id,
+                    runset_model.baseline_run_id,
                     model.entity,
                     model.project,
                 ),
                 pinned_runs=[
                     _format_decoded_pin(rid, model.entity, model.project)
-                    for rid in (model.spec.section.run_sets[0].pinned_run_ids or [])
+                    for rid in (runset_model.pinned_run_ids or [])
                 ],
             ),
+        )
+        obj.runset_settings._custom_run_colors_passthrough = (
+            custom_run_colors_passthrough
         )
         obj._internal_name = model.name
         obj._internal_id = model.id
@@ -937,6 +1107,24 @@ class Workspace(Base):
                 expr.expr_to_filters(self.runset_settings.filters)  # type: ignore[arg-type] # validator ensures this is always str
             )
 
+        runset_id = self._internal_runset_id
+        if self.runset_settings.group_colors and not runset_id:
+            runset_id = _generate_name()
+            object.__setattr__(self, "_internal_runset_id", runset_id)
+
+        custom_run_colors = {
+            **self.runset_settings._custom_run_colors_passthrough,
+            **_serialize_group_colors(
+                self.runset_settings.group_colors,
+                self.runset_settings.groupby,
+                runset_id,
+            ),
+            **{
+                id: config.color
+                for id, config in self.runset_settings.run_settings.items()
+            },
+        }
+
         return internal.View(
             entity=self.entity,
             project=self.project,
@@ -959,7 +1147,7 @@ class Workspace(Base):
                     settings=internal_settings,
                     run_sets=[
                         internal.Runset(
-                            id=self._internal_runset_id,
+                            id=runset_id,
                             run_feed=internal.RunFeed(
                                 column_pinned=column_pinned_dict,
                                 column_visible=column_visible_dict,
@@ -971,7 +1159,10 @@ class Workspace(Base):
                                 is_regex=is_regex,
                             ),
                             filters=filters_value,
-                            grouping=[g.to_key() for g in self.runset_settings.groupby],
+                            grouping=[
+                                _groupby_to_key(g)
+                                for g in self.runset_settings.groupby
+                            ],
                             sort=internal.Sort(
                                 keys=[o.to_key() for o in self.runset_settings.order]
                             ),
@@ -1001,10 +1192,7 @@ class Workspace(Base):
                             ),
                         ),
                     ],
-                    custom_run_colors={
-                        id: config.color
-                        for id, config in self.runset_settings.run_settings.items()
-                    },
+                    custom_run_colors=custom_run_colors,
                 ),
             ),
         )


### PR DESCRIPTION
JIRA/GH Issues(s)
-----------
https://coreweave.atlassian.net/browse/WB-36002

Description
-----------
**note:** requires [frontend PR #46413](https://github.com/wandb/core/pull/46413) (WB-36001) to render the colors in the UI

Adds programmatic group-row colors to workspace runsets, the SDK side of the hierarchical group color work.

- Adds `group_colors` to `ws.RunsetSettings`, keyed by a string (first groupby level) or `ws.GroupPath(...)` for nested levels, with values as hex colors
- Serializes to the `run-color-group:` custom-run-color scheme shared with the frontend (#46413), so SDK-set and UI-set colors coexist in the same `customRunColors` map
- Round-trips unknown / UI-authored `run-color-group:` keys untouched via a passthrough, so a load + save never drops colors the SDK doesn't recognize
- Normalizes config groupby keys to include `.value` on serialize (matches backend storage + how panels group) — `ws.Config("model")` now groups correctly, not just colors
- Invalid entries (empty path, depth beyond groupby, non-string segment/color, or no groupby) warn and are omitted rather than failing the save

ex.
```python
import wandb_workspaces.workspaces as ws

workspace = ws.Workspace(
    entity=ENTITY,
    project=PROJECT,
    runset_settings=ws.RunsetSettings(
        groupby=[ws.Metric("group"), ws.Config("model")],
        group_colors={
            "sweep_alpha": "#4E79A7",                              # first groupby level
            ws.GroupPath("sweep_alpha", "model_vit"): "#59A14F",   # nested level
        },
    ),
)
workspace.save()
```

Testing
-------
- [x] Added unit tests
- [ ] Manual testing (full UI render requires frontend PR #46413)
- [ ] N/A

repro for testers: `examples/workspaces/05_group_colors.py`
focused test run: `uv run pytest tests/test_workspaces.py -q` (58 passed); `ruff check` + `mypy .` clean

Server compatibility
--------------------
- [ ] _Requires a minimum W&B Server version (label `requires-server/X.Y+` applied)_
- [x] _SaaS only — not yet in any tagged W&B Server release (label `requires-server/unreleased` applied)_
- [ ] _N/A — works on all currently supported servers_
