### PR TITLE
fix(workspaces): resolve preserved panel overrides when copying a saved view

### DIFF
--- a/examples/workspaces/06_copy_view_to_another_project.py
+++ b/examples/workspaces/06_copy_view_to_another_project.py
@@ -30,4 +30,8 @@ workspace.save_as_new_view()
 
 # NOTE: an auto-generated view regenerates its panels from the target project's
 # metrics; an explicitly-built view carries its panels as-is, so those may render
-# empty for metrics the target project hasn't logged.
+# empty for metrics the target project hasn't logged. In either case, your UI
+# customizations - custom panels and the sections they sit in - carry over to the
+# copy. Editing a customized panel's config via the SDK isn't fully supported yet,
+# so the saved customization takes precedence over the edit and the SDK logs a
+# warning.

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1,7 +1,7 @@
 import base64
 import os
 import sys
-from typing import Any, Dict, Generic, Optional, Type, TypeVar
+from typing import Any, Dict, Generic, Optional, Type, TypeVar, get_args
 from unittest.mock import Mock, patch
 
 import pytest
@@ -268,6 +268,189 @@ def test_workspace_without_overrides_omits_override_keys():
     pbc = dumped["section"]["panelBankConfig"]
     assert "panelConfigOverrides" not in pbc
     assert "panelPlacementOverrides" not in pbc
+
+
+def _custom_panel_dict(panel_id: str = "p1") -> dict:
+    """A custom (isAuto=False) LinePlot wire dict with a known ``__id__``."""
+    pd = wr.interface.LinePlot(y=["loss"])._to_model().model_dump(by_alias=True)
+    pd["__id__"] = panel_id
+    pd["isAuto"] = False
+    return pd
+
+
+def _view_with_custom_panels(
+    sections: list,
+    config_overrides: Optional[dict] = None,
+    placement_overrides: Optional[dict] = None,
+) -> ws_internal.View:
+    pbc: Dict[str, Any] = {"state": 1, "settings": {}, "sections": sections}
+    if config_overrides is not None:
+        pbc["panelConfigOverrides"] = config_overrides
+    if placement_overrides is not None:
+        pbc["panelPlacementOverrides"] = placement_overrides
+    spec = ws_internal.WorkspaceViewspec.model_validate(
+        {
+            "section": {
+                "panelBankConfig": pbc,
+                "panelBankSectionConfig": {"name": "Report Panels", "pinned": False},
+                "customRunColors": {},
+                "runSets": [{}],
+                "settings": {},
+            }
+        }
+    )
+    return ws_internal.View(
+        entity="e", project="p", display_name="d", name="nw-x-v", id="id", spec=spec
+    )
+
+
+def _representative_panels() -> list:
+    """One instance of every interface panel type."""
+    panels = [
+        wr.interface.LinePlot(),
+        wr.interface.ScatterPlot(),
+        wr.interface.BarPlot(),
+        wr.interface.ScalarChart(),
+        wr.interface.CodeComparer(),
+        wr.interface.ParallelCoordinatesPlot(),
+        wr.interface.ParameterImportancePlot(),
+        wr.interface.RunComparer(),
+        wr.interface.MediaBrowser(),
+        wr.interface.MarkdownPanel(),
+        wr.interface.CustomChart(),
+        wr.interface.WeavePanel(),
+    ]
+    panels += [
+        wr.interface._lookup_panel(WeavePanelFactory.build_summary_table_panel()),
+        wr.interface._lookup_panel(WeavePanelFactory.build_artifact_panel()),
+        wr.interface._lookup_panel(WeavePanelFactory.build_artifact_version_panel()),
+    ]
+    return panels
+
+
+def test_section_id_roundtrips_and_fresh_section_omits_it():
+    """A loaded section keeps its ``__id__``; a from-scratch section emits none."""
+    view = _view_with_custom_panels(
+        [{"__id__": "sec-1", "name": "Charts", "panels": []}]
+    )
+    section = (
+        ws.Workspace._from_model(view)
+        ._to_model()
+        .spec.section.panel_bank_config.sections[0]
+    )
+    assert section.id == "sec-1"
+
+    dumped = ws.Section(name="New")._to_model().model_dump(
+        by_alias=True, exclude_none=True
+    )
+    assert "__id__" not in dumped
+
+
+def test_custom_panel_isauto_roundtrips_and_fresh_panel_omits_it():
+    """A loaded custom panel keeps ``isAuto: false``; a fresh panel emits none."""
+    view = _view_with_custom_panels(
+        [{"__id__": "sec-1", "name": "Charts", "panels": [_custom_panel_dict()]}]
+    )
+    panel = (
+        ws.Workspace._from_model(view)
+        ._to_model()
+        .spec.section.panel_bank_config.sections[0]
+        .panels[0]
+    )
+    assert panel.model_dump(by_alias=True, exclude_none=True)["isAuto"] is False
+
+    fresh = wr.interface.LinePlot(y=["loss"])._to_model().model_dump(
+        by_alias=True, exclude_none=True
+    )
+    assert "isAuto" not in fresh
+
+
+@pytest.mark.parametrize(
+    "panel", _representative_panels(), ids=lambda p: type(p).__name__
+)
+def test_all_panel_types_preserve_isauto(panel):
+    """Every panel type preserves ``isAuto`` across a model round-trip."""
+    object.__setattr__(panel, "_is_auto", False)
+    reloaded = wr.interface._lookup_panel(panel._to_model())
+    assert reloaded._is_auto is False
+
+
+def test_representative_panels_cover_every_panel_type():
+    """The representative list covers every ``PanelTypes`` member except
+    ``UnknownPanel`` (which has no ``_is_auto``)."""
+    covered = {type(p) for p in _representative_panels()}
+    expected = set(get_args(wr.interface.PanelTypes)) - {wr.interface.UnknownPanel}
+    assert covered == expected
+
+
+def test_override_resolution_invariants():
+    """After a round-trip, every override key and ``sectionId`` resolves to a
+    panel or section present in the output."""
+    config = {"__custom_panel__:p1": {"config": {"chartTitle": "Loss"}}}
+    placement = {"__custom_panel__:p1": {"sectionId": "sec-1", "orderKey": "a0"}}
+    view = _view_with_custom_panels(
+        [{"__id__": "sec-1", "name": "Charts", "panels": [_custom_panel_dict("p1")]}],
+        config,
+        placement,
+    )
+    pbc = ws.Workspace._from_model(view)._to_model().spec.section.panel_bank_config
+    section_ids = {s.id for s in pbc.sections}
+    panel_ids = {p.id for s in pbc.sections for p in s.panels}
+
+    for ov in pbc.panel_placement_overrides.values():
+        assert ov["sectionId"] in section_ids
+    for key in {**pbc.panel_config_overrides, **pbc.panel_placement_overrides}:
+        assert key.split("__custom_panel__:")[-1] in panel_ids
+
+
+def test_placement_override_dropped_when_panel_moves_sections():
+    """Moving a custom panel drops its placement override so the SDK move wins."""
+    config = {"__custom_panel__:p1": {"config": {"chartTitle": "Loss"}}}
+    placement = {"__custom_panel__:p1": {"sectionId": "sec-1", "orderKey": "a0"}}
+    view = _view_with_custom_panels(
+        [
+            {"__id__": "sec-1", "name": "Charts", "panels": [_custom_panel_dict("p1")]},
+            {"__id__": "sec-2", "name": "More", "panels": []},
+        ],
+        config,
+        placement,
+    )
+    workspace = ws.Workspace._from_model(view)
+    workspace.sections[1].panels.append(workspace.sections[0].panels.pop(0))
+
+    pbc = workspace._to_model().spec.section.panel_bank_config
+    assert not pbc.panel_placement_overrides  # dropped (None or {})
+    assert pbc.panel_config_overrides == config  # untouched
+
+
+def test_config_override_preserved_and_warns_on_edit():
+    """Editing a customized panel keeps its override and warns that the edit
+    may be shadowed."""
+    config = {"__custom_panel__:p1": {"config": {"chartTitle": "Loss"}}}
+    view = _view_with_custom_panels(
+        [{"__id__": "sec-1", "name": "Charts", "panels": [_custom_panel_dict("p1")]}],
+        config,
+    )
+    workspace = ws.Workspace._from_model(view)
+    workspace.sections[0].panels[0].title = "Edited"
+
+    with patch.object(ws_interface.wandb, "termwarn") as warn:
+        pbc = workspace._to_model().spec.section.panel_bank_config
+    warn.assert_called_once()
+    assert pbc.panel_config_overrides == config
+
+
+def test_clean_copy_emits_no_override_warning():
+    """A load and re-save with no edits emits no warning."""
+    config = {"__custom_panel__:p1": {"config": {"chartTitle": "Loss"}}}
+    view = _view_with_custom_panels(
+        [{"__id__": "sec-1", "name": "Charts", "panels": [_custom_panel_dict("p1")]}],
+        config,
+    )
+    workspace = ws.Workspace._from_model(view)
+    with patch.object(ws_interface.wandb, "termwarn") as warn:
+        workspace._to_model()
+    warn.assert_not_called()
 
 
 def _view_with_section_settings(

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -1314,6 +1314,8 @@ class Panel(Base):
     _id: str = Field(
         default_factory=internal._generate_name, init=False, repr=False, kw_only=True
     )
+    # `false` for a UI-customized panel loaded from a spec; None otherwise.
+    _is_auto: Optional[bool] = Field(default=None, init=False, repr=False, kw_only=True)
 
 
 @dataclass(config=dataclass_config, repr=False)
@@ -2216,6 +2218,7 @@ class LinePlot(Panel):
                 override_marks=self.line_marks,
             ),
             id=self._id,
+            is_auto=self._is_auto,
             layout=self.layout._to_model(),
         )
 
@@ -2263,6 +2266,7 @@ class LinePlot(Panel):
         object.__setattr__(obj, "legend_fields", model.config.legend_fields)
         object.__setattr__(obj, "metric_regex", model.config.metric_regex)
         object.__setattr__(obj, "_id", model.id)
+        object.__setattr__(obj, "_is_auto", model.is_auto)
         object.__setattr__(
             obj, "point_visualization_method", model.config.point_visualization_method
         )
@@ -2349,6 +2353,7 @@ class ScatterPlot(Panel):
             ),
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -2378,6 +2383,7 @@ class ScatterPlot(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._is_auto = model.is_auto
         return obj
 
 
@@ -2452,6 +2458,7 @@ class BarPlot(Panel):
             ),
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -2477,6 +2484,7 @@ class BarPlot(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._is_auto = model.is_auto
         return obj
 
 
@@ -2521,6 +2529,7 @@ class ScalarChart(Panel):
             ),
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -2536,6 +2545,7 @@ class ScalarChart(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._is_auto = model.is_auto
         return obj
 
 
@@ -2556,6 +2566,7 @@ class CodeComparer(Panel):
             config=internal.CodeComparerConfig(diff=self.diff),
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -2565,6 +2576,7 @@ class CodeComparer(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._is_auto = model.is_auto
         return obj
 
 
@@ -2639,6 +2651,7 @@ class ParallelCoordinatesPlot(Panel):
             ),
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -2658,6 +2671,7 @@ class ParallelCoordinatesPlot(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._is_auto = model.is_auto
         return obj
 
 
@@ -2683,6 +2697,7 @@ class ParameterImportancePlot(Panel):
             ),
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -2692,6 +2707,7 @@ class ParameterImportancePlot(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._is_auto = model.is_auto
 
         return obj
 
@@ -2714,6 +2730,7 @@ class RunComparer(Panel):
             config=internal.RunComparerConfig(diff_only=self.diff_only),
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -2723,6 +2740,7 @@ class RunComparer(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._is_auto = model.is_auto
 
         return obj
 
@@ -2791,6 +2809,7 @@ class MediaBrowser(Panel):
             ),
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -2817,6 +2836,7 @@ class MediaBrowser(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._is_auto = model.is_auto
 
         return obj
 
@@ -2837,6 +2857,7 @@ class MarkdownPanel(Panel):
             config=internal.MarkdownPanelConfig(value=self.markdown),
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -2846,6 +2867,7 @@ class MarkdownPanel(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._is_auto = model.is_auto
 
         return obj
 
@@ -2930,6 +2952,7 @@ class CustomChart(Panel):
             ),
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -2962,6 +2985,7 @@ class CustomChart(Panel):
             layout=Layout._from_model(model.layout),
         )
         obj._id = model.id
+        obj._is_auto = model.is_auto
         return obj
 
 
@@ -3005,12 +3029,14 @@ class WeavePanel(Panel):
             config=self.config,
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
     def _from_model(cls, model: internal.WeavePanel):
         obj = cls(config=model.config)
         obj._id = model.id
+        obj._is_auto = model.is_auto
         return obj
 
 
@@ -3246,6 +3272,7 @@ class WeavePanelSummaryTable(Panel):
             },
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -3254,6 +3281,7 @@ class WeavePanelSummaryTable(Panel):
         table_name = inputs["key"]["val"]
         obj = cls(table_name=table_name)
         obj._id = model.id
+        obj._is_auto = model.is_auto
         return obj
 
 
@@ -3383,6 +3411,7 @@ class WeavePanelArtifactVersionedFile(Panel):
             },
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -3395,6 +3424,7 @@ class WeavePanelArtifactVersionedFile(Panel):
         file = inputs["path"]["val"]
         obj = cls(artifact=artifact, version=version, file=file)
         obj._id = model.id
+        obj._is_auto = model.is_auto
         return obj
 
 
@@ -3497,6 +3527,7 @@ class WeavePanelArtifact(WeavePanel):
             },
             layout=self.layout._to_model(),
             id=self._id,
+            is_auto=self._is_auto,
         )
 
     @classmethod
@@ -3508,6 +3539,7 @@ class WeavePanelArtifact(WeavePanel):
         )
         obj = cls(artifact=artifact, tab=tab)
         obj._id = model.id
+        obj._is_auto = model.is_auto
         return obj
 
 

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -238,6 +238,7 @@ class LocalPanelSettings(ReportAPIBaseModel):
 
 
 class PanelBankConfigSectionsItem(ReportAPIBaseModel):
+    id: Optional[str] = Field(None, alias="__id__")
     name: str = "Hidden Panels"
     is_open: bool = False
     type: str = "flow"

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -611,6 +611,8 @@ class Layout(ReportAPIBaseModel):
 class Panel(ReportAPIBaseModel):
     id: str = Field("", alias="__id__")
     layout: Layout = Field(default_factory=Layout)
+    # `false` marks a panel the user customized in the app; None for auto/SDK-authored panels.
+    is_auto: Optional[bool] = None
 
 
 class GridSettings(ReportAPIBaseModel):

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -528,9 +528,14 @@ class Section(Base):
     )
     panel_settings: SectionPanelSettings = Field(default_factory=SectionPanelSettings)
 
+    # Set from a loaded spec's `__id__`, never generated (unlike Panel._id). A
+    # fresh section then omits `__id__`; a loaded one keeps its id so placement
+    # overrides resolve.
+    _id: Optional[str] = Field(default=None, init=False, repr=False)
+
     @classmethod
     def _from_model(cls, model: internal.PanelBankConfigSectionsItem):
-        return cls(
+        obj = cls(
             name=model.name,
             panels=[_lookup_panel(p) for p in model.panels],
             is_open=model.is_open,
@@ -538,6 +543,8 @@ class Section(Base):
             layout_settings=SectionLayoutSettings._from_model(model.flow_config),
             panel_settings=SectionPanelSettings._from_model(model.local_panel_settings),
         )
+        obj._id = model.id
+        return obj
 
     def _to_model(self):
         panel_models = [p._to_model() for p in self.panels]
@@ -547,6 +554,7 @@ class Section(Base):
         # Add warning that panel layout only works if they set section settings layout = "custom"
 
         return internal.PanelBankConfigSectionsItem(
+            id=self._id or None,
             name=self.name,
             panels=panel_models,
             is_open=self.is_open,

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -896,6 +896,11 @@ class Workspace(Base):
     _stashed_panel_placement_overrides: Optional[dict] = Field(
         default=None, init=False, repr=False
     )
+    # Per-custom-panel wire dumps captured on load, keyed by `__custom_panel__:<_id>`.
+    # Lets _to_model detect an SDK edit that a preserved config override would shadow.
+    _stashed_custom_panel_dumps: Optional[dict] = Field(
+        default=None, init=False, repr=False
+    )
 
     @property
     def auto_generate_panels(self) -> Optional[bool]:
@@ -1087,10 +1092,80 @@ class Workspace(Base):
         obj._stashed_panel_placement_overrides = (
             panel_bank_config.panel_placement_overrides
         )
+        obj._stashed_custom_panel_dumps = {
+            key: dump for key, (_, dump) in obj._custom_panel_index().items()
+        } or None
         return obj
+
+    def _custom_panel_index(self) -> Dict[str, Tuple[Optional[str], dict]]:
+        """Map each custom panel's override key to its `(section._id, wire dump)`.
+
+        Only panels marked `isAuto is False` are custom and keyed as
+        `__custom_panel__:<_id>` (matching the app's `getOverrideKey`). Auto panels and
+        `UnknownPanel`s (which lack `_is_auto`) are skipped.
+        """
+        index: Dict[str, Tuple[Optional[str], dict]] = {}
+        for section in self.sections:
+            for panel in section.panels:
+                # UnknownPanel has neither attribute; getattr keeps it out safely.
+                panel_id = getattr(panel, "_id", None)
+                if getattr(panel, "_is_auto", None) is False and panel_id is not None:
+                    key = f"__custom_panel__:{panel_id}"
+                    index[key] = (
+                        section._id,
+                        panel._to_model().model_dump(by_alias=True),
+                    )
+        return index
+
+    def _reconciled_overrides(self) -> Tuple[Optional[dict], Optional[dict]]:
+        """Reconcile the stashed override maps against the current (maybe edited) panels.
+
+        Returns `(config_overrides, placement_overrides)` to emit. A placement override
+        for a custom panel that moved to a different section is dropped so the SDK move
+        takes effect (the panel falls back to its spec-array position); config overrides
+        are preserved, but a warning is raised for any customized panel whose config was
+        edited, since the override still takes precedence.
+        """
+        config_overrides = self._stashed_panel_config_overrides
+        placement_overrides = self._stashed_panel_placement_overrides
+        if not config_overrides and not placement_overrides:
+            return config_overrides, placement_overrides
+
+        index = self._custom_panel_index()
+
+        if placement_overrides:
+            pruned = dict(placement_overrides)
+            for key, (section_id, _) in index.items():
+                override = pruned.get(key)
+                # Drop only when we're sure this is a genuine cross-section move; leave
+                # entries of unexpected shape intact rather than risk corrupting them.
+                if (
+                    isinstance(override, dict)
+                    and "sectionId" in override
+                    and override["sectionId"] != section_id
+                ):
+                    del pruned[key]
+            placement_overrides = pruned or None
+
+        if config_overrides:
+            baseline = self._stashed_custom_panel_dumps or {}
+            edited = [
+                key
+                for key, (_, dump) in index.items()
+                if key in config_overrides and dump != baseline.get(key)
+            ]
+            if edited:
+                wandb.termwarn(
+                    f"{len(edited)} customized panel(s) were edited in the SDK, but their "
+                    "saved UI customizations are preserved and may take precedence over "
+                    "those edits. Editing customized panels is not yet fully supported."
+                )
+
+        return config_overrides, placement_overrides
 
     def _to_model(self) -> internal.View:
         sections = [s._to_model() for s in self.sections]
+        config_overrides, placement_overrides = self._reconciled_overrides()
 
         is_regex = True if self.runset_settings.regex_query else None
         auto_organize_prefix = 2 if self.settings.group_by_prefix == "last" else 1
@@ -1180,8 +1255,8 @@ class Workspace(Base):
                             auto_organize_prefix=auto_organize_prefix,
                         ),
                         sections=sections,
-                        panel_config_overrides=self._stashed_panel_config_overrides,
-                        panel_placement_overrides=self._stashed_panel_placement_overrides,
+                        panel_config_overrides=config_overrides,
+                        panel_placement_overrides=placement_overrides,
                     ),
                     panel_bank_section_config=internal.PanelBankSectionConfig(
                         pinned=False


### PR DESCRIPTION
JIRA/GH Issues(s)
-----------

- Fixes WB-35557

Description
-----------

After #182 preserves the UI override maps and #183 restores auto-generated panels, a copied view's *custom-panel* customizations still don't render. The SDK loads only the base panel list, dropping the section `__id__` and panel `isAuto: false` that `panelPlacementOverrides` / `panelConfigOverrides` key on (via the app's `getOverrideKey`), so on save the placements orphan and the custom panels get compressed away.

This PR carries `__id__` and `isAuto` through the panel round-trip so the preserved overrides resolve on the copy. It also adds `_reconciled_overrides` for the narrow case where a *new* SDK edit collides with a preserved override - moving a custom panel to another section drops its stale placement entry so the SDK move wins, while an edited config is preserved (the override still takes precedence) and logs a `termwarn`.

Testing
-------
How was this PR tested?

- [X] _Added unit tests_
- [X] _Manual testing (include description)_
- [ ] _N/A (include explanation)_

Server compatibility
--------------------

- [ ] _Requires a minimum W&B Server version (label `requires-server/X.Y+` applied)_
- [ ] _SaaS only — not yet in any tagged W&B Server release (label `requires-server/unreleased` applied)_
- [X] _N/A — works on all currently supported servers_

