### PR TITLE
fix: Group panels by run-level attributes without .value

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -800,6 +800,21 @@ def test_groupby_aggregate_behavior():
         assert model.config.aggregate is False
 
 
+def test_groupby_metric_field_round_trip():
+    """wr.Metric is a valid groupby and survives a panel round-trip."""
+
+    for cls in (wr.LinePlot, wr.BarPlot):
+        # wr.Metric is accepted on the field and serializes to its backend name.
+        model = cls(groupby=wr.Metric("Group"))._to_model()
+        assert model.config.group_by == "group"
+
+        # Run attribute round-trips to its plain frontend name; a logged
+        # metric stays a Metric.
+        assert cls._from_model(model).groupby == "Group"
+        loss = cls._from_model(cls(groupby=wr.Metric("loss"))._to_model())
+        assert loss.groupby == wr.Metric("loss")
+
+
 def test_strip_refs():
     """Test that _strip_refs removes ref fields correctly from nested structures"""
     # Test comprehensive nested structure with proper ref objects

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -666,6 +666,16 @@ def test_metric_to_backend_groupby():
         # Pass-through when ".value" is already present (flat-key format)
         ("pbt.workspace.value", "pbt.workspace.value"),
         ("config.pbt.workspace.value", "pbt.workspace.value"),
+        # Run-level attributes map to their backend name with NO ".value"
+        # (regression: "Group" used to serialize as "Group.value" and render
+        # as a single collapsed "Group: -" bar).
+        ("Group", "group"),
+        ("Sweep", "sweep"),
+        ("State", "state"),
+        # Explicit Config() of a name that collides with a run attribute is
+        # still treated as a config key.
+        (wr.Config("Group"), "Group.value"),
+        ("config.Group", "Group.value"),
         # Edge cases
         (None, None),
         ("", ".value"),
@@ -687,7 +697,11 @@ def test_metric_to_frontend_groupby():
         ("keys.value.key1", wr.Config("keys.key1")),
         # Flat-key format (.value at end)
         ("pbt.workspace.value", wr.Config("pbt.workspace")),
-        # Non-config paths pass through unchanged
+        # Run-level attributes map back to their frontend name
+        ("group", "Group"),
+        ("sweep", "Sweep"),
+        ("state", "State"),
+        # Non-config / unrecognized paths pass through unchanged
         ("non_config_path", "non_config_path"),
         (None, None),
         ("None", "None"),

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -676,6 +676,12 @@ def test_metric_to_backend_groupby():
         # still treated as a config key.
         (wr.Config("Group"), "Group.value"),
         ("config.Group", "Group.value"),
+        # A bare string already resolves a run attribute (above); wr.Metric is
+        # the explicit form — same result, and the counterpart to wr.Config for
+        # a colliding name. Names are FE-to-BE mapped like everywhere else.
+        (wr.Metric("Group"), "group"),
+        (wr.Metric("State"), "state"),
+        (wr.Metric("CreatedTimestamp"), "createdAt"),
         # Edge cases
         (None, None),
         ("", ".value"),
@@ -697,12 +703,14 @@ def test_metric_to_frontend_groupby():
         ("keys.value.key1", wr.Config("keys.key1")),
         # Flat-key format (.value at end)
         ("pbt.workspace.value", wr.Config("pbt.workspace")),
-        # Run-level attributes map back to their frontend name
+        # Known run-level attributes map back to their plain frontend name.
         ("group", "Group"),
         ("sweep", "Sweep"),
         ("state", "State"),
-        # Non-config / unrecognized paths pass through unchanged
-        ("non_config_path", "non_config_path"),
+        ("createdAt", "CreatedTimestamp"),
+        # Unrecognized run-section paths stay a Metric (a bare string there
+        # would re-serialize down the config ".value" path and not round-trip).
+        ("non_config_path", wr.Metric("non_config_path")),
         (None, None),
         ("None", "None"),
     ]

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -4397,10 +4397,11 @@ def _metric_to_frontend_panel_grid(x: str):
     return _metric_to_frontend(x)
 
 
-def _metric_to_backend_groupby(val: Optional[Union[str, "Config"]]) -> Optional[str]:
+def _metric_to_backend_groupby(
+    val: Optional[Union[str, "Config", "Metric"]]
+) -> Optional[str]:
     """
-    Normalise a group-by key so the backend always receives a path containing
-    ``.value``.
+    Normalise a group-by key into the string the backend expects.
 
     Run-level attributes (``Group``, ``Sweep``, ``State``, ...) are addressed by
     their backend name with NO ``.value`` suffix, mirroring how
@@ -4414,6 +4415,10 @@ def _metric_to_backend_groupby(val: Optional[Union[str, "Config"]]) -> Optional[
     allows users to pass the exact backend key for flat dotted config keys (see
     ambiguity note in ``expr.groupby_str_to_key`` for details).
 
+    A bare string matching a run-level attribute name (any key in
+    ``expr.FE_METRIC_NAME_MAP``) resolves to that attribute, not a config key;
+    use ``wr.Config("State")`` for a config key of the same name.
+
     Accepts
     --------
     1. wr.Config("epochs")              ➔ "epochs.value"
@@ -4422,14 +4427,18 @@ def _metric_to_backend_groupby(val: Optional[Union[str, "Config"]]) -> Optional[
     4. "a.b.value"                      ➔ "a.b.value"  (pass-through)
     5. "a.value.b"                      ➔ "a.value.b"  (pass-through)
     6. "Group" / "Sweep" / "State"      ➔ "group" / "sweep" / "state"
+    7. wr.Metric("Group")               ➔ "group"  (explicit run attribute)
     """
     if val in (None, "None"):
         return val
 
-    # 1) unwrap wr.Config / strip a "config." prefix. Either form is an explicit
-    #    signal that the key is a config (hyperparameter) key, so we must NOT
-    #    treat it as a run-level attribute even if its name collides with one
-    #    (e.g. wr.Config("Group") means a config key literally named "Group").
+    # 1) wr.Metric is an explicit run-section key: return its backend name, no
+    #    ".value" (that envelope is config-only). Counterpart to wr.Config.
+    if isinstance(val, Metric):
+        return expr.to_backend_name(val.name)
+
+    # 2) wr.Config / a "config." prefix explicitly marks a config key, so don't
+    #    treat it as a run attribute even if the name collides with one.
     explicit_config = False
     if isinstance(val, Config):
         val = val.name
@@ -4438,14 +4447,14 @@ def _metric_to_backend_groupby(val: Optional[Union[str, "Config"]]) -> Optional[
         val = val.split("config.", 1)[1]
         explicit_config = True
 
-    # 2) bare run-level attributes map to their backend name with no ".value"
+    # 3) bare run-level attributes map to their backend name with no ".value"
     #    suffix (the same path expr.groupby_str_to_key uses for Runset grouping).
     if not explicit_config and val in expr.FE_METRIC_NAME_MAP:
         return expr.to_backend_name(val)
 
     segments = val.split(".")
 
-    # 3) if ".value" is already present anywhere, the user has provided the
+    # 4) if ".value" is already present anywhere, the user has provided the
     #    exact backend key — pass through as-is.
     #    Note: this means a config key literally named "value" (e.g.
     #    wandb.config.settings = {"value": 123} -> backend key
@@ -4465,20 +4474,23 @@ def _metric_to_frontend_groupby(val: Optional[str]):
         "epochs.value"   ➔ Config("epochs")
         "a.value.b"      ➔ Config("a.b")
         "a.b.value"      ➔ Config("a.b")
-        "group"          ➔ "Group"   (run-level attribute)
+        "group"          ➔ "Group"   (known run-level attribute)
     Handles both nested-dict format (``.value`` after first segment) and
     flat-key format (``.value`` at the end). A path without ``.value`` is a
-    run-level attribute: its backend name is mapped back to the frontend form
-    (e.g. "group" ➔ "Group"); anything unrecognized is returned unchanged.
+    run-section key: a known run attribute maps back to its plain frontend name
+    (e.g. "group" ➔ "Group"); any other name is returned as a ``Metric``, since
+    a bare string there would re-serialize down the config ".value" path.
     """
     if val in (None, "None") or not isinstance(val, str):
         return val
 
     parts = val.split(".")
     if "value" not in parts:
-        # Not a config key: map known run-level backend names back to their
-        # frontend form (the inverse of _metric_to_backend_groupby).
-        return expr._convert_be_to_fe_metric_name(val)
+        # Run-section key: known run attributes round-trip as their plain
+        # frontend name; anything else must stay a Metric to round-trip.
+        if val in expr.FE_METRIC_NAME_MAP.inv:
+            return expr.to_frontend_name(val)
+        return Metric(val)
 
     # Strip the "value" segment wherever it appears and reconstruct the path
     path_parts = [p for p in parts if p != "value"]

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -4402,11 +4402,17 @@ def _metric_to_backend_groupby(val: Optional[Union[str, "Config"]]) -> Optional[
     Normalise a group-by key so the backend always receives a path containing
     ``.value``.
 
-    By default, assumes nested dict config and inserts ``.value`` after the
-    first segment. If ``.value`` already appears anywhere in the path, the
-    value is returned as-is — this allows users to pass the exact backend key
-    for flat dotted config keys (see ambiguity note in
-    ``expr.groupby_str_to_key`` for details).
+    Run-level attributes (``Group``, ``Sweep``, ``State``, ...) are addressed by
+    their backend name with NO ``.value`` suffix, mirroring how
+    ``expr.groupby_str_to_key`` handles Runset grouping. Without this, grouping a
+    panel by ``"Group"`` serialized to ``"Group.value"``, which the frontend
+    could not resolve and rendered as a single collapsed ``"Group: -"`` bar.
+
+    Otherwise the key is assumed to be a config (hyperparameter) key: nested dict
+    config gets ``.value`` inserted after the first segment. If ``.value``
+    already appears anywhere in the path, the value is returned as-is; this
+    allows users to pass the exact backend key for flat dotted config keys (see
+    ambiguity note in ``expr.groupby_str_to_key`` for details).
 
     Accepts
     --------
@@ -4415,17 +4421,27 @@ def _metric_to_backend_groupby(val: Optional[Union[str, "Config"]]) -> Optional[
     3. "epochs" / "a.b"                 ➔ "epochs.value" / "a.value.b"
     4. "a.b.value"                      ➔ "a.b.value"  (pass-through)
     5. "a.value.b"                      ➔ "a.value.b"  (pass-through)
+    6. "Group" / "Sweep" / "State"      ➔ "group" / "sweep" / "state"
     """
     if val in (None, "None"):
         return val
 
-    # 1) unwrap wr.Config
+    # 1) unwrap wr.Config / strip a "config." prefix. Either form is an explicit
+    #    signal that the key is a config (hyperparameter) key, so we must NOT
+    #    treat it as a run-level attribute even if its name collides with one
+    #    (e.g. wr.Config("Group") means a config key literally named "Group").
+    explicit_config = False
     if isinstance(val, Config):
         val = val.name
-
-    # 2) drop an explicit "config." prefix for uniform handling
-    if val.startswith("config."):
+        explicit_config = True
+    elif val.startswith("config."):
         val = val.split("config.", 1)[1]
+        explicit_config = True
+
+    # 2) bare run-level attributes map to their backend name with no ".value"
+    #    suffix (the same path expr.groupby_str_to_key uses for Runset grouping).
+    if not explicit_config and val in expr.FE_METRIC_NAME_MAP:
+        return expr.to_backend_name(val)
 
     segments = val.split(".")
 
@@ -4449,16 +4465,20 @@ def _metric_to_frontend_groupby(val: Optional[str]):
         "epochs.value"   ➔ Config("epochs")
         "a.value.b"      ➔ Config("a.b")
         "a.b.value"      ➔ Config("a.b")
+        "group"          ➔ "Group"   (run-level attribute)
     Handles both nested-dict format (``.value`` after first segment) and
-    flat-key format (``.value`` at the end). Anything without ``.value``
-    in the path is returned unchanged.
+    flat-key format (``.value`` at the end). A path without ``.value`` is a
+    run-level attribute: its backend name is mapped back to the frontend form
+    (e.g. "group" ➔ "Group"); anything unrecognized is returned unchanged.
     """
     if val in (None, "None") or not isinstance(val, str):
         return val
 
     parts = val.split(".")
     if "value" not in parts:
-        return val  # not a config key, just return as-is
+        # Not a config key: map known run-level backend names back to their
+        # frontend form (the inverse of _metric_to_backend_groupby).
+        return expr._convert_be_to_fe_metric_name(val)
 
     # Strip the "value" segment wherever it appears and reconstruct the path
     path_parts = [p for p in parts if p != "value"]

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -2105,8 +2105,10 @@ class LinePlot(Panel):
         title_x (Optional[str]): The label of the x-axis.
         title_y (Optional[str]): The label of the y-axis.
         ignore_outliers (Optional[bool]): If set to `True`, do not plot outliers.
-        groupby (Optional[str]): Group runs based on a metric logged to your W&B project that the
-            report pulls information from.
+        groupby (Optional[Union[str, Config, Metric]]): Group runs by a key. A bare
+            string or `wr.Metric(...)` names a run-level attribute (e.g. "Group");
+            `wr.Config(...)` names a config key. A bare string matching an
+            attribute name resolves to the attribute, not a config key.
         groupby_aggfunc (Optional[GroupAgg]): Aggregate runs with specified
             function. Options include "mean", "min", "max", "median", "sum", "samples", or `None`.
         groupby_rangefunc (Optional[GroupArea]):  Group runs based on a range. Options
@@ -2155,7 +2157,7 @@ class LinePlot(Panel):
     title_x: Optional[str] = None
     title_y: Optional[str] = None
     ignore_outliers: Optional[bool] = None
-    groupby: Optional[Union[str, Config]] = None
+    groupby: Optional[Union[str, Config, Metric]] = None
     groupby_aggfunc: Optional[GroupAgg] = None
     groupby_rangefunc: Optional[GroupArea] = None
     smoothing_factor: Optional[float] = None
@@ -2399,8 +2401,10 @@ class BarPlot(Panel):
         range_x (Tuple[float | None, float | None]): Tuple that specifies the range of the x-axis.
         title_x (Optional[str]): The label of the x-axis.
         title_y (Optional[str]): The label of the y-axis.
-        groupby (Optional[str]): Group runs based on a metric logged to your W&B project that the
-            report pulls information from.
+        groupby (Optional[Union[str, Config, Metric]]): Group runs by a key. A bare
+            string or `wr.Metric(...)` names a run-level attribute (e.g. "Group");
+            `wr.Config(...)` names a config key. A bare string matching an
+            attribute name resolves to the attribute, not a config key.
         groupby_aggfunc (Optional[GroupAgg]): Aggregate runs with specified
             function. Options include "mean", "min", "max", "median", "sum", "samples", or `None`.
         groupby_rangefunc (Optional[GroupArea]):  Group runs based on a range. Options
@@ -2422,7 +2426,7 @@ class BarPlot(Panel):
     range_x: Range = Field(default_factory=lambda: (None, None))
     title_x: Optional[str] = None
     title_y: Optional[str] = None
-    groupby: Optional[Union[str, Config]] = None
+    groupby: Optional[Union[str, Config, Metric]] = None
     groupby_aggfunc: Optional[GroupAgg] = None
     groupby_rangefunc: Optional[GroupArea] = None
     max_runs_to_show: Optional[int] = None


### PR DESCRIPTION

JIRA/GH Issues(s)
-----------

https://coreweave.atlassian.net/browse/WB-36405

Description
-----------

Grouping a report panel by a run-level attribute (`Group`, `Sweep`, `State`) causes issues. `BarPlot(groupby="Group")` rendered a single collapsed bar labeled `"Group: -"`, and `BarPlot(groupby=wr.Metric("Group"))` raised `TypeError`.

This PR resolves run-attribute keys to their backend name with no `.value` config envelope, in both directions, and makes `wr.Metric` a first-class group-by value.

- `_metric_to_backend_groupby`: check `expr.FE_METRIC_NAME_MAP` before assuming a config key, and accept `wr.Metric` as an explicit run-section key.
- `_metric_to_frontend_groupby`: map known backend attribute names back to their frontend form (`"group"` → `"Group"`); any other run-section key round-trips as `wr.Metric`, since a bare string there would re-serialize down the `.value` path.
- `LinePlot.groupby` / `BarPlot.groupby` now accept `Union[str, Config, Metric]`, so `wr.Metric` is valid on the field.

Testing
-------
How was this PR tested?

- [X] _Added unit tests_
- [ ] _Manual testing (include description)_
- [ ] _N/A (include explanation)_

`test_metric_to_backend_groupby` and `test_metric_to_frontend_groupby`

Server compatibility
--------------------
<!--
If this PR relies on backend or UI behavior that only exists in some
W&B Server releases, apply the matching label from the Labels sidebar:

  - `requires-server/X.Y+`     — minimum tagged server release needed
  - `requires-server/unreleased` — works on SaaS today but not yet in any
                                   tagged server release; on-prem users
                                   should wait for a future server.

Leave unchecked if the change is pure SDK / works on all supported servers.
-->

- [ ] _Requires a minimum W&B Server version (label `requires-server/X.Y+` applied)_
- [ ] _SaaS only — not yet in any tagged W&B Server release (label `requires-server/unreleased` applied)_
- [X] _N/A — works on all currently supported servers_

