### PR TITLE
fix(reports): scope share links to all referenced projects

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -2300,9 +2300,7 @@ class TestReportSharing:
                 text="Collapsed",
                 collapsed_blocks=[
                     wr.PanelGrid(
-                        runsets=[
-                            wr.Runset(entity="nested-ent", project="nested-proj")
-                        ]
+                        runsets=[wr.Runset(entity="nested-ent", project="nested-proj")]
                     )
                 ],
             ),
@@ -2316,24 +2314,38 @@ class TestReportSharing:
             {"entityName": "nested-ent", "projectName": "nested-proj"},
         ]
 
-    def test_enable_share_link_returns_existing(self, monkeypatch):
-        """enable_share_link returns existing link if one is already active."""
+    def test_enable_share_link_refreshes_existing_token_scope(self, monkeypatch):
+        """enable_share_link refreshes the returned token when its scope changed."""
+        updated = []
 
         class _Client:
             app_url = "https://wandb.ai/"
 
             def execute(self, query, *, variable_values):
-                return {
-                    "view": {
-                        "accessTokens": [
-                            {
-                                "token": "existing_tok",
-                                "type": "PUBLIC",
-                                "revokedAt": None,
-                            }
-                        ]
+                query_name = TestReportSharing._query_name(query)
+                if query_name == "ViewAccessTokens":
+                    return {
+                        "view": {
+                            "accessTokens": [
+                                {
+                                    "token": "existing_tok",
+                                    "type": "PUBLIC",
+                                    "revokedAt": None,
+                                    "projects": [],
+                                },
+                                {
+                                    "token": "another_tok",
+                                    "type": "PUBLIC",
+                                    "revokedAt": None,
+                                    "projects": [],
+                                },
+                            ]
+                        }
                     }
-                }
+                if query_name == "updateAccessTokenProjects":
+                    updated.append(variable_values)
+                    return {"updateAccessTokenProjects": {"success": True}}
+                raise AssertionError(f"Unexpected query: {query}")
 
         class _Api:
             client = _Client()
@@ -2344,6 +2356,97 @@ class TestReportSharing:
 
         url = report.enable_share_link()
         assert "accessToken=existing_tok" in url
+        assert updated == [
+            {
+                "token": "existing_tok",
+                "projects": [{"entityName": "ent", "projectName": "proj"}],
+            }
+        ]
+
+    def test_enable_share_link_skips_update_when_scope_matches(self, monkeypatch):
+        """enable_share_link avoids a mutation when the existing scope is current."""
+
+        class _Client:
+            app_url = "https://wandb.ai/"
+
+            def execute(self, query, *, variable_values):
+                if TestReportSharing._query_name(query) == "ViewAccessTokens":
+                    return {
+                        "view": {
+                            "accessTokens": [
+                                {
+                                    "token": "existing_tok",
+                                    "type": "PUBLIC",
+                                    "revokedAt": None,
+                                    "projects": [
+                                        {
+                                            "entityName": "other-ent",
+                                            "name": "other-proj",
+                                        },
+                                        {"entityName": "ent", "name": "proj"},
+                                    ],
+                                }
+                            ]
+                        }
+                    }
+                raise AssertionError(f"Unexpected query: {query}")
+
+        class _Api:
+            client = _Client()
+            default_entity = "ent"
+
+        self._api = _Api()
+        report = self._make_report(monkeypatch)
+        report.blocks = [
+            wr.PanelGrid(
+                runsets=[
+                    wr.Runset(entity="other-ent", project="other-proj")
+                ]
+            )
+        ]
+
+        url = report.enable_share_link()
+
+        assert "accessToken=existing_tok" in url
+
+    def test_enable_share_link_raises_when_existing_token_refresh_fails(
+        self, monkeypatch
+    ):
+        """enable_share_link reports a failed existing-token scope update."""
+
+        class _Client:
+            app_url = "https://wandb.ai/"
+
+            def execute(self, query, *, variable_values):
+                query_name = TestReportSharing._query_name(query)
+                if query_name == "ViewAccessTokens":
+                    return {
+                        "view": {
+                            "accessTokens": [
+                                {
+                                    "token": "existing_tok",
+                                    "type": "PUBLIC",
+                                    "revokedAt": None,
+                                    "projects": [],
+                                }
+                            ]
+                        }
+                    }
+                if query_name == "updateAccessTokenProjects":
+                    return {"updateAccessTokenProjects": {"success": False}}
+                raise AssertionError(f"Unexpected query: {query}")
+
+        class _Api:
+            client = _Client()
+            default_entity = "ent"
+
+        self._api = _Api()
+        report = self._make_report(monkeypatch)
+
+        with pytest.raises(
+            RuntimeError, match="failed to update access token projects"
+        ):
+            report.enable_share_link()
 
     def test_enable_share_link_raises_without_id(self, monkeypatch):
         """enable_share_link raises ValueError if report has no id."""

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -2258,27 +2258,94 @@ class TestReportSharing:
         url = report.enable_share_link()
         assert "accessToken=tok_abc123" in url
         assert captured["variables"]["viewId"] == "dummy-id"
-        assert captured["variables"]["entityName"] == "ent"
-        assert captured["variables"]["projectName"] == "proj"
+        assert captured["variables"]["projects"] == [
+            {"entityName": "ent", "projectName": "proj"}
+        ]
 
-    def test_enable_share_link_returns_existing(self, monkeypatch):
-        """enable_share_link returns existing link if one is already active."""
+    def test_enable_share_link_includes_cross_project_runsets(self, monkeypatch):
+        """Share links include deduplicated runset projects, including nested grids."""
+        captured = {}
 
         class _Client:
             app_url = "https://wandb.ai/"
 
             def execute(self, query, *, variable_values):
-                return {
-                    "view": {
-                        "accessTokens": [
-                            {
-                                "token": "existing_tok",
-                                "type": "PUBLIC",
-                                "revokedAt": None,
-                            }
-                        ]
+                if TestReportSharing._query_name(query) == "ViewAccessTokens":
+                    return {"view": {"accessTokens": []}}
+                if TestReportSharing._query_name(query) == "createAccessToken":
+                    captured["variables"] = variable_values
+                    return {
+                        "createAccessToken": {
+                            "accessToken": {"token": "tok_xproj", "type": "PUBLIC"}
+                        }
                     }
-                }
+                raise AssertionError(f"Unexpected query: {query}")
+
+        class _Api:
+            client = _Client()
+            default_entity = "ent"
+
+        self._api = _Api()
+        report = self._make_report(monkeypatch)
+        report.blocks = [
+            wr.PanelGrid(
+                runsets=[
+                    wr.Runset(entity="ent", project="proj"),
+                    wr.Runset(entity="other-ent", project="other-proj"),
+                    wr.Runset(entity="other-ent", project="other-proj"),
+                    wr.Runset(),
+                ]
+            ),
+            wr.H1(
+                text="Collapsed",
+                collapsed_blocks=[
+                    wr.PanelGrid(
+                        runsets=[
+                            wr.Runset(entity="nested-ent", project="nested-proj")
+                        ]
+                    )
+                ],
+            ),
+        ]
+
+        report.enable_share_link()
+
+        assert captured["variables"]["projects"] == [
+            {"entityName": "ent", "projectName": "proj"},
+            {"entityName": "other-ent", "projectName": "other-proj"},
+            {"entityName": "nested-ent", "projectName": "nested-proj"},
+        ]
+
+    def test_enable_share_link_refreshes_existing_tokens(self, monkeypatch):
+        """enable_share_link refreshes every existing PUBLIC token before returning."""
+        updated = []
+
+        class _Client:
+            app_url = "https://wandb.ai/"
+
+            def execute(self, query, *, variable_values):
+                query_name = TestReportSharing._query_name(query)
+                if query_name == "ViewAccessTokens":
+                    return {
+                        "view": {
+                            "accessTokens": [
+                                {
+                                    "token": "existing_tok",
+                                    "type": "PUBLIC",
+                                    "revokedAt": None,
+                                },
+                                {
+                                    "token": "another_tok",
+                                    "type": "PUBLIC",
+                                    "revokedAt": None,
+                                },
+                            ]
+                        }
+                    }
+                if query_name == "updateAccessTokenProjects":
+                    updated.append(variable_values)
+                    return {"updateAccessTokenProjects": {"success": True}}
+                raise AssertionError(f"Unexpected query: {query}")
 
         class _Api:
             client = _Client()
@@ -2289,6 +2356,52 @@ class TestReportSharing:
 
         url = report.enable_share_link()
         assert "accessToken=existing_tok" in url
+        assert updated == [
+            {
+                "token": "existing_tok",
+                "projects": [{"entityName": "ent", "projectName": "proj"}],
+            },
+            {
+                "token": "another_tok",
+                "projects": [{"entityName": "ent", "projectName": "proj"}],
+            },
+        ]
+
+    def test_enable_share_link_raises_when_existing_token_refresh_fails(
+        self, monkeypatch
+    ):
+        """enable_share_link reports a failed existing-token scope update."""
+
+        class _Client:
+            app_url = "https://wandb.ai/"
+
+            def execute(self, query, *, variable_values):
+                query_name = TestReportSharing._query_name(query)
+                if query_name == "ViewAccessTokens":
+                    return {
+                        "view": {
+                            "accessTokens": [
+                                {
+                                    "token": "existing_tok",
+                                    "type": "PUBLIC",
+                                    "revokedAt": None,
+                                }
+                            ]
+                        }
+                    }
+                if query_name == "updateAccessTokenProjects":
+                    return {"updateAccessTokenProjects": {"success": False}}
+                raise AssertionError(f"Unexpected query: {query}")
+
+        class _Api:
+            client = _Client()
+            default_entity = "ent"
+
+        self._api = _Api()
+        report = self._make_report(monkeypatch)
+
+        with pytest.raises(RuntimeError, match="failed to update access token projects"):
+            report.enable_share_link()
 
     def test_enable_share_link_raises_without_id(self, monkeypatch):
         """enable_share_link raises ValueError if report has no id."""

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -2316,36 +2316,24 @@ class TestReportSharing:
             {"entityName": "nested-ent", "projectName": "nested-proj"},
         ]
 
-    def test_enable_share_link_refreshes_existing_tokens(self, monkeypatch):
-        """enable_share_link refreshes every existing PUBLIC token before returning."""
-        updated = []
+    def test_enable_share_link_returns_existing(self, monkeypatch):
+        """enable_share_link returns existing link if one is already active."""
 
         class _Client:
             app_url = "https://wandb.ai/"
 
             def execute(self, query, *, variable_values):
-                query_name = TestReportSharing._query_name(query)
-                if query_name == "ViewAccessTokens":
-                    return {
-                        "view": {
-                            "accessTokens": [
-                                {
-                                    "token": "existing_tok",
-                                    "type": "PUBLIC",
-                                    "revokedAt": None,
-                                },
-                                {
-                                    "token": "another_tok",
-                                    "type": "PUBLIC",
-                                    "revokedAt": None,
-                                },
-                            ]
-                        }
+                return {
+                    "view": {
+                        "accessTokens": [
+                            {
+                                "token": "existing_tok",
+                                "type": "PUBLIC",
+                                "revokedAt": None,
+                            }
+                        ]
                     }
-                if query_name == "updateAccessTokenProjects":
-                    updated.append(variable_values)
-                    return {"updateAccessTokenProjects": {"success": True}}
-                raise AssertionError(f"Unexpected query: {query}")
+                }
 
         class _Api:
             client = _Client()
@@ -2356,52 +2344,6 @@ class TestReportSharing:
 
         url = report.enable_share_link()
         assert "accessToken=existing_tok" in url
-        assert updated == [
-            {
-                "token": "existing_tok",
-                "projects": [{"entityName": "ent", "projectName": "proj"}],
-            },
-            {
-                "token": "another_tok",
-                "projects": [{"entityName": "ent", "projectName": "proj"}],
-            },
-        ]
-
-    def test_enable_share_link_raises_when_existing_token_refresh_fails(
-        self, monkeypatch
-    ):
-        """enable_share_link reports a failed existing-token scope update."""
-
-        class _Client:
-            app_url = "https://wandb.ai/"
-
-            def execute(self, query, *, variable_values):
-                query_name = TestReportSharing._query_name(query)
-                if query_name == "ViewAccessTokens":
-                    return {
-                        "view": {
-                            "accessTokens": [
-                                {
-                                    "token": "existing_tok",
-                                    "type": "PUBLIC",
-                                    "revokedAt": None,
-                                }
-                            ]
-                        }
-                    }
-                if query_name == "updateAccessTokenProjects":
-                    return {"updateAccessTokenProjects": {"success": False}}
-                raise AssertionError(f"Unexpected query: {query}")
-
-        class _Api:
-            client = _Client()
-            default_entity = "ent"
-
-        self._api = _Api()
-        report = self._make_report(monkeypatch)
-
-        with pytest.raises(RuntimeError, match="failed to update access token projects"):
-            report.enable_share_link()
 
     def test_enable_share_link_raises_without_id(self, monkeypatch):
         """enable_share_link raises ValueError if report has no id."""

--- a/wandb_workspaces/reports/v2/gql.py
+++ b/wandb_workspaces/reports/v2/gql.py
@@ -98,19 +98,34 @@ view_access_tokens = """
 create_access_token = """
     mutation createAccessToken(
         $viewId: ID!
-        $entityName: String!
-        $projectName: String!
+        $projects: [ProjectSpecifier!]!
     ) {
         createAccessToken(
             input: {
                 viewId: $viewId
-                projects: [{ entityName: $entityName, projectName: $projectName }]
+                projects: $projects
             }
         ) {
             accessToken {
                 token
                 type
             }
+        }
+    }
+"""
+
+update_access_token_projects = """
+    mutation updateAccessTokenProjects(
+        $token: String!
+        $projects: [ProjectSpecifier!]!
+    ) {
+        updateAccessTokenProjects(
+            input: {
+                token: $token
+                projects: $projects
+            }
+        ) {
+            success
         }
     }
 """

--- a/wandb_workspaces/reports/v2/gql.py
+++ b/wandb_workspaces/reports/v2/gql.py
@@ -114,22 +114,6 @@ create_access_token = """
     }
 """
 
-update_access_token_projects = """
-    mutation updateAccessTokenProjects(
-        $token: String!
-        $projects: [ProjectSpecifier!]!
-    ) {
-        updateAccessTokenProjects(
-            input: {
-                token: $token
-                projects: $projects
-            }
-        ) {
-            success
-        }
-    }
-"""
-
 revoke_access_token = """
     mutation revokeAccessToken($token: String!) {
         revokeAccessToken(input: { token: $token }) {

--- a/wandb_workspaces/reports/v2/gql.py
+++ b/wandb_workspaces/reports/v2/gql.py
@@ -90,6 +90,10 @@ view_access_tokens = """
                 token
                 type
                 revokedAt
+                projects {
+                    entityName
+                    name
+                }
             }
         }
     }
@@ -110,6 +114,22 @@ create_access_token = """
                 token
                 type
             }
+        }
+    }
+"""
+
+update_access_token_projects = """
+    mutation updateAccessTokenProjects(
+        $token: String!
+        $projects: [ProjectSpecifier!]!
+    ) {
+        updateAccessTokenProjects(
+            input: {
+                token: $token
+                projects: $projects
+            }
+        ) {
+            success
         }
     }
 """

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3707,6 +3707,44 @@ class Report(Base):
         separator = "&" if "?" in base else "?"
         return f"{base}{separator}accessToken={quote(token, safe='')}"
 
+    def _share_link_projects(self) -> LList[Dict[str, str]]:
+        """Return the projects that an anonymous report viewer must be able to read."""
+        projects: Dict[Tuple[str, str], Dict[str, str]] = {}
+
+        def add_project(entity_name: str, project_name: str) -> None:
+            if entity_name and project_name:
+                projects[(entity_name, project_name)] = {
+                    "entityName": entity_name,
+                    "projectName": project_name,
+                }
+
+        def visit_blocks(blocks: Iterable[BlockTypes]) -> None:
+            for block in blocks:
+                if isinstance(block, PanelGrid):
+                    for runset in block.runsets:
+                        add_project(runset.entity, runset.project)
+
+                if isinstance(block, Heading):
+                    collapsed_blocks = getattr(block, "collapsed_blocks", None)
+                    if collapsed_blocks:
+                        visit_blocks(collapsed_blocks)
+
+        add_project(self.entity, self.project)
+        visit_blocks(self.blocks)
+        return list(projects.values())
+
+    def _update_share_link_projects(self, tokens: LList[str]) -> None:
+        """Synchronize existing public access tokens with the report's projects."""
+        projects = self._share_link_projects()
+        for token in tokens:
+            r = execute_graphql(
+                _get_api(),
+                gql.update_access_token_projects,
+                {"token": token, "projects": projects},
+            )
+            if not r["updateAccessTokenProjects"]["success"]:
+                raise RuntimeError("failed to update access token projects")
+
     def get_share_url(self) -> Optional[str]:
         """Fetch the magic link URL for this report, or None if sharing is not enabled.
 
@@ -3726,7 +3764,7 @@ class Report(Base):
         """Enable "anyone with link can view" sharing for this report.
 
         Creates a public access token for the report. If a share link already
-        exists, returns the existing link.
+        exists, refreshes its project access and returns the existing link.
 
         Returns:
             str: The magic link URL that can be shared.
@@ -3734,9 +3772,10 @@ class Report(Base):
         if not self.id:
             raise ValueError("save report before enabling share link")
 
-        existing = self._get_active_share_token()
-        if existing is not None:
-            url = self._build_share_url(existing)
+        existing_tokens = self._get_active_share_tokens()
+        if existing_tokens:
+            self._update_share_link_projects(existing_tokens)
+            url = self._build_share_url(existing_tokens[0])
             wandb.termlog("Share link already active.")
             return url
 
@@ -3745,8 +3784,7 @@ class Report(Base):
             gql.create_access_token,
             {
                 "viewId": self.id,
-                "entityName": self.entity,
-                "projectName": self.project,
+                "projects": self._share_link_projects(),
             },
         )
         token = r["createAccessToken"]["accessToken"]["token"]

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3733,6 +3733,18 @@ class Report(Base):
         visit_blocks(self.blocks)
         return list(projects.values())
 
+    def _update_share_link_projects(
+        self, token: str, projects: LList[Dict[str, str]]
+    ) -> None:
+        """Synchronize an existing public access token with the report's projects."""
+        r = execute_graphql(
+            _get_api(),
+            gql.update_access_token_projects,
+            {"token": token, "projects": projects},
+        )
+        if not r["updateAccessTokenProjects"]["success"]:
+            raise RuntimeError("failed to update access token projects")
+
     def get_share_url(self) -> Optional[str]:
         """Fetch the magic link URL for this report, or None if sharing is not enabled.
 
@@ -3752,7 +3764,7 @@ class Report(Base):
         """Enable "anyone with link can view" sharing for this report.
 
         Creates a public access token for the report. If a share link already
-        exists, returns the existing link.
+        exists, refreshes its project access and returns the existing link.
 
         Returns:
             str: The magic link URL that can be shared.
@@ -3760,9 +3772,21 @@ class Report(Base):
         if not self.id:
             raise ValueError("save report before enabling share link")
 
-        existing = self._get_active_share_token()
-        if existing is not None:
-            url = self._build_share_url(existing)
+        existing_tokens = self._get_active_share_token_objects()
+        if existing_tokens:
+            existing = existing_tokens[0]
+            desired_projects = self._share_link_projects()
+            current_scope = {
+                (project["entityName"], project["name"])
+                for project in existing["projects"]
+            }
+            desired_scope = {
+                (project["entityName"], project["projectName"])
+                for project in desired_projects
+            }
+            if current_scope != desired_scope:
+                self._update_share_link_projects(existing["token"], desired_projects)
+            url = self._build_share_url(existing["token"])
             wandb.termlog("Share link already active.")
             return url
 
@@ -3817,6 +3841,10 @@ class Report(Base):
 
     def _get_active_share_tokens(self) -> LList[str]:
         """Return all active PUBLIC access token strings."""
+        return [token["token"] for token in self._get_active_share_token_objects()]
+
+    def _get_active_share_token_objects(self) -> LList[Dict[str, Any]]:
+        """Return all active PUBLIC access token objects."""
         r = execute_graphql(
             _get_api(),
             gql.view_access_tokens,
@@ -3826,7 +3854,7 @@ class Report(Base):
         if not view:
             return []
         return [
-            t["token"]
+            t
             for t in view["accessTokens"]
             if t["type"] == "PUBLIC" and t.get("revokedAt") is None
         ]

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -3733,18 +3733,6 @@ class Report(Base):
         visit_blocks(self.blocks)
         return list(projects.values())
 
-    def _update_share_link_projects(self, tokens: LList[str]) -> None:
-        """Synchronize existing public access tokens with the report's projects."""
-        projects = self._share_link_projects()
-        for token in tokens:
-            r = execute_graphql(
-                _get_api(),
-                gql.update_access_token_projects,
-                {"token": token, "projects": projects},
-            )
-            if not r["updateAccessTokenProjects"]["success"]:
-                raise RuntimeError("failed to update access token projects")
-
     def get_share_url(self) -> Optional[str]:
         """Fetch the magic link URL for this report, or None if sharing is not enabled.
 
@@ -3764,7 +3752,7 @@ class Report(Base):
         """Enable "anyone with link can view" sharing for this report.
 
         Creates a public access token for the report. If a share link already
-        exists, refreshes its project access and returns the existing link.
+        exists, returns the existing link.
 
         Returns:
             str: The magic link URL that can be shared.
@@ -3772,10 +3760,9 @@ class Report(Base):
         if not self.id:
             raise ValueError("save report before enabling share link")
 
-        existing_tokens = self._get_active_share_tokens()
-        if existing_tokens:
-            self._update_share_link_projects(existing_tokens)
-            url = self._build_share_url(existing_tokens[0])
+        existing = self._get_active_share_token()
+        if existing is not None:
+            url = self._build_share_url(existing)
             wandb.termlog("Share link already active.")
             return url
 


### PR DESCRIPTION
## Summary
- Fixes https://coreweave.atlassian.net/browse/WB-37970 
- scope newly created report share links to the report project and every project referenced by panel-grid runsets
- recursively include runsets in collapsed heading content while deduplicating projects and ignoring incomplete runsets
- preserve existing share URLs by refreshing the returned PUBLIC token only when its current project scope differs from the report

The refresh path matches the app's established behavior while avoiding unnecessary mutations on repeated `enable_share_link()` calls.

## Test plan
- [x] `uv run pytest -o addopts='' tests/test_reports.py -q` (125 passed)
- [x] `uv run ruff check wandb_workspaces/reports/v2/gql.py wandb_workspaces/reports/v2/interface.py tests/test_reports.py`
- [x] `git diff --check`