### PR TITLE
fix(reports): build report URL slugs without percent escapes

### DIFF
--- a/tests/test_report_url_slug.py
+++ b/tests/test_report_url_slug.py
@@ -1,0 +1,43 @@
+import pytest
+
+import wandb_workspaces.reports.v1 as wr_v1
+import wandb_workspaces.reports.v2 as wr
+
+
+class _ServiceApi:
+    app_url = "https://service.wandb.test/"
+
+
+class _Api:
+    default_entity = "ent"
+
+    def __init__(self):
+        self._service_api = _ServiceApi()
+
+
+@pytest.mark.parametrize(
+    "title,slug",
+    [
+        (
+            "RL Experiment Decision Report — JetBlue Prime",
+            "RL-Experiment-Decision-Report-JetBlue-Prime",
+        ),
+        ("25%engag_emb+flat", "25-engag_emb-flat"),
+        # re's \W is Unicode-aware, so a CJK title used to survive into the slug
+        # and get percent-encoded.
+        ("数据集 0", "-0"),
+        ("Report: v1.2 (final)", "Report-v1-2-final-"),
+    ],
+)
+def test_report_url_slug_has_no_percent_escapes(monkeypatch, title, slug):
+    monkeypatch.setattr(wr.interface, "_get_api", lambda: _Api())
+
+    v2 = wr.Report(project="proj", entity="ent", title=title)
+    v2.id = "abc123"
+    v1 = wr_v1.Report(project="proj", entity="ent", title=title, _api=_Api())
+    v1._viewspec["id"] = "abc123=="
+
+    expected = f"https://service.wandb.test/ent/proj/reports/{slug}--abc123"
+    assert v2.url == expected
+    assert v1.url == expected
+    assert "%" not in v2.url

--- a/wandb_workspaces/reports/v1/report.py
+++ b/wandb_workspaces/reports/v1/report.py
@@ -1,8 +1,6 @@
 import base64
 import inspect
 import json
-import re
-import urllib
 from copy import deepcopy
 from typing import List as LList
 
@@ -12,6 +10,7 @@ from wandb.apis.public import Api as PublicApi
 from wandb.sdk.lib import ipython
 
 from wandb_workspaces._graphql import execute_graphql, get_app_url
+from wandb_workspaces.utils.slugs import slugify_title
 
 from ._blocks import P, PanelGrid, UnknownBlock, WeaveBlock, block_mapping, weave_blocks
 from .mutations import UPSERT_VIEW, VIEW_REPORT
@@ -195,9 +194,7 @@ class Report(Base):
 
     @property
     def url(self) -> str:
-        title = re.sub(r"\W", "-", self.title)
-        title = re.sub(r"-+", "-", title)
-        title = urllib.parse.quote(title)
+        title = slugify_title(self.title)
         id = self.id.replace("=", "")
         app_url = get_app_url(self._api)
         if not app_url.endswith("/"):

--- a/wandb_workspaces/reports/v2/interface.py
+++ b/wandb_workspaces/reports/v2/interface.py
@@ -48,6 +48,7 @@ from pydantic import ConfigDict, Field, model_validator, validator
 from pydantic.dataclasses import dataclass
 
 from wandb_workspaces._graphql import execute_graphql, get_app_url
+from wandb_workspaces.utils.slugs import slugify_title
 
 from . import gql, internal
 from ... import expr
@@ -3651,7 +3652,7 @@ class Report(Base):
 
         base = urlparse(get_app_url(_get_api()))
 
-        title = self.title.replace(" ", "-")
+        title = slugify_title(self.title)
 
         scheme = base.scheme
         netloc = base.netloc
@@ -4455,7 +4456,7 @@ def _metric_to_frontend_panel_grid(x: str):
 
 
 def _metric_to_backend_groupby(
-    val: Optional[Union[str, "Config", "Metric"]]
+    val: Optional[Union[str, "Config", "Metric"]],
 ) -> Optional[str]:
     """
     Normalise a group-by key into the string the backend expects.

--- a/wandb_workspaces/utils/slugs.py
+++ b/wandb_workspaces/utils/slugs.py
@@ -1,0 +1,24 @@
+"""Slug helpers for building W&B app URLs."""
+
+import re
+
+_NON_SLUG_CHAR = re.compile(r"[^A-Za-z0-9_]")
+_REPEATED_DASH = re.compile(r"-+")
+
+
+def slugify_title(title: str) -> str:
+    """Convert a report title into the slug the W&B app builds for the same report.
+
+    The app maps every character outside ``[A-Za-z0-9_]`` to a dash and collapses
+    runs of dashes (``makeNameAndID`` in the frontend). Keeping this identical
+    matters because the slug is only decoration — the report is resolved from the
+    ``--<id>`` suffix — while a slug carrying percent escapes can break the app:
+    react-router decodes the pathname and throws on an escape it cannot decode,
+    which a truncated link (streamed text, a copy-paste cut short) easily
+    produces. An ASCII slug has nothing to escape.
+
+    Note ``re`` is Unicode-aware, so ``\\W`` here would keep CJK characters as
+    word characters and leave them to be percent-encoded; the explicit ASCII
+    class above does not.
+    """
+    return _REPEATED_DASH.sub("-", _NON_SLUG_CHAR.sub("-", title))


### PR DESCRIPTION
<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
Please use conventional commits in your PR title. If you are unsure what conventional commits are or how to use them, please check out [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits).

JIRA/GH Issues(s)
-----------
Paste links to relevant JIRA/GH issues here, one per line e.g.
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
_What does this PR do? Write a short paragraph to contextualize and explain your change._

Testing
-------
How was this PR tested?

- [ ] _Added unit tests_
- [ ] _Manual testing (include description)_
- [ ] _N/A (include explanation)_

Server compatibility
--------------------

- [ ] _Requires a minimum W&B Server version (label `requires-server/X.Y+` applied)_
- [ ] _SaaS only — not yet in any tagged W&B Server release (label `requires-server/unreleased` applied)_
- [ ] _N/A — works on all currently supported servers_


Link to Devin session: https://coreweave.devinenterprise.com/sessions/04633aac1ec7466995d2a5e908d8b880
Requested by: @ericakdiaz