### PR TITLE
chore(release): fix PyPI publish (Metadata-Version 2.5) and bump to 0.4.8

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.version-check.outputs.version_changed == 'true'
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           print-hash: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wandb-workspaces"
-version = "0.4.7"
+version = "0.4.8"
 description = "A library for programatically working with the Weights & Biases UI."
 authors = [{ name = "Weights & Biases", email = "support@wandb.com" }]
 requires-python = ">=3.10,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -275,7 +275,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "wandb-workspaces"
-version = "0.4.7"
+version = "0.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Problem

Neither v0.4.6 nor v0.4.7 actually made it to PyPI — the latest release there is still 0.4.5. Both `Auto Release on Version Change` runs failed at the **Publish to PyPI** step with:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Root cause: the build backend (`hatchling`, unpinned) now emits `Metadata-Version: 2.5`, but the workflow pins `pypa/gh-action-pypi-publish` to a commit from Sep 2025 whose bundled twine predates metadata 2.5.

## Fix

- Update the `gh-action-pypi-publish` pin to v1.14.2 (`dc37677`), which bundles twine 7.0.0 / packaging 26.2 and accepts metadata 2.5.
- Bump version to 0.4.8 so merging this PR triggers the release workflow with the fixed action (it only fires on a version change, and re-running the failed runs would reuse the old workflow file).

## Aftermath of v0.4.6 / v0.4.7

Those two GitHub releases/tags are nearly identical to each other and were never published to PyPI. Options: leave them as-is (harmless), or delete both GitHub releases + tags so 0.4.8 is the single release containing the wandb>=0.28.2 changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)