### PR TITLE
fix(workspaces): load and round-trip workspaces with UI-only panel override keys

### DIFF
--- a/examples/workspaces/06_copy_view_to_another_project.py
+++ b/examples/workspaces/06_copy_view_to_another_project.py
@@ -1,0 +1,32 @@
+import os
+
+import wandb_workspaces.workspaces as ws
+
+# A Workspace is a single saved view; from_url() returns it directly. To copy a
+# view to another project, load it, point it at the destination, and save it as
+# a new view.
+
+# !! edit to your source entity, project, and saved view !!
+source_entity = os.getenv("WANDB_ENTITY")
+source_project = os.getenv("WANDB_PROJECT")
+saved_view = "your-view-id"
+
+# !! edit to your destination entity, project, and view name !!
+target_entity = "target-entity"
+target_project = "target-project"
+target_view_name = "Copied view"
+
+# 1. Load the source view. Its sections, panels, and settings are all populated.
+url = f"https://wandb.ai/{source_entity}/{source_project}?nw={saved_view}"
+workspace = ws.Workspace.from_url(url)
+
+# 2. Point it at the destination and name the copy.
+workspace.entity = target_entity
+workspace.project = target_project
+workspace.name = target_view_name
+
+# 3. Save as a new view in the destination project; logs the new view's URL.
+workspace.save_as_new_view()
+
+# NOTE: panels reference metric names, so copied panels may render empty for
+# metrics the target project hasn't logged.

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -11,6 +11,7 @@ import wandb_workspaces.reports.v2.internal as _wr
 import wandb_workspaces.expr
 import wandb_workspaces.reports.v2 as wr
 import wandb_workspaces.workspaces as ws
+import wandb_workspaces.workspaces.internal as ws_internal
 import wandb_workspaces.workspaces.interface as ws_interface
 from wandb_workspaces.workspaces._run_color_groups import (
     RUN_COLOR_GROUP_KEY_PREFIX,
@@ -220,6 +221,53 @@ def test_load_workspace_from_url():
             "name": "test_project",
             "viewName": "nw-51cset95tvn-v",
         }
+
+
+def test_workspace_roundtrips_panel_overrides():
+    """A view with UI-only override keys loads with its sections intact and
+    re-saves with the keys preserved (via the interface stash)."""
+    overrides = {"val_loss": {"config": {"chartTitle": "Loss"}}}
+    placements = {"val_loss": {"sectionId": "sec-1", "orderKey": "a0"}}
+
+    spec = ws_internal.WorkspaceViewspec.model_validate(
+        {
+            "section": {
+                "panelBankConfig": {
+                    "state": 1,
+                    "settings": {},
+                    "sections": [{"name": "Charts", "panels": []}],
+                    "panelConfigOverrides": overrides,
+                    "panelPlacementOverrides": placements,
+                },
+                "panelBankSectionConfig": {"name": "Report Panels", "pinned": False},
+                "customRunColors": {},
+                "runSets": [{}],
+                "settings": {},
+            }
+        }
+    )
+    model = ws_internal.View(
+        entity="e", project="p", display_name="d", name="nw-x-v", id="id", spec=spec
+    )
+
+    workspace = ws.Workspace._from_model(model)
+    assert [s.name for s in workspace.sections] == ["Charts"]
+
+    roundtripped = workspace._to_model().spec.section.panel_bank_config
+    assert roundtripped.panel_config_overrides == overrides
+    assert roundtripped.panel_placement_overrides == placements
+
+
+def test_workspace_without_overrides_omits_override_keys():
+    """A from-scratch workspace never emits the UI-only override keys."""
+    dumped = (
+        ws.Workspace(entity="e", project="p")
+        ._to_model()
+        .spec.model_dump(by_alias=True, exclude_none=True)
+    )
+    pbc = dumped["section"]["panelBankConfig"]
+    assert "panelConfigOverrides" not in pbc
+    assert "panelPlacementOverrides" not in pbc
 
 
 def test_save_workspace():

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -21,7 +21,6 @@ from pydantic import (
     StringConstraints,
     computed_field,
     field_validator,
-    root_validator,
     validator,
 )
 from pydantic.alias_generators import to_camel
@@ -260,17 +259,9 @@ class PanelBankConfig(ReportAPIBaseModel):
     sections: LList[PanelBankConfigSectionsItem] = Field(
         default_factory=lambda: [PanelBankConfigSectionsItem()]
     )
-
-    # Run keys are arbitrarily added here, so add some type checking for safety
-    # All run keys have the shape (key:str, value:colour)
-    @root_validator(pre=True)
-    def check_arbitrary_keys(cls, values):  # noqa: N805
-        fixed_keys = cls.__annotations__.keys()
-        ignored_keys = {"ref"}
-        for k, v in values.items():
-            if k not in fixed_keys and k not in ignored_keys and not isinstance(v, str):
-                raise ValueError(f"Arbitrary key '{k}' must be of type 'str'")
-        return values
+    # Opaque, UI-only maps the app writes here; round-tripped, not SDK-authored.
+    panel_config_overrides: Optional[dict] = None
+    panel_placement_overrides: Optional[dict] = None
 
 
 class PanelBankSectionConfig(ReportAPIBaseModel):

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -875,8 +875,16 @@ class Workspace(Base):
     _internal_runset_id: str = Field("", init=False, repr=False)
     "The runset ID of the workspace."
 
+    # Wire values stashed on load and replayed on save, so a load -> save
+    # round-trip preserves what _to_model would otherwise regenerate or drop.
     _stashed_filters_v2: Optional[dict] = Field(default=None, init=False, repr=False)
     _stashed_filter_string: Optional[str] = Field(default=None, init=False, repr=False)
+    _stashed_panel_config_overrides: Optional[dict] = Field(
+        default=None, init=False, repr=False
+    )
+    _stashed_panel_placement_overrides: Optional[dict] = Field(
+        default=None, init=False, repr=False
+    )
 
     @property
     def auto_generate_panels(self) -> bool:
@@ -1049,6 +1057,11 @@ class Workspace(Base):
         obj._internal_runset_id = runset_model.id
         obj._stashed_filters_v2 = stashed_v2
         obj._stashed_filter_string = filter_string
+        panel_bank_config = model.spec.section.panel_bank_config
+        obj._stashed_panel_config_overrides = panel_bank_config.panel_config_overrides
+        obj._stashed_panel_placement_overrides = (
+            panel_bank_config.panel_placement_overrides
+        )
         return obj
 
     def _to_model(self) -> internal.View:
@@ -1142,6 +1155,8 @@ class Workspace(Base):
                             auto_organize_prefix=auto_organize_prefix,
                         ),
                         sections=sections,
+                        panel_config_overrides=self._stashed_panel_config_overrides,
+                        panel_placement_overrides=self._stashed_panel_placement_overrides,
                     ),
                     panel_bank_section_config=internal.PanelBankSectionConfig(
                         pinned=False


### PR DESCRIPTION
JIRA/GH Issues(s)
-----------

- Fixes WB-35557

Description
-----------

`Workspace.from_url()` raised a `ValidationError` on any saved view carrying the app's UI-only `panelConfigOverrides` / `panelPlacementOverrides` keys - a `check_arbitrary_keys` guard on `PanelBankConfig` rejected the nested dicts the app writes there, so cloning such a view was impossible.

This PR models the two keys as opaque `Optional[dict]` fields and drops the guard (unknown keys already fall through `extra="ignore"`), so `from_url()` loads them instead of crashing. `_to_model()` rebuilds `panelBankConfig` from scratch, so the workspace also stashes the maps on load and re-emits them on save, preserving them across a load -> save.

Also adds an example for copying a saved view to another project.

Testing
-------
How was this PR tested?

- [X] _Added unit tests_
- [ ] _Manual testing (include description)_
- [ ] _N/A (include explanation)_

Server compatibility
--------------------

- [ ] _Requires a minimum W&B Server version (label `requires-server/X.Y+` applied)_
- [ ] _SaaS only — not yet in any tagged W&B Server release (label `requires-server/unreleased` applied)_
- [X] _N/A — works on all currently supported servers_

