### PR TITLE
fix(workspaces): round-trip isPanelsAuto and defaultName on sections

### DIFF
--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -391,6 +391,29 @@ def test_section_flags_roundtrip_and_fresh_section_omits_them():
     assert "defaultName" not in fresh
 
 
+def test_unflagged_panels_stamped_custom_only_in_ispanelsauto_true_sections():
+    """In a preserved ``isPanelsAuto: true`` section, the app's save-time
+    compression deletes any panel not explicitly ``isAuto: false``, so panels
+    without the flag (fresh SDK-authored ones) are stamped custom on emit.
+    Sections without the preserved ``true`` flag emit panels untouched."""
+    view = _view_with_custom_panels(
+        [
+            {"__id__": "sec-1", "name": "Charts", "isPanelsAuto": True, "panels": []},
+            {"__id__": "sec-2", "name": "Legacy", "panels": []},
+        ]
+    )
+    workspace = ws.Workspace._from_model(view)
+    workspace.sections[0].panels.append(wr.LinePlot(y=["loss"]))
+    workspace.sections[1].panels.append(wr.LinePlot(y=["loss"]))
+    sections = workspace._to_model().spec.section.panel_bank_config.sections
+
+    stamped = sections[0].panels[0].model_dump(by_alias=True, exclude_none=True)
+    assert stamped["isAuto"] is False
+
+    untouched = sections[1].panels[0].model_dump(by_alias=True, exclude_none=True)
+    assert "isAuto" not in untouched
+
+
 def test_custom_panel_isauto_roundtrips_and_fresh_panel_omits_it():
     """A loaded custom panel keeps ``isAuto: false``; a fresh panel emits none."""
     view = _view_with_custom_panels(

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -344,6 +344,53 @@ def test_section_id_roundtrips_and_fresh_section_omits_it():
     assert "__id__" not in dumped
 
 
+def test_section_flags_roundtrip_and_fresh_section_omits_them():
+    """A loaded section keeps ``isPanelsAuto`` and ``defaultName`` (the app's
+    compression and auto-section matching depend on them); a from-scratch
+    section emits neither, and an absent flag stays absent."""
+    view = _view_with_custom_panels(
+        [
+            {
+                "__id__": "sec-1",
+                "name": "train",
+                "isPanelsAuto": False,
+                "panels": [],
+            },
+            {
+                "__id__": "sec-2",
+                "name": "Renamed Charts",
+                "isPanelsAuto": True,
+                "defaultName": "Charts",
+                "panels": [],
+            },
+            {"__id__": "sec-3", "name": "Legacy", "panels": []},
+        ]
+    )
+    sections = (
+        ws.Workspace._from_model(view)
+        ._to_model()
+        .spec.section.panel_bank_config.sections
+    )
+
+    manual = sections[0].model_dump(by_alias=True, exclude_none=True)
+    assert manual["isPanelsAuto"] is False
+    assert "defaultName" not in manual
+
+    renamed = sections[1].model_dump(by_alias=True, exclude_none=True)
+    assert renamed["isPanelsAuto"] is True
+    assert renamed["defaultName"] == "Charts"
+
+    legacy = sections[2].model_dump(by_alias=True, exclude_none=True)
+    assert "isPanelsAuto" not in legacy
+    assert "defaultName" not in legacy
+
+    fresh = (
+        ws.Section(name="New")._to_model().model_dump(by_alias=True, exclude_none=True)
+    )
+    assert "isPanelsAuto" not in fresh
+    assert "defaultName" not in fresh
+
+
 def test_custom_panel_isauto_roundtrips_and_fresh_panel_omits_it():
     """A loaded custom panel keeps ``isAuto: false``; a fresh panel emits none."""
     view = _view_with_custom_panels(

--- a/wandb_workspaces/reports/v2/internal.py
+++ b/wandb_workspaces/reports/v2/internal.py
@@ -247,6 +247,13 @@ class PanelBankConfigSectionsItem(ReportAPIBaseModel):
     local_panel_settings: LocalPanelSettings = Field(default_factory=LocalPanelSettings)
     panels: LList["PanelTypes"] = Field(default_factory=list)
     pinned: Optional[bool] = None
+    # App-managed section flags; round-tripped, not SDK-authored. `isPanelsAuto`
+    # gates the app's save-time compression of auto-generated panels, and
+    # `defaultName` lets a renamed section keep receiving its auto panels.
+    # Optional so an absent flag round-trips as absent (exclude_none), not
+    # forced to a default.
+    is_panels_auto: Optional[bool] = None
+    default_name: Optional[str] = None
 
     @validator("panels", pre=True, each_item=True)
     def parse_panel(cls, v):  # noqa: N805

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -533,6 +533,14 @@ class Section(Base):
     # overrides resolve.
     _id: Optional[str] = Field(default=None, init=False, repr=False)
 
+    # App-managed section flags loaded from the spec and round-tripped verbatim
+    # so an SDK save can't strip them. `isPanelsAuto` gates the app's save-time
+    # compression of auto panels (stripping it can permanently trap a section's
+    # auto panels in the saved spec); `defaultName` keeps a renamed section
+    # matched to its auto panels. Fresh sections omit both.
+    _is_panels_auto: Optional[bool] = Field(default=None, init=False, repr=False)
+    _default_name: Optional[str] = Field(default=None, init=False, repr=False)
+
     @classmethod
     def _from_model(cls, model: internal.PanelBankConfigSectionsItem):
         obj = cls(
@@ -544,6 +552,8 @@ class Section(Base):
             panel_settings=SectionPanelSettings._from_model(model.local_panel_settings),
         )
         obj._id = model.id
+        obj._is_panels_auto = model.is_panels_auto
+        obj._default_name = model.default_name
         return obj
 
     def _to_model(self):
@@ -561,6 +571,8 @@ class Section(Base):
             pinned=self.pinned,
             flow_config=flow_config,
             local_panel_settings=local_panel_settings,
+            is_panels_auto=self._is_panels_auto,
+            default_name=self._default_name,
         )
 
 

--- a/wandb_workspaces/workspaces/interface.py
+++ b/wandb_workspaces/workspaces/interface.py
@@ -558,6 +558,20 @@ class Section(Base):
 
     def _to_model(self):
         panel_models = [p._to_model() for p in self.panels]
+
+        # In a section the app has marked `isPanelsAuto: true`, the app's
+        # save-time compression keeps only panels explicitly marked
+        # `isAuto: false` and strips the rest (regenerating true auto panels
+        # from history keys). A panel without the flag — e.g. one authored in
+        # this SDK and appended to a loaded section — would be silently
+        # deleted by the app's next save. Stamp unflagged panels as custom so
+        # they survive. Sections without a preserved `true` flag emit their
+        # panels untouched.
+        if self._is_panels_auto is True:
+            for pm in panel_models:
+                if getattr(pm, "is_auto", False) is None:
+                    pm.is_auto = False
+
         flow_config = self.layout_settings._to_model()
         local_panel_settings = self.panel_settings._to_model()
 


### PR DESCRIPTION
JIRA/GH Issues(s)
-----------
https://coreweave.atlassian.net/browse/WB-39022

Description
-----------
`PanelBankConfigSectionsItem` had no `is_panels_auto` or `default_name` fields, and the base model ignores unknown keys, so loading a workspace view and saving it back silently dropped both from every section.

Both fields are written by the app, not the SDK. `isPanelsAuto` gates the app's save-time compression of auto-generated panels; `defaultName` keeps a renamed section matched to its auto panels. Stripping `isPanelsAuto` makes a section permanently uncompressible when it contains any custom panel. Confirmed impact: a saved view transferred through this SDK was created at 48 KB (the source was sparse/compressed), and because the transfer stripped the section flags, the app's next save materialized ~535K auto panels — the view went 48 KB → 119.6 MB in one session, and a second view on the same project repeated the pattern a day later (128 KB → 146 MB). With the flags preserved, the app's save-time compression would have kept both views at KB scale.

Two commits:

1. **Round-trip the flags.** Both fields added to the model as optional and carried through `Section` (stashed in `_from_model`, re-emitted in `_to_model`) — the same treatment `panelConfigOverrides`/`panelPlacementOverrides` and `Section._id` already get. An absent flag round-trips as absent (`exclude_none`); from-scratch sections still emit neither key.

2. **Guard against a deletion path the preservation opens.** In a section the app marks `isPanelsAuto: true`, save-time compression keeps only panels explicitly `isAuto: false`. A fresh SDK-authored panel (which carries no `isAuto`) appended to such a section would be silently deleted by the app's next save. On emit, unflagged panels in a preserved-`true` section are stamped `isAuto: false` so the app keeps them. Since the SDK previously stripped the flag on every save, no existing script emits a preserved-`true` section — this branch only runs in territory the fix opens, so existing output is unchanged. One visible consequence: under sparse overrides, a stamped panel keyed to an existing metric coexists with the regenerated auto panel for that metric (the same semantics the app gives quick-added duplicate panels) rather than replacing it — the alternative was the panel being deleted outright.

Known gaps deliberately left out: `sectionSettings` is still dropped on round-trip (round-tripping it could shadow SDK edits to the deprecated `localPanelSettings` the app migrates from), and the typed panel models still drop some config fields (e.g. `colorEachMetricDifferently`, ScatterPlot axis settings).

Testing
-------
- [x] _Added unit tests_ — flag round-trip (explicit `false`, explicit `true` + `defaultName`, absent-stays-absent, fresh-section-omits) and the stamping guard (stamped in preserved-`true` sections, untouched elsewhere). Full suite passes (297 tests); ruff, ruff-format, mypy clean.
- [x] _Manual testing (include description)_ — round-tripped a truncated copy of the real 121 MB incident spec through `Workspace._from_model → _to_model`: all section flags, `__id__`s, panel counts, panel `isAuto` values, and both override maps preserved positionally.
- [ ] _N/A (include explanation)_

Server compatibility
--------------------
- [ ] _Requires a minimum W&B Server version (label `requires-server/X.Y+` applied)_
- [ ] _SaaS only — not yet in any tagged W&B Server release (label `requires-server/unreleased` applied)_
- [x] _N/A — works on all currently supported servers (the fields are opaque spec content the app writes; the SDK just stops dropping them)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
