### PR TITLE
fix(workspaces): preserve auto_generate_panels when copying a saved view

### DIFF
--- a/examples/workspaces/06_copy_view_to_another_project.py
+++ b/examples/workspaces/06_copy_view_to_another_project.py
@@ -28,5 +28,6 @@ workspace.name = target_view_name
 # 3. Save as a new view in the destination project; logs the new view's URL.
 workspace.save_as_new_view()
 
-# NOTE: panels reference metric names, so copied panels may render empty for
-# metrics the target project hasn't logged.
+# NOTE: an auto-generated view regenerates its panels from the target project's
+# metrics; an explicitly-built view carries its panels as-is, so those may render
+# empty for metrics the target project hasn't logged.

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1,7 +1,7 @@
 import base64
 import os
 import sys
-from typing import Any, Dict, Generic, Type, TypeVar
+from typing import Any, Dict, Generic, Optional, Type, TypeVar
 from unittest.mock import Mock, patch
 
 import pytest
@@ -268,6 +268,87 @@ def test_workspace_without_overrides_omits_override_keys():
     pbc = dumped["section"]["panelBankConfig"]
     assert "panelConfigOverrides" not in pbc
     assert "panelPlacementOverrides" not in pbc
+
+
+def _view_with_section_settings(
+    settings: dict, workspace_settings: Optional[dict] = None
+) -> ws_internal.View:
+    section = {
+        "panelBankConfig": {
+            "state": 1,
+            "settings": {},
+            "sections": [{"name": "Charts", "panels": []}],
+        },
+        "panelBankSectionConfig": {"name": "Report Panels", "pinned": False},
+        "customRunColors": {},
+        "runSets": [{}],
+        "settings": settings,
+    }
+    if workspace_settings is not None:
+        section["workspaceSettings"] = workspace_settings
+    spec = ws_internal.WorkspaceViewspec.model_validate({"section": section})
+    return ws_internal.View(
+        entity="e", project="p", display_name="d", name="nw-x-v", id="id", spec=spec
+    )
+
+
+def test_auto_generate_panels_absent_roundtrips_as_omitted():
+    """Absent in both blocks stays absent so the app defaults to auto-generating."""
+    workspace = ws.Workspace._from_model(_view_with_section_settings({}))
+    assert workspace.auto_generate_panels is None
+
+    settings = workspace._to_model().spec.model_dump(by_alias=True, exclude_none=True)[
+        "section"
+    ]["settings"]
+    assert "shouldAutoGeneratePanels" not in settings
+
+
+def test_auto_generate_panels_reads_legacy_settings():
+    """A legacy view (no workspaceSettings) is read from section.settings."""
+    view = _view_with_section_settings({"shouldAutoGeneratePanels": True})
+    workspace = ws.Workspace._from_model(view)
+    assert workspace.auto_generate_panels is True
+    assert workspace._to_model().spec.section.settings.should_auto_generate_panels
+
+
+def test_auto_generate_panels_reads_modern_workspace_settings():
+    """A modern view is read from workspaceSettings and re-emitted (not the modern
+    block, which stays unwritten so the app's legacy migration still fires)."""
+    view = _view_with_section_settings({}, {"shouldAutoGeneratePanels": False})
+    workspace = ws.Workspace._from_model(view)
+    assert workspace.auto_generate_panels is False
+
+    model = workspace._to_model()
+    assert model.spec.section.settings.should_auto_generate_panels is False
+    assert model.spec.section.workspace_settings is None
+
+
+def test_auto_generate_panels_modern_block_overrides_legacy():
+    """A non-empty workspaceSettings is authoritative; legacy is ignored (matches
+    the app), so a modern block lacking the flag reads as absent, not the legacy value."""
+    view = _view_with_section_settings(
+        {"shouldAutoGeneratePanels": True}, {"linePlot": {}}
+    )
+    workspace = ws.Workspace._from_model(view)
+    assert workspace.auto_generate_panels is None
+
+
+def test_auto_generate_panels_ignores_non_bool():
+    """The app's transient 'pending' (or any non-bool) is not treated as a value."""
+    view = _view_with_section_settings({}, {"shouldAutoGeneratePanels": "pending"})
+    workspace = ws.Workspace._from_model(view)
+    assert workspace.auto_generate_panels is None
+
+
+def test_from_scratch_workspace_emits_auto_generate_panels_false():
+    """A from-scratch workspace stays curated (explicit false), unchanged."""
+    workspace = ws.Workspace(entity="e", project="p")
+    assert workspace.auto_generate_panels is False
+
+    settings = workspace._to_model().spec.model_dump(by_alias=True, exclude_none=True)[
+        "section"
+    ]["settings"]
+    assert settings["shouldAutoGeneratePanels"] is False
 
 
 def test_save_workspace():

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -850,9 +850,10 @@ class Workspace(Base):
             the top of the workspace in the UI.
         runset_settings (RunsetSettings): Settings for the runset
             (the left bar containing runs) in a workspace.
-        auto_generate_panels (bool): Whether to automatically generate panels for all keys logged in this project.
+        auto_generate_panels (Optional[bool]): Whether to automatically generate panels for all keys logged in this project.
             Recommended if you would like all available data to be visualized by default.
-            This can only be set during workspace creation and cannot be modified afterward.
+            None defers to the app default (generate); a value loaded from an existing
+            view is preserved on save. This can only be set during workspace creation.
     """
 
     entity: str
@@ -861,7 +862,9 @@ class Workspace(Base):
     sections: LList[Section] = Field(default_factory=list)
     settings: WorkspaceSettings = Field(default_factory=WorkspaceSettings)
     runset_settings: RunsetSettings = Field(default_factory=RunsetSettings)
-    _auto_generate_panels: bool = Field(
+    # Default False keeps from-scratch workspaces curated (explicit false). A
+    # value loaded via _from_model (None/True/False) is preserved on round-trip.
+    _auto_generate_panels: Optional[bool] = Field(
         default=False, repr=True, alias="auto_generate_panels"
     )
 
@@ -887,7 +890,7 @@ class Workspace(Base):
     )
 
     @property
-    def auto_generate_panels(self) -> bool:
+    def auto_generate_panels(self) -> Optional[bool]:
         return self._auto_generate_panels
 
     @property
@@ -954,6 +957,19 @@ class Workspace(Base):
 
         section_settings = model.spec.section.settings
         panel_bank_settings = model.spec.section.panel_bank_config.settings
+
+        # shouldAutoGeneratePanels moved from legacy `section.settings` to modern
+        # `section.workspaceSettings`, so prefer a populated modern block (more
+        # than just `ref`) and fall back to legacy, matching the app. Guard for a
+        # bool because the app can store a transient 'pending'.
+        workspace_settings_raw = model.spec.section.workspace_settings or {}
+        if any(key != "ref" for key in workspace_settings_raw):
+            raw_auto_generate = workspace_settings_raw.get("shouldAutoGeneratePanels")
+            auto_generate_panels = (
+                raw_auto_generate if isinstance(raw_auto_generate, bool) else None
+            )
+        else:
+            auto_generate_panels = section_settings.should_auto_generate_panels
         x_axis = expr._convert_be_to_fe_metric_name(section_settings.x_axis)
         point_viz_method: Literal["bucketing", "downsampling"]
         if (pvm := section_settings.point_visualization_method) == "bucketing-gorilla":
@@ -1024,6 +1040,7 @@ class Workspace(Base):
             entity=model.entity,
             project=model.project,
             name=model.display_name,
+            auto_generate_panels=auto_generate_panels,
             sections=[
                 Section._from_model(s)
                 for s in model.spec.section.panel_bank_config.sections

--- a/wandb_workspaces/workspaces/internal.py
+++ b/wandb_workspaces/workspaces/internal.py
@@ -49,7 +49,10 @@ class ViewspecSectionSettings(WorkspaceAPIBaseModel):
     point_visualization_method: Optional[PointVizMethod] = None
     suppress_legends: Optional[bool] = None
     tooltip_number_of_runs: Optional[TooltipNumberOfRuns] = None
-    should_auto_generate_panels: bool = False
+    # The app treats an absent value as True and auto-generates panels; only an
+    # explicit False disables that. Keep it Optional so None is omitted on save
+    # (exclude_none) and an absent flag round-trips as absent, not forced False.
+    should_auto_generate_panels: Optional[bool] = None
 
     @computed_field  # type: ignore[misc]
     @property
@@ -76,6 +79,12 @@ class ViewspecSection(WorkspaceAPIBaseModel):
     name: str = ""
     run_sets: LList[Runset] = Field(default_factory=lambda: [Runset()])
     settings: ViewspecSectionSettings = Field(default_factory=ViewspecSectionSettings)
+    # Captures the app's modern `workspaceSettings` block so _from_model can read
+    # shouldAutoGeneratePanels from it. _to_model never writes it back; emitting
+    # it would stop the app migrating the legacy `settings`.
+    #
+    # TODO: Support all modern workspace settings.
+    workspace_settings: Optional[dict] = None
     open_run_set: int = 0
     open_viz: bool = True
 


### PR DESCRIPTION
JIRA/GH Issues(s)
-----------
Paste links to relevant JIRA/GH issues here, one per line e.g.
- Fixes WB-35557

Description
-----------

> [!NOTE]
> The approach taken here works around the fact that `workspaceSettings` isn't fully modeled yet. Future work should be done to migrate off of legacy settings and onto the newer workspace settings.

When you load a saved view with `Workspace.from_url()` and save it again (e.g. copying a workspace to another project), the copy renders empty. `_from_model` never read `shouldAutoGeneratePanels`, so the flag stayed at its `False` default and `_to_model` wrote an explicit `false` - which the app treats as "don't auto-generate", suppressing the panels an auto-generated workspace would otherwise rebuild.

This PR reads the flag on load and makes it `Optional[bool]`, so an absent value round-trips as absent (omitted on save via `exclude_none`) instead of being forced to `false`. It reads from the modern `section.workspaceSettings` block and falls back to legacy `section.settings`, matching the app's `parseWorkspaceSpec` precedence. From-scratch workspaces are unchanged - they still emit an explicit `false`.

Testing
-------
How was this PR tested?

- [X] _Added unit tests_
- [X] _Manual testing (include description)_
- [ ] _N/A (include explanation)_

Server compatibility
--------------------

- [ ] _Requires a minimum W&B Server version (label `requires-server/X.Y+` applied)_
- [ ] _SaaS only — not yet in any tagged W&B Server release (label `requires-server/unreleased` applied)_
- [X] _N/A — works on all currently supported servers_

